### PR TITLE
Add casscf_6 test from Forte

### DIFF
--- a/tests/orbopt/test_casscf_6.py
+++ b/tests/orbopt/test_casscf_6.py
@@ -1,0 +1,29 @@
+import pytest
+
+from forte2 import *
+from forte2.helpers.comparisons import approx
+
+
+def test_casscf_6():
+    """Test CASSCF (frozen core orbital) with HF molecule."""
+    emcscf = -99.939295399756
+
+    xyz = f"""
+    F            0.000000000000     0.000000000000    -0.075563346255
+    H            0.000000000000     0.000000000000     1.424436653745
+    """
+
+    system = System(
+        xyz=xyz, basis_set="cc-pvdz", auxiliary_basis_set="def2-universal-jkfit"
+    )
+
+    rhf = RHF(charge=0, econv=1e-12)(system)
+    ci_state = CIStates(
+        active_spaces=[4, 5],
+        core_orbitals=[0, 1, 2, 3], # orb 0 is frozen in forte test
+        states=State(nel=10, multiplicity=1, ms=0.0),
+    )
+    mc = MCOptimizer(ci_state)(rhf)
+    mc.run()
+
+    assert mc.E == approx(emcscf)

--- a/tests/orbopt/test_casscf_6.py
+++ b/tests/orbopt/test_casscf_6.py
@@ -8,7 +8,7 @@ def test_casscf_6():
     """Test CASSCF (frozen core orbital) with HF molecule."""
     emcscf = -99.939295399756
 
-    xyz = f"""
+    xyz = """
     F            0.000000000000     0.000000000000    -0.075563346255
     H            0.000000000000     0.000000000000     1.424436653745
     """


### PR DESCRIPTION
Added CAS test (with 1 frozen core orbital) for HF molecule from Forte.