### PR TITLE
Implementation of davidson-liu with shift

### DIFF
--- a/tests/helpers/test_davidsonliu.py
+++ b/tests/helpers/test_davidsonliu.py
@@ -270,3 +270,49 @@ def test_dl_restart_2():
     evals, _ = solver.solve()
 
     assert evals[0] == approx(ref_evals2[0])
+
+
+def test_dl_shift():
+    # 1. Build a small random symmetric matrix H
+    np.random.seed(0)
+    size = 100
+    nroot = 5
+    H = np.random.randn(size, size)
+    H = 0.5 * (H + H.T)
+
+    # 2. Reference solution via NumPy
+    ref_vals, ref_vecs = np.linalg.eigh(H)
+    # user-specified shift for target eigenvalue
+    eta = ref_vals[20] + np.random.uniform(-1, 1)
+    # reorder ref eigenpair by user-specified shift
+    idx = np.argsort(np.abs(ref_vals - eta)) 
+    ref_vals = ref_vals[idx]
+    ref_vecs = ref_vecs[:, idx]
+    ref_vals = ref_vals[:nroot]
+
+    # 3. σ-builder that handles multiple columns at once
+    def sigma_builder(basis_block: np.ndarray, sigma_block: np.ndarray) -> None:
+        sigma_block[:] = H @ basis_block
+
+    # 4. Instantiate and configure solver
+    
+    solver = DavidsonLiuSolver(
+        size=size, nroot=nroot, collapse_per_root=5, basis_per_root=10, eta=eta
+    )
+    solver.add_h_diag(np.diag(H))
+    solver.add_sigma_builder(sigma_builder)
+    # no guesses → solver will generate random initial vectors
+
+    # 5. Run Davidson
+    evals, evecs = solver.solve()
+
+    # 6. Compare eigenvalues
+    assert np.allclose(
+        evals, ref_vals, atol=1e-12
+    ), f"Eigenvalues mismatch: {evals} vs {ref_vals}"
+
+    # # 7. Compare eigenvector subspaces via projector difference
+    P_solver = evecs @ evecs.T
+    P_ref = ref_vecs[:, :nroot] @ ref_vecs[:, :nroot].T
+    diff_norm = np.linalg.norm(P_solver - P_ref)
+    assert diff_norm < 1e-5, f"Eigenvector subspaces differ (norm {diff_norm:.2e})"


### PR DESCRIPTION
## Description
Adds support for a user-specified shift in the `DavidsonLiuSolver` class to enable targeting higher eigenvalue pairs.

## User Notes
- [x] Features added
- [ ] Changes to compilation (if any)

## Checklist
- [x] Added/updated tests of new features
- [x] Removed comments in code and input files
- [x] Documented source code
- [x] Checked for redundant headers
- [x] Checked for consistency in the formatting of the output
- [x] Ready to go!