### PR TITLE
Fix memory handling in CI algorithms

### DIFF
--- a/forte2/api/ci_api.cc
+++ b/forte2/api/ci_api.cc
@@ -47,6 +47,8 @@ void export_ci_sigma_builder_api(nb::module_& m) {
              "Initialize the CISigmaBuilder with CIStrings, energy, Hamiltonian, and integrals")
         .def("set_algorithm", &CISigmaBuilder::set_algorithm, "algorithm"_a,
              "Set the sigma build algorithm (options = kh, hz)")
+        .def("get_algorithm", &CISigmaBuilder::get_algorithm,
+             "Get the current sigma build algorithm")
         .def("set_memory", &CISigmaBuilder::set_memory, "memory"_a,
              "Set the memory limit for the builder (in MB)")
         .def("form_Hdiag_csf", &CISigmaBuilder::form_Hdiag_csf, "dets"_a, "spin_adapter"_a,

--- a/forte2/ci/ci.py
+++ b/forte2/ci/ci.py
@@ -203,7 +203,6 @@ class _CIBase:
             for i in range(ncols):
                 self.spin_adapter.csf_C_to_det_C(Bblock[:, i], self.b_det)
                 self.ci_sigma_builder.Hamiltonian(self.b_det, self.sigma_det)
-                # self.sigma_det = np.dot(Hex, self.b_det)
                 self.spin_adapter.det_C_to_csf_C(self.sigma_det, Sblock[:, i])
 
         self.eigensolver.add_sigma_builder(sigma_builder)

--- a/forte2/ci/ci.py
+++ b/forte2/ci/ci.py
@@ -163,6 +163,8 @@ class _CIBase:
         self.ci_sigma_builder.set_memory(self.ci_builder_memory)
         self.ci_sigma_builder.set_algorithm(self.ci_algorithm)
 
+        logger.log(f"Using CI algorithm: {self.ci_sigma_builder.get_algorithm()}", self.log_level)
+
         Hdiag = self.ci_sigma_builder.form_Hdiag_csf(
             self.dets, self.spin_adapter, spin_adapt_full_preconditioner=False
         )
@@ -222,7 +224,7 @@ class _CIBase:
         logger.log(f"h_aabb time:    {h_aabb:.3f} s/build", self.log_level)
         logger.log(f"h_aaaa time:    {h_aaaa:.3f} s/build", self.log_level)
         logger.log(f"h_bbbb time:    {h_bbbb:.3f} s/build", self.log_level)
-        logger.log(f"total time:     {h_tot:.3f} s/build", self.log_level)
+        logger.log(f"total time:     {h_tot:.3f} s/build\n", self.log_level)
 
         if self.do_test_rdms:
             self._test_rdms()

--- a/forte2/ci/ci_sigma_builder.cc
+++ b/forte2/ci/ci_sigma_builder.cc
@@ -42,13 +42,6 @@ CISigmaBuilder::CISigmaBuilder(const CIStrings& lists, double E, np_matrix& H, n
     set_Hamiltonian(E, H, V);
 }
 
-CISigmaBuilder::~CISigmaBuilder() {
-    // Destructor does not need to do anything special
-    // LOG(log_level_) << std::fixed << std::setprecision(3);
-    // LOG(log_level_) << "\nTiming for 2RDM(aa):" << rdm2_aa_timer_ << " seconds";
-    // LOG(log_level_) << "Timing for 2RDM(ab):" << rdm2_ab_timer_ << " seconds";
-}
-
 void CISigmaBuilder::set_algorithm(const std::string& algorithm) {
     if (algorithm == "kh" or algorithm == "knowles-handy") {
         algorithm_ = CIAlgorithm::Knowles_Handy;
@@ -162,21 +155,26 @@ void CISigmaBuilder::Hamiltonian(np_vector basis, np_vector sigma) const {
         H2_kh(b_span, s_span);
         haabb_timer_ += h_aabb_timer.elapsed_seconds();
     } else {
-        H1_aa_gemm(b_span, s_span, true, h_hz);
-        H1_aa_gemm(b_span, s_span, false, h_hz);
+        H1_hz(b_span, s_span, true, h_hz);
+        H1_hz(b_span, s_span, false, h_hz);
 
         local_timer h_aabb_timer;
-        H2_aabb_gemm(b_span, s_span);
+        H2_hz_opposite_spin(b_span, s_span);
         haabb_timer_ += h_aabb_timer.elapsed_seconds();
 
         local_timer h_aaaa_timer;
-        H2_aaaa_gemm(b_span, s_span, true);
+        H2_hz_same_spin(b_span, s_span, true);
         haaaa_timer_ += h_aaaa_timer.elapsed_seconds();
 
         local_timer h_bbbb_timer;
-        H2_aaaa_gemm(b_span, s_span, false);
+        H2_hz_same_spin(b_span, s_span, false);
         hbbbb_timer_ += h_bbbb_timer.elapsed_seconds();
     }
+    // std::cout << "Sigma: ";
+    // for (auto val : s_span) {
+    //     std::cout << val << std::endl;
+    // }
+
     hdiag_timer_ += t.elapsed_seconds();
     build_count_++;
 }

--- a/forte2/ci/ci_sigma_builder.h
+++ b/forte2/ci/ci_sigma_builder.h
@@ -23,7 +23,6 @@ class CISigmaBuilder {
     // == Class Constructor ==
     CISigmaBuilder(const CIStrings& lists, double E, np_matrix& H, np_tensor4& V,
                    int log_level = 3);
-    ~CISigmaBuilder();
 
     // == Class Public Functions ==
 
@@ -274,6 +273,15 @@ class CISigmaBuilder {
     mutable std::vector<double> TR;
     mutable std::vector<double> TL;
 
+    /// @brief Temporary vectors used to store blocks of data of the form
+    /// L(op,K,L) = <K|op|I> C_{IL}
+    /// where `op` is an operator, K is a state in N, N-1, or N-2 electron strings
+    /// while I and L are alpha/beta string
+    /// These vectors are allocated on the first call to the Hamiltonian function
+    /// and resized as needed
+    mutable std::vector<double> Kblock1_;
+    mutable std::vector<double> Kblock2_;
+
     /// @brief Scalar contribution to the sigma vector |sigma> = E |basis>
     void H0(std::span<double> basis, std::span<double> sigma) const;
 
@@ -289,28 +297,24 @@ class CISigmaBuilder {
     /// @brief  One-electron contribution to the sigma vector |sigma> = H |basis>
     /// @param alfa If true, compute the alpha contribution, otherwise the beta
     /// @param h The one-electron integrals
-    void H1_aa_gemm(std::span<double> basis, std::span<double> sigma, bool alfa,
-                    std::span<double> h) const;
+    void H1_hz(std::span<double> basis, std::span<double> sigma, bool alfa,
+               std::span<double> h) const;
 
     /// @brief  Two-electron same-spin contribution to the sigma vector |sigma> = H |basis>
     /// @param alfa If true, compute the alpha contribution, otherwise the beta
-    void H2_aaaa_gemm(std::span<double> basis, std::span<double> sigma, bool alfa) const;
+    void H2_hz_same_spin(std::span<double> basis, std::span<double> sigma, bool alfa) const;
 
     /// @brief  Two-electron mixed-spin contribution to the sigma vector |sigma> = H |basis>
     /// @param basis The basis vector
     /// @param sigma The resulting sigma vector
-    void H2_aabb_gemm(std::span<double> basis, std::span<double> sigma) const;
+    void H2_hz_opposite_spin(std::span<double> basis, std::span<double> sigma) const;
 
     // -- Knowles-Handy Algorithm Functions/Data --
+
     // Modified one-electron integrals used in the Knowles-Handy algorithm
     mutable std::vector<double> h_kh;
     // Modified two-electron integrals used in the Knowles-Handy algorithm
     mutable std::vector<double> v_ijkl_hk;
-    /// @brief Temporary vectors used for the Knowles-Handy algorithm
-    /// These vectors are allocated on the first call to the Hamiltonian function
-    /// and resized as needed
-    mutable std::vector<double> Kblock1_;
-    mutable std::vector<double> Kblock2_;
 
     /// @brief Builds the one-electron contribution to the sigma vector using the Knowles-Handy
     /// algorithm.

--- a/forte2/ci/ci_sigma_builder.h
+++ b/forte2/ci/ci_sigma_builder.h
@@ -6,6 +6,7 @@
 #include <span>
 
 #include "helpers/ndarray.h"
+#include "helpers/spin.h"
 
 #include "ci/ci_strings.h"
 #include "ci/slater_rules.h"
@@ -34,6 +35,10 @@ class CISigmaBuilder {
     /// @param algorithm The CI algorithm to use (default is "knowles-handy")
     /// Supported algorithms: "kh", "hz", "knowles-handy", "harrison-zarrabian"
     void set_algorithm(const std::string& algorithm);
+
+    /// @brief Get the name of the current sigma build algorithm
+    /// @return The name of the current sigma build algorithm
+    std::string get_algorithm() const;
 
     /// @brief Set the one and two-electron integrals for the Hamiltonian
     void set_Hamiltonian(double E, np_matrix H, np_tensor4 V);
@@ -76,11 +81,11 @@ class CISigmaBuilder {
     /// @brief Compute the spin-dependent one-electron reduced density matrix
     /// @param C_left The left-hand side coefficients
     /// @param C_right The right-hand side coefficients
-    /// @param alfa If true, compute the alpha contribution, otherwise the beta
+    /// @param spin The spin component to compute
     /// @return The one-electron reduced density matrix stored as
     ///        gamma(spin)[p][q] = <L| a^+_p a_q |R> with p,q orbitals of spin alpha/beta
     /// @note If the number of orbitals is 0, a matrix of shape (0, 0) is returned
-    np_matrix compute_s_1rdm(np_vector C_left, np_vector C_right, bool alfa) const;
+    np_matrix compute_s_1rdm(np_vector C_left, np_vector C_right, Spin spin) const;
 
     /// @brief Compute the alpha one-electron reduced density matrix
     /// @param C_left The left-hand side coefficients
@@ -108,11 +113,11 @@ class CISigmaBuilder {
     /// @brief Compute the same-spin two-electron reduced density matrix
     /// @param C_left The left-hand side coefficients
     /// @param C_right The right-hand side coefficients
-    /// @param alfa If true, compute the alpha contribution, otherwise the beta
+    /// @param spin The spin component to compute
     /// @return The two-electron same-spin reduced density matrix stored as a matrix
     ///        gamma(sigma)[p>q][r>s] = <L| a^+_p a^+_q a_s a_r |R>
     ///        with p > q, and r > s orbitals of spin sigma
-    np_matrix compute_ss_2rdm(np_vector C_left, np_vector C_right, bool alfa) const;
+    np_matrix compute_ss_2rdm(np_vector C_left, np_vector C_right, Spin spin) const;
 
     /// @brief Compute the alpha-alpha two-electron reduced density matrix
     /// @param C_left The left-hand side coefficients
@@ -159,11 +164,11 @@ class CISigmaBuilder {
     /// @brief Compute the three-electron same-spin reduced density matrix
     /// @param C_left The left-hand side coefficients
     /// @param C_right The right-hand side coefficients
-    /// @param alfa If true, compute the alpha contribution, otherwise the beta
+    /// @param spin The spin component to compute
     /// @return The three-electron same-spin reduced density matrix stored as a matrix
     ///        gamma(sigma)[p>q>r][s>t>u] = <L| a^+_p a^+_q a^+_r a_u a_t a_s |R>
     ///        with p > q > r, and s > t > u orbitals of spin sigma
-    np_matrix compute_sss_3rdm(np_vector C_left, np_vector C_right, bool alfa) const;
+    np_matrix compute_sss_3rdm(np_vector C_left, np_vector C_right, Spin spin) const;
 
     /// @brief Compute the alpha-alpha-alpha three-electron same-spin reduced density matrix
     /// @param C_left The left-hand side coefficients
@@ -297,12 +302,12 @@ class CISigmaBuilder {
     /// @brief  One-electron contribution to the sigma vector |sigma> = H |basis>
     /// @param alfa If true, compute the alpha contribution, otherwise the beta
     /// @param h The one-electron integrals
-    void H1_hz(std::span<double> basis, std::span<double> sigma, bool alfa,
+    void H1_hz(std::span<double> basis, std::span<double> sigma, Spin spin,
                std::span<double> h) const;
 
     /// @brief  Two-electron same-spin contribution to the sigma vector |sigma> = H |basis>
     /// @param alfa If true, compute the alpha contribution, otherwise the beta
-    void H2_hz_same_spin(std::span<double> basis, std::span<double> sigma, bool alfa) const;
+    void H2_hz_same_spin(std::span<double> basis, std::span<double> sigma, Spin spin) const;
 
     /// @brief  Two-electron mixed-spin contribution to the sigma vector |sigma> = H |basis>
     /// @param basis The basis vector
@@ -318,7 +323,7 @@ class CISigmaBuilder {
 
     /// @brief Builds the one-electron contribution to the sigma vector using the Knowles-Handy
     /// algorithm.
-    void H1_kh(std::span<double> basis, std::span<double> sigma, bool alpha) const;
+    void H1_kh(std::span<double> basis, std::span<double> sigma, Spin spin) const;
 
     /// @brief Builds the two-electron contribution to the sigma vector using the Knowles-Handy
     /// algorithm.
@@ -329,13 +334,13 @@ class CISigmaBuilder {
 };
 
 [[nodiscard]] std::span<double> gather_block(std::span<double> source, std::span<double> dest,
-                                             bool alfa, const CIStrings& lists, int class_Ia,
+                                             Spin spin, const CIStrings& lists, int class_Ia,
                                              int class_Ib);
 
-void zero_block(std::span<double> dest, bool alfa, const CIStrings& lists, int class_Ia,
+void zero_block(std::span<double> dest, Spin spin, const CIStrings& lists, int class_Ia,
                 int class_Ib);
 
-void scatter_block(std::span<double> source, std::span<double> dest, bool alfa,
+void scatter_block(std::span<double> source, std::span<double> dest, Spin spin,
                    const CIStrings& lists, int class_Ia, int class_Ib);
 
 } // namespace forte2

--- a/forte2/ci/ci_sigma_builder_3rdm.cc
+++ b/forte2/ci/ci_sigma_builder_3rdm.cc
@@ -8,7 +8,7 @@
 
 namespace forte2 {
 
-np_matrix CISigmaBuilder::compute_sss_3rdm(np_vector C_left, np_vector C_right, bool alfa) const {
+np_matrix CISigmaBuilder::compute_sss_3rdm(np_vector C_left, np_vector C_right, Spin spin) const {
     local_timer timer;
 
     const auto na = lists_.na();
@@ -24,7 +24,7 @@ np_matrix CISigmaBuilder::compute_sss_3rdm(np_vector C_left, np_vector C_right, 
     auto rdm = make_zeros<nb::numpy, double, 2>({ntriplets, ntriplets});
 
     // skip building the RDM if there are not enough electrons
-    if ((alfa and (na < 3)) or ((!alfa) and (nb < 3)))
+    if ((is_alpha(spin) and (na < 3)) or (is_beta(spin) and (nb < 3)))
         return rdm;
 
     auto Cl_span = vector::as_span(C_left);
@@ -34,39 +34,42 @@ np_matrix CISigmaBuilder::compute_sss_3rdm(np_vector C_left, np_vector C_right, 
     const auto& alfa_address = lists_.alfa_address();
     const auto& beta_address = lists_.beta_address();
 
-    int num_3h_classes =
-        alfa ? lists_.alfa_address_3h()->nclasses() : lists_.beta_address_3h()->nclasses();
+    int num_3h_classes = is_alpha(spin) ? lists_.alfa_address_3h()->nclasses()
+                                        : lists_.beta_address_3h()->nclasses();
 
     for (int class_K = 0; class_K < num_3h_classes; ++class_K) {
-        size_t maxK = alfa ? lists_.alfa_address_3h()->strpcls(class_K)
-                           : lists_.beta_address_3h()->strpcls(class_K);
+        size_t maxK = is_alpha(spin) ? lists_.alfa_address_3h()->strpcls(class_K)
+                                     : lists_.beta_address_3h()->strpcls(class_K);
 
         // loop over blocks of matrix C
         for (const auto& [nI, class_Ia, class_Ib] : lists_.determinant_classes()) {
             if (lists_.block_size(nI) == 0)
                 continue;
 
-            auto tr = gather_block(Cr_span, TR, alfa, lists_, class_Ia, class_Ib);
+            auto tr = gather_block(Cr_span, TR, spin, lists_, class_Ia, class_Ib);
 
             for (const auto& [nJ, class_Ja, class_Jb] : lists_.determinant_classes()) {
                 // The string class on which we don't act must be the same for I and J
-                if ((alfa and (class_Ib != class_Jb)) or (not alfa and (class_Ia != class_Ja)))
+                if ((is_alpha(spin) and (class_Ib != class_Jb)) or
+                    (is_beta(spin) and (class_Ia != class_Ja)))
                     continue;
                 if (lists_.block_size(nJ) == 0)
                     continue;
 
-                const size_t maxL =
-                    alfa ? beta_address->strpcls(class_Ib) : alfa_address->strpcls(class_Ia);
+                const size_t maxL = is_alpha(spin) ? beta_address->strpcls(class_Ib)
+                                                   : alfa_address->strpcls(class_Ia);
 
                 if (maxL > 0) {
                     // Get a pointer to the correct block of matrix C
-                    auto tl = gather_block(Cl_span, TL, alfa, lists_, class_Ja, class_Jb);
+                    auto tl = gather_block(Cl_span, TL, spin, lists_, class_Ja, class_Jb);
 
                     for (size_t K{0}; K < maxK; ++K) {
-                        auto& Krlist = alfa ? lists_.get_alfa_3h_list(class_K, K, class_Ia)
-                                            : lists_.get_beta_3h_list(class_K, K, class_Ib);
-                        auto& Kllist = alfa ? lists_.get_alfa_3h_list(class_K, K, class_Ja)
-                                            : lists_.get_beta_3h_list(class_K, K, class_Jb);
+                        auto& Krlist = is_alpha(spin)
+                                           ? lists_.get_alfa_3h_list(class_K, K, class_Ia)
+                                           : lists_.get_beta_3h_list(class_K, K, class_Ib);
+                        auto& Kllist = is_alpha(spin)
+                                           ? lists_.get_alfa_3h_list(class_K, K, class_Ja)
+                                           : lists_.get_beta_3h_list(class_K, K, class_Jb);
                         for (const auto& [sign_K, p, q, r, I] : Krlist) {
                             const size_t pqr_index = triplet_index_gt(p, q, r);
                             for (const auto& [sign_L, s, t, u, J] : Kllist) {
@@ -86,11 +89,11 @@ np_matrix CISigmaBuilder::compute_sss_3rdm(np_vector C_left, np_vector C_right, 
 }
 
 np_matrix CISigmaBuilder::compute_aaa_3rdm(np_vector C_left, np_vector C_right) const {
-    return compute_sss_3rdm(C_left, C_right, true);
+    return compute_sss_3rdm(C_left, C_right, Spin::Alpha);
 }
 
 np_matrix CISigmaBuilder::compute_bbb_3rdm(np_vector C_left, np_vector C_right) const {
-    return compute_sss_3rdm(C_left, C_right, false);
+    return compute_sss_3rdm(C_left, C_right, Spin::Beta);
 }
 
 np_tensor4 CISigmaBuilder::compute_aab_3rdm(np_vector C_left, np_vector C_right) const {
@@ -359,7 +362,7 @@ np_tensor6 CISigmaBuilder::compute_sf_3rdm(np_vector C_left, np_vector C_right) 
 
     // To reduce the  memory footprint, we compute the aaa and bbb contributions in a packed
     // format and one at a time.
-    for (auto spin : {true, false}) {
+    for (auto spin : {Spin::Alpha, Spin::Beta}) {
         auto rdm_sss = compute_sss_3rdm(C_left, C_right, spin);
         auto rdm_sss_v = rdm_sss.view();
 

--- a/forte2/ci/ci_sigma_builder_harrison_zarrabian.cc
+++ b/forte2/ci/ci_sigma_builder_harrison_zarrabian.cc
@@ -1,7 +1,4 @@
 #include <algorithm>
-#include <future>
-#include <iostream>
-#include <thread>
 #include <vector>
 
 #include "helpers/timer.hpp"
@@ -13,25 +10,25 @@
 
 namespace forte2 {
 
-void CISigmaBuilder::H1_hz(std::span<double> basis, std::span<double> sigma, bool alfa,
+void CISigmaBuilder::H1_hz(std::span<double> basis, std::span<double> sigma, Spin spin,
                            std::span<double> h) const {
     const size_t norb = lists_.norb();
     const auto na = lists_.na();
     const auto nb = lists_.nb();
 
     // skip this block if there is no electron with equal spin to that on which this operator acts
-    if ((alfa and (na < 1)) or ((!alfa) and (nb < 1)))
+    if ((is_alpha(spin) and (na < 1)) or (is_beta(spin) and (nb < 1)))
         return;
 
     const auto& alfa_address = lists_.alfa_address();
     const auto& beta_address = lists_.beta_address();
-    int num_1h_classes =
-        alfa ? lists_.alfa_address_1h()->nclasses() : lists_.beta_address_1h()->nclasses();
+    const int num_1h_classes = is_alpha(spin) ? lists_.alfa_address_1h()->nclasses()
+                                              : lists_.beta_address_1h()->nclasses();
 
     // |K>|L> = ± a_p |I>|L>
     for (int class_K = 0; class_K < num_1h_classes; ++class_K) {
-        size_t maxK = alfa ? lists_.alfa_address_1h()->strpcls(class_K)
-                           : lists_.beta_address_1h()->strpcls(class_K);
+        const size_t maxK = is_alpha(spin) ? lists_.alfa_address_1h()->strpcls(class_K)
+                                           : lists_.beta_address_1h()->strpcls(class_K);
 
         if (maxK == 0)
             continue;
@@ -43,48 +40,66 @@ void CISigmaBuilder::H1_hz(std::span<double> basis, std::span<double> sigma, boo
                 continue;
 
             // size of the strings with opposite spin to the one on which we act
-            size_t maxL = alfa ? beta_address->strpcls(class_Ib) : alfa_address->strpcls(class_Ia);
+            const size_t maxL =
+                is_alpha(spin) ? beta_address->strpcls(class_Ib) : alfa_address->strpcls(class_Ia);
 
             if (maxL > 0) {
-                // find the size of the block
-                const size_t dimKL = maxK * maxL;
-                // storing this block requires a temp_dim = norb * maxK * maxL matrix
-                const auto temp_dim = norb * dimKL;
-                // allocate temporary buffers if needed
-                if (Kblock1_.size() < temp_dim) {
-                    Kblock1_.resize(temp_dim);
-                    Kblock2_.resize(temp_dim);
-                }
-                // Use TL_local to store the result of the transformation to the 1h basis
-                std::fill_n(Kblock2_.begin(), temp_dim, 0.0);
-                std::fill_n(Kblock1_.begin(), temp_dim, 0.0);
+                // Grab the temporary buffers that will hold intermediates D(i,[K L])
+                // and return the maximum size of a chunk of K indices
+                auto [Kblock1, Kblock2, K_chunk_size] = get_Kblock_spans(norb * maxL, maxK);
 
-                auto tr = gather_block(basis, TR, alfa, lists_, class_Ia, class_Ib);
+                // number of elements in the temporary buffer
+                const auto temp_dim = norb * K_chunk_size * maxL;
 
-                for (size_t K = 0; K < maxK; ++K) {
-                    auto& Klist = alfa ? lists_.get_alfa_1h_list(class_K, K, class_Ia)
-                                       : lists_.get_beta_1h_list(class_K, K, class_Ib);
-                    for (const auto& [sign_K, q, I] : Klist) {
-                        add(maxL, sign_K, &tr[I * maxL], 1, &Kblock2_[q * dimKL + K * maxL], 1);
-                    }
-                }
+                // Grab a span with the C coefficients
+                auto tr = gather_block(basis, TR, spin, lists_, class_Ia, class_Ib);
 
-                matrix_product('N', 'N', norb, dimKL, norb, 1.0, h.data(), norb, Kblock2_.data(),
-                               dimKL, 0.0, Kblock1_.data(), dimKL);
+                // Loop over ranges of K indices in chuncks of size K_chunk_size
+                for (size_t K_start = 0; K_start < maxK; K_start += K_chunk_size) {
+                    const size_t K_end = std::min(K_start + K_chunk_size, maxK);
+                    // size of the K range, which may be smaller than K_chunk_size
+                    const size_t K_size = K_end - K_start;
+                    // number of columns in the chunk we are processing
+                    const size_t dimKL = K_size * maxL;
 
-                for (const auto& [nJ, class_Ja, class_Jb] : lists_.determinant_classes()) {
-                    if ((alfa) and (class_Ib != class_Jb) or ((!alfa) and (class_Ia != class_Ja)))
-                        continue;
+                    std::fill_n(Kblock2.begin(), temp_dim, 0.0);
 
-                    std::fill_n(TL.begin(), TL.size(), 0.0);
-                    for (size_t K = 0; K < maxK; ++K) {
-                        auto& Klist = alfa ? lists_.get_alfa_1h_list(class_K, K, class_Ja)
-                                           : lists_.get_beta_1h_list(class_K, K, class_Jb);
-                        for (const auto& [sign_K, p, I] : Klist) {
-                            add(maxL, sign_K, &Kblock1_[p * dimKL + K * maxL], 1, &TL[I * maxL], 1);
+                    // Loop over the K indices in the chunk
+                    for (size_t K = 0; K < K_size; ++K) {
+                        const auto& Klist =
+                            is_alpha(spin)
+                                ? lists_.get_alfa_1h_list(class_K, K_start + K, class_Ia)
+                                : lists_.get_beta_1h_list(class_K, K_start + K, class_Ib);
+                        // D(q,[K L]) += <K|a_q|I> C(I,L)
+                        for (const auto& [sign_K, q, I] : Klist) {
+                            add(maxL, sign_K, &tr[I * maxL], 1, &Kblock2_[q * dimKL + K * maxL], 1);
                         }
                     }
-                    scatter_block(TL, sigma, alfa, lists_, class_Ja, class_Jb);
+
+                    // E(p,[K L]) = sum_q h(p,q) D(q,[K L])
+                    matrix_product('N', 'N', norb, dimKL, norb, 1.0, h.data(), norb,
+                                   Kblock2_.data(), dimKL, 0.0, Kblock1_.data(), dimKL);
+
+                    // sigma(J L) += <J|a^+_p|K> E(p,[K L])
+                    for (const auto& [nJ, class_Ja, class_Jb] : lists_.determinant_classes()) {
+                        if ((is_alpha(spin) and (class_Ib != class_Jb)) or
+                            (is_beta(spin) and (class_Ia != class_Ja)))
+                            continue;
+
+                        // zero the temporary buffer that will hold the result
+                        std::fill_n(TL.begin(), TL.size(), 0.0);
+                        for (size_t K = 0; K < K_size; ++K) {
+                            const auto& Klist =
+                                is_alpha(spin)
+                                    ? lists_.get_alfa_1h_list(class_K, K_start + K, class_Ja)
+                                    : lists_.get_beta_1h_list(class_K, K_start + K, class_Jb);
+                            for (const auto& [sign_K, p, I] : Klist) {
+                                add(maxL, sign_K, &Kblock1_[p * dimKL + K * maxL], 1, &TL[I * maxL],
+                                    1);
+                            }
+                        }
+                        scatter_block(TL, sigma, spin, lists_, class_Ja, class_Jb);
+                    }
                 }
             }
         }
@@ -92,8 +107,8 @@ void CISigmaBuilder::H1_hz(std::span<double> basis, std::span<double> sigma, boo
 }
 
 void CISigmaBuilder::H2_hz_same_spin(std::span<double> basis, std::span<double> sigma,
-                                     bool alfa) const {
-    if ((alfa and (lists_.na() < 2)) or ((!alfa) and (lists_.nb() < 2)))
+                                     Spin spin) const {
+    if ((is_alpha(spin) and (lists_.na() < 2)) or (is_beta(spin) and (lists_.nb() < 2)))
         return;
 
     const size_t norb = lists_.norb();
@@ -102,81 +117,74 @@ void CISigmaBuilder::H2_hz_same_spin(std::span<double> basis, std::span<double> 
     const auto& alfa_address = lists_.alfa_address();
     const auto& beta_address = lists_.beta_address();
 
-    int num_2h_classes =
-        alfa ? lists_.alfa_address_2h()->nclasses() : lists_.beta_address_2h()->nclasses();
+    const int num_2h_classes = is_alpha(spin) ? lists_.alfa_address_2h()->nclasses()
+                                              : lists_.beta_address_2h()->nclasses();
 
     for (int class_K = 0; class_K < num_2h_classes; ++class_K) {
-        size_t maxK = alfa ? lists_.alfa_address_2h()->strpcls(class_K)
-                           : lists_.beta_address_2h()->strpcls(class_K);
+        const size_t maxK = is_alpha(spin) ? lists_.alfa_address_2h()->strpcls(class_K)
+                                           : lists_.beta_address_2h()->strpcls(class_K);
 
         // loop over blocks of matrix C
         for (const auto& [nI, class_Ia, class_Ib] : lists_.determinant_classes()) {
             if (lists_.block_size(nI) == 0)
                 continue;
 
-            size_t maxL = alfa ? beta_address->strpcls(class_Ib) : alfa_address->strpcls(class_Ia);
+            const size_t maxL =
+                is_alpha(spin) ? beta_address->strpcls(class_Ib) : alfa_address->strpcls(class_Ia);
 
             if (maxL > 0) {
-                // We gather the block of C into TR
-                const size_t dimKL = maxK * maxL;
+                // grab temporary buffers and the maximum size of a chunk of K indices
+                auto [Kblock1, Kblock2, K_chunk_size] = get_Kblock_spans(npairs * maxL, maxK);
 
-                // This block requires a temp_dim = npairs * maxK * maxL matrix
-                const auto temp_dim = npairs * dimKL;
-                if (Kblock1_.size() < temp_dim) {
-                    Kblock1_.resize(temp_dim);
-                    Kblock2_.resize(temp_dim);
-                }
-                // We use TL_local to store the result of the transformation to the 2h
-                // basis
-                std::fill_n(Kblock2_.begin(), temp_dim, 0.0);
-                std::fill_n(Kblock1_.begin(), temp_dim, 0.0);
+                // number of elements in the temporary blocks
+                const auto temp_dim = npairs * K_chunk_size * maxL;
 
-                auto tr = gather_block(basis, TR, alfa, lists_, class_Ia, class_Ib);
+                auto tr = gather_block(basis, TR, spin, lists_, class_Ia, class_Ib);
 
-                for (size_t K = 0; K < maxK; ++K) {
-                    auto& Krlist = alfa ? lists_.get_alfa_2h_list(class_K, K, class_Ia)
-                                        : lists_.get_beta_2h_list(class_K, K, class_Ib);
-                    for (const auto& [sign_K, q, s, I] : Krlist) {
-                        const size_t qs_index = q * (q - 1) / 2 + s;
-                        for (size_t idx{0}; idx != maxL; ++idx) {
-                            Kblock2_[qs_index * dimKL + K * maxL + idx] +=
-                                sign_K * tr[I * maxL + idx];
+                // Loop over ranges of K indices in chuncks of size K_chunk_size
+                for (size_t K_start = 0; K_start < maxK; K_start += K_chunk_size) {
+                    const size_t K_end = std::min(K_start + K_chunk_size, maxK);
+                    // size of the K range, which may be smaller than K_chunk_size
+                    const size_t K_size = K_end - K_start;
+                    const size_t dimKL = K_size * maxL;
+
+                    std::fill_n(Kblock2.begin(), temp_dim, 0.0);
+
+                    for (size_t K = 0; K < K_size; ++K) {
+                        const auto& Krlist =
+                            is_alpha(spin)
+                                ? lists_.get_alfa_2h_list(class_K, K + K_start, class_Ia)
+                                : lists_.get_beta_2h_list(class_K, K + K_start, class_Ib);
+                        for (const auto& [sign_K, q, s, I] : Krlist) {
+                            const size_t qs_index = pair_index_gt(q, s);
+                            add(maxL, sign_K, &tr[I * maxL], 1,
+                                &Kblock2_[qs_index * dimKL + K * maxL], 1);
                         }
                     }
-                }
-                matrix_product('N', 'N', npairs, dimKL, npairs, 1.0, v_pr_qs_a.data(), npairs,
-                               Kblock2_.data(), dimKL, 0.0, Kblock1_.data(), dimKL);
 
-                for (const auto& [nJ, class_Ja, class_Jb] : lists_.determinant_classes()) {
-                    if (((alfa) and (class_Ib != class_Jb)) or ((!alfa) and (class_Ia != class_Ja)))
-                        continue;
+                    matrix_product('N', 'N', npairs, dimKL, npairs, 1.0, v_pr_qs_a.data(), npairs,
+                                   Kblock2_.data(), dimKL, 0.0, Kblock1_.data(), dimKL);
 
-                    std::fill_n(TL.begin(), TL.size(), 0.0);
-                    for (size_t K = 0; K < maxK; ++K) {
-                        auto& Klist = alfa ? lists_.get_alfa_2h_list(class_K, K, class_Ja)
-                                           : lists_.get_beta_2h_list(class_K, K, class_Jb);
-                        for (const auto& [sign_K, p, r, I] : Klist) {
-                            const size_t pr_index = p * (p - 1) / 2 + r;
-                            add(maxL, sign_K, &Kblock1_[pr_index * dimKL + K * maxL], 1,
-                                &TL[I * maxL], 1);
+                    for (const auto& [nJ, class_Ja, class_Jb] : lists_.determinant_classes()) {
+                        if (((is_alpha(spin) and (class_Ib != class_Jb)) or
+                             (is_beta(spin) and (class_Ia != class_Ja))))
+                            continue;
+
+                        std::fill_n(TL.begin(), TL.size(), 0.0);
+                        for (size_t K = 0; K < K_size; ++K) {
+                            const auto& Klist =
+                                is_alpha(spin)
+                                    ? lists_.get_alfa_2h_list(class_K, K + K_start, class_Ja)
+                                    : lists_.get_beta_2h_list(class_K, K + K_start, class_Jb);
+                            for (const auto& [sign_K, p, r, I] : Klist) {
+                                const size_t pr_index = pair_index_gt(p, r);
+                                add(maxL, sign_K, &Kblock1_[pr_index * dimKL + K * maxL], 1,
+                                    &TL[I * maxL], 1);
+                            }
                         }
+                        scatter_block(TL, sigma, spin, lists_, class_Ja, class_Jb);
                     }
-                    scatter_block(TL, sigma, alfa, lists_, class_Ja, class_Jb);
                 }
-
-                // std::fill_n(TL.begin(), temp_dim, 0.0);
-
-                // for (size_t K = 0; K < maxK; ++K) {
-                //     auto& Krlist = alfa ? lists_.get_alfa_2h_list(class_K, K, class_Ia)
-                //                         : lists_.get_beta_2h_list(class_K, K, class_Ib);
-                //     for (const auto& [sign_K, p, r, I] : Krlist) {
-                //         const size_t pr_index = p * (p - 1) / 2 + r;
-                //         for (size_t idx{0}; idx != maxL; ++idx) {
-                //             TL[I * maxL + idx] += sign_K * TR[pr_index * dimKL + K * maxL + idx];
-                //         }
-                //     }
-                // }
-                // scatter_block(TL, sigma, alfa, lists_, class_Ia, class_Ib);
             }
         }
     }
@@ -192,9 +200,6 @@ void CISigmaBuilder::H2_hz_opposite_spin(std::span<double> basis, std::span<doub
     const int num_1h_class_Ka = lists_.alfa_address_1h()->nclasses();
     const int num_1h_class_Kb = lists_.beta_address_1h()->nclasses();
 
-    std::vector<double> TR_local;
-    std::vector<double> TL_local;
-
     // loop over blocks of N-2 space
     for (int class_Ka = 0; class_Ka < num_1h_class_Ka; ++class_Ka) {
         for (int class_Kb = 0; class_Kb < num_1h_class_Kb; ++class_Kb) {
@@ -202,23 +207,20 @@ void CISigmaBuilder::H2_hz_opposite_spin(std::span<double> basis, std::span<doub
             const auto maxKb = lists_.beta_address_1h()->strpcls(class_Kb);
 
             // We gather the block of C into TR
-            size_t Kb_block_start = 0;
-            size_t Kb_block_end = maxKb;
-            size_t Kb_block_size = maxKb;
-            const size_t Ka_block_size = std::min(134217728 / (maxKb * norb2), maxKa);
+            const size_t Kb_block_start = 0;
+            const size_t Kb_block_end = maxKb;
+            const size_t Kb_block_size = maxKb;
+
+            auto [Kblock1, Kblock2, Ka_block_size] = get_Kblock_spans(norb2 * maxKb, maxKa);
+
             for (size_t Ka_block_start = 0; Ka_block_start < maxKa;
                  Ka_block_start += Ka_block_size) {
                 size_t Ka_block_end = std::min(Ka_block_start + Ka_block_size, maxKa);
                 size_t Ka_block_size = Ka_block_end - Ka_block_start;
-                const auto Kdim = Ka_block_size * (Kb_block_end - Kb_block_start);
+                const auto Kdim = Ka_block_size * Kb_block_size;
                 const auto temp_dim = norb2 * Kdim;
 
-                // This block requires a temp_dim = norb * norb * maxKa * maxKb matrix
-                if (TR_local.size() < temp_dim) {
-                    TR_local.resize(temp_dim);
-                    TL_local.resize(temp_dim);
-                }
-                std::fill_n(TR_local.begin(), temp_dim, 0.0);
+                std::fill_n(Kblock1.begin(), temp_dim, 0.0);
 
                 // D([qs],[Ka Kb]) = \sum_{Ia,Ib} B^{Ka,Kb,Ia,Ib}_{pq} C_{Ia,Ib}
                 for (const auto& [nI, class_Ia, class_Ib] : lists_.determinant_classes()) {
@@ -242,7 +244,7 @@ void CISigmaBuilder::H2_hz_opposite_spin(std::span<double> basis, std::span<doub
                                 const size_t b_offset = Cr_offset + Ia * maxIb;
                                 for (const auto& [sign_s, s, Ib] : KbL) {
                                     const size_t qs_index = qnorb + s;
-                                    TR_local[qs_index * Kdim + Kidx] =
+                                    Kblock1[qs_index * Kdim + Kidx] =
                                         sign_q * sign_s * basis[b_offset + Ib];
                                 }
                             }
@@ -251,7 +253,7 @@ void CISigmaBuilder::H2_hz_opposite_spin(std::span<double> basis, std::span<doub
                 }
 
                 matrix_product('N', 'N', norb2, Kdim, norb2, 1.0, v_pr_qs.data(), norb2,
-                               TR_local.data(), Kdim, 0.0, TL_local.data(), Kdim);
+                               Kblock1.data(), Kdim, 0.0, Kblock2.data(), Kdim);
 
                 // D([qs],[Ka Kb]) = \sum_{Ia,Ib} B^{Ka,Kb,Ia,Ib}_{pq} C_{Ia,Ib}
                 for (const auto& [nI, class_Ia, class_Ib] : lists_.determinant_classes()) {
@@ -276,7 +278,7 @@ void CISigmaBuilder::H2_hz_opposite_spin(std::span<double> basis, std::span<doub
                                 for (const auto& [sign_r, r, Ib] : KbL) {
                                     const size_t pr_index = pnorb + r;
                                     sigma[s_offset + Ib] +=
-                                        sign_p * sign_r * TL_local[pr_index * Kdim + Kidx];
+                                        sign_p * sign_r * Kblock2[pr_index * Kdim + Kidx];
                                 }
                             }
                         }

--- a/forte2/ci/ci_sigma_builder_knowles_handy.cc
+++ b/forte2/ci/ci_sigma_builder_knowles_handy.cc
@@ -5,6 +5,7 @@
 #include "helpers/timer.hpp"
 #include "helpers/blas.h"
 #include "helpers/logger.h"
+#include "helpers/memory.h"
 
 #include "ci_sigma_builder.h"
 
@@ -27,31 +28,31 @@ void scatter_alpha_block(const CIStrings& lists, size_t class_Ka, size_t class_K
                          std::span<double> sigma);
 } // namespace
 
-void CISigmaBuilder::H1_kh(std::span<double> basis, std::span<double> sigma, bool alfa) const {
+void CISigmaBuilder::H1_kh(std::span<double> basis, std::span<double> sigma, Spin spin) const {
     size_t norb = lists_.norb();
     // loop over blocks of matrix C
     for (const auto& [nI, class_Ia, class_Ib] : lists_.determinant_classes()) {
         if (lists_.block_size(nI) == 0)
             continue;
-        auto Cr = gather_block(basis, TR, alfa, lists_, class_Ia, class_Ib);
+        auto Cr = gather_block(basis, TR, spin, lists_, class_Ia, class_Ib);
 
         for (const auto& [nJ, class_Ja, class_Jb] : lists_.determinant_classes()) {
             // For alpha operator, the beta string classes of the result must be the same
-            if (alfa and (class_Ib != class_Jb))
+            if (is_alpha(spin) and (class_Ib != class_Jb))
                 continue;
             // For beta operator, the alpha string classes of the result must be the same
-            if (not alfa and (class_Ia != class_Ja))
+            if (is_beta(spin) and (class_Ia != class_Ja))
                 continue;
             if (lists_.block_size(nJ) == 0)
                 continue;
 
             std::fill_n(TL.begin(), lists_.block_size(nJ), 0.0);
 
-            size_t maxL = alfa ? lists_.beta_address()->strpcls(class_Ib)
-                               : lists_.alfa_address()->strpcls(class_Ia);
+            const size_t maxL = is_alpha(spin) ? lists_.beta_address()->strpcls(class_Ib)
+                                               : lists_.alfa_address()->strpcls(class_Ia);
 
-            const auto& pq_vo_list = alfa ? lists_.get_alfa_vo_list(class_Ia, class_Ja)
-                                          : lists_.get_beta_vo_list(class_Ib, class_Jb);
+            const auto& pq_vo_list = is_alpha(spin) ? lists_.get_alfa_vo_list(class_Ia, class_Ja)
+                                                    : lists_.get_beta_vo_list(class_Ib, class_Jb);
 
             for (const auto& [pq, vo_list] : pq_vo_list) {
                 const auto& [p, q] = pq;
@@ -60,7 +61,7 @@ void CISigmaBuilder::H1_kh(std::span<double> basis, std::span<double> sigma, boo
                     add(maxL, sign * Hpq, &Cr[I * maxL], 1, &TL[J * maxL], 1);
                 }
             }
-            scatter_block(TL, sigma, alfa, lists_, class_Ja, class_Jb);
+            scatter_block(TL, sigma, spin, lists_, class_Ja, class_Jb);
         }
     }
 }
@@ -106,32 +107,29 @@ void CISigmaBuilder::H2_kh(std::span<double> basis, std::span<double> sigma) con
                 // dimensions of the matrix we are going to use for this Ka
                 // chunk
                 const size_t Kdim = Ka_size * Kb_size;
-                // dimension of the D([i<=j],[Ka Kb]) tensor we are going to
-                // use
+                // dimension of the D([i<=j],[Ka Kb]) tensor
                 const size_t temp_dim = npairs * Kdim;
 
                 // skip empty blocks
                 if (temp_dim == 0)
                     continue;
 
-                // zero out the block that will hold the D([i>=j],[Ka Kb])
-                // tensor
+                // zero out the block that will hold the D([i>=j],[Ka Kb]) tensor
                 std::fill_n(Kblock1.begin(), temp_dim, 0.0);
 
                 // alpha contribution to the D matrix D([i>=j],[Ka Kb])
                 gather_alpha_block(lists_, class_Ka, class_Kb, Ka_start, Ka_size, Kdim, maxKb,
                                    basis, std::span{Kblock1.data(), temp_dim});
 
-                // cyclic transpose of the D matrix D([i>=j],[Ka Kb]) to
-                // D([i>=j],[Kb Ka])
+                // cyclic transpose of the D matrix D([i>=j],[Ka Kb]) to D([i>=j],[Kb Ka])
                 transpose_23(Kblock1, Kblock2, npairs, Ka_size, maxKb);
 
                 // beta contribution to the D matrix D([i>=j],[Kb Ka])
                 gather_beta_block(lists_, class_Ka, class_Kb, Ka_start, Ka_size, Kdim, maxKb, basis,
                                   TR, std::span{Kblock2.data(), temp_dim});
 
-                // matrix-matrix multiplication 0.5 * V([k>=l][i>=j]) *
-                // D([i>=j],[Kb Ka]) The result is the matrix E([k>=l],[Kb Ka])
+                // matrix-matrix multiplication 0.5 * V([k>=l][i>=j]) * D([i>=j],[Kb Ka])
+                // The result is the matrix E([k>=l],[Kb Ka])
                 // [note that the Ka/Kb indices are still transposed]
                 matrix_product('N', 'N', npairs, Kdim, npairs, 0.5, v_ijkl_hk.data(), npairs,
                                Kblock2.data(), Kdim, 0.0, Kblock1.data(), Kdim);
@@ -154,53 +152,45 @@ void CISigmaBuilder::H2_kh(std::span<double> basis, std::span<double> sigma) con
 }
 
 std::tuple<std::span<double>, std::span<double>, size_t>
-CISigmaBuilder::get_Kblock_spans(size_t dim, size_t maxKa) const {
-    // calculate the amount needed to store the Kblock1_ and Kblock2_ buffers
-    // fully in core.
-    const size_t temp_full_size = dim * maxKa;
+CISigmaBuilder::get_Kblock_spans(size_t nrows, size_t ncols) const {
+    // Find the maximum size of the temporary block to allocate. This is either set by the full
+    // size of the block (nrows * ncols) or by the available memory size, whichever is smaller
+    std::size_t block_size = std::min(nrows * ncols, memory_size_ / (2 * sizeof(double)));
 
-    // Find the maximum size of the temporary buffers to allocate. This is either set by the full
-    // size of the buffers or by the available memory size, whichever is smaller
-    std::size_t temp_memory_size = std::min(memory_size_ / (2 * sizeof(double)), temp_full_size);
-    if (Kblock1_.size() < temp_memory_size) {
-        LOG(log_level_) << "Allocating Knowles-Handy temporary buffers of size 2 x "
-                        << temp_memory_size << " ("
-                        << 2 * temp_memory_size * sizeof(double) / (1024 * 1024) << " MB).";
-        Kblock1_.resize(temp_memory_size);
-        Kblock2_.resize(temp_memory_size);
+    // Find the corresponding chunk size for K
+    size_t cols_chunk_size = std::min(block_size / nrows, ncols);
+
+    // If the chunk size is too small to store one row, resize it
+    bool need_resize = false;
+    if (cols_chunk_size < 1) {
+        // resize to a reasonable minimum and update block_size
+        cols_chunk_size = std::min(static_cast<size_t>(64), ncols);
+        block_size = nrows * cols_chunk_size;
+        need_resize = true;
     }
 
-    // Derive Ka_max_size from our preallocated buffers:
-    size_t available = Kblock1_.size(); // assume Kblock2_ same size
-    size_t Ka_max_size = std::min(available / dim, maxKa);
-    if (Ka_max_size < 1) {
-        // too small for even one row of Ka => resize to hold a reasonable
-        // minimum
-        Ka_max_size = std::min(static_cast<size_t>(64),
-                               maxKa); // 64 is a reasonable minimum size
-        size_t new_dim = Ka_max_size * dim;
-        Kblock1_.resize(new_dim);
-        Kblock2_.resize(new_dim);
-        auto available_MB = 2 * available / (1024 * 1024 * sizeof(double));
-        auto new_dim_MB = 2 * new_dim / (1024 * 1024 * sizeof(double));
-        std::cerr << "Warning: dim = " << dim << ", maxKa = " << maxKa
-                  << " Knowles-Handy temporary buffers too small (" << 2 * available
-                  << " elements; " << available_MB << " MB); resized to " << 2 * new_dim
-                  << " elements; " << new_dim_MB << " MB.\n"
-                  << "For best performance, set the memory size via the "
-                     "CISigmaBuilder::set_memory() function.\n";
+    // If the temporary buffers are too small, resize them
+    if (Kblock1_.size() < block_size) {
+        Kblock1_.resize(block_size);
+        Kblock2_.resize(block_size);
+        if (need_resize) {
+            auto block_size_MB = to_mb<double>(2 * block_size);
+            LOG(log_level_) << "Available memory is too small to hold a row of the CI buffers.\n"
+                               "Block size has been adjusted to 2 x "
+                            << block_size << " (" << block_size_MB << " MB) to hold "
+                            << cols_chunk_size
+                            << " columns.\n"
+                               "For best performance, increase the memory limit.";
+        }
     }
 
-    size_t max_temp_dim = dim * Ka_max_size;
-
-    return {std::span<double>{Kblock1_.data(), max_temp_dim},
-            std::span<double>{Kblock2_.data(), max_temp_dim}, Ka_max_size};
+    return {std::span<double>{Kblock1_.data(), block_size},
+            std::span<double>{Kblock2_.data(), block_size}, cols_chunk_size};
 }
 
 // The following functions are used to gather and scatter blocks of data and
 // are relevant only to this file. They live in the anonymous namespace to
 // avoid polluting the global namespace.
-
 namespace {
 /// @brief Cyclic multithreaded transpose of indices 2 and 3 of a 3D tensor
 /// in[i][j][k] -> out[i][k][j]
@@ -298,7 +288,7 @@ void gather_beta_block(const CIStrings& lists, size_t class_Ka, size_t class_Kb,
         size_t maxIa = lists.alfa_address()->strpcls(class_Ia);
 
         // transposes the basis vector into TR
-        auto basis_tr = gather_block(basis, TR, false, lists, class_Ia, class_Ib);
+        auto basis_tr = gather_block(basis, TR, Spin::Beta, lists, class_Ia, class_Ib);
 
         // add contributions to the Kblock
         for (size_t Kb = 0; Kb < maxKb; ++Kb) {
@@ -329,7 +319,7 @@ void scatter_beta_block(const CIStrings& lists, size_t class_Ka, size_t class_Kb
         const auto maxIa = lists.alfa_address()->strpcls(class_Ia);
 
         // zero out the TR temporary vector for the scatter operation
-        zero_block(TR, false, lists, class_Ia, class_Ib);
+        zero_block(TR, Spin::Beta, lists, class_Ia, class_Ib);
 
         // scatter contributions from the Kblock into the TR vector
         for (size_t Kb = 0; Kb < maxKb; ++Kb) {
@@ -342,7 +332,7 @@ void scatter_beta_block(const CIStrings& lists, size_t class_Ka, size_t class_Kb
         }
 
         // scatter the TR([Kb Ka]) vector to the sigma vector
-        scatter_block(TR, sigma, false, lists, class_Ia, class_Ib);
+        scatter_block(TR, sigma, Spin::Beta, lists, class_Ia, class_Ib);
     }
 }
 

--- a/forte2/ci/ci_utils.py
+++ b/forte2/ci/ci_utils.py
@@ -15,25 +15,40 @@ def pretty_print_gas_info(ci_strings: CIStrings):
 
     logger.log_info1("\nGAS information:")
     for i in range(num_spaces):
-        logger.log_info1(f"GAS space {i + 1} : size = {gas_sizes[i]}, ")
+        logger.log_info1(f"GAS{i + 1}: size = {gas_sizes[i]}, ")
 
-    s = "\n    Config."
+    table = []  # table[space_index] = [(aocc, bocc) for each config]
+
     for i in range(num_spaces):
-        s += f"   Space {i + 1}"
-    s += "\n            "
-    for i in range(num_spaces):
-        s += "   α    β "
-    ndash = 7 + 10 * num_spaces
-    dash = "-" * ndash
-    s += f"\n    {dash}"
-    num_conf = 0
-    for aocc_idx, bocc_idx in occupation_pairs:
-        num_conf += 1
-        aocc = alfa_occupation[aocc_idx]
-        bocc = beta_occupation[bocc_idx]
-        s += f"\n    {num_conf:6d} "
-        for i in range(num_spaces):
-            s += f" {aocc[i]:4d} {bocc[i]:4d}"
+        row = []
+        for aocc_idx, bocc_idx in occupation_pairs:
+            aocc = alfa_occupation[aocc_idx]
+            bocc = beta_occupation[bocc_idx]
+            row.append((aocc[i], bocc[i]))
+        table.append(row)
+
+    # Build header
+    header = "Config.    "
+    for conf_num in range(len(occupation_pairs)):
+        header += f"{conf_num + 1:>3}"
+    table_width = len(header)
+    dash = "\n" + "-" * table_width
+    eq_dash = "=" * table_width
+
+    # Print rows: one per space
+    rows = [header]
+    for space_idx, row in enumerate(table, start=1):
+        s_row = f"\nGAS{space_idx:1d} α Occ."
+        for a_val, b_val in row:
+            s_row += f" {a_val:2d}"
+        s_row += f"\nGAS{space_idx:1d} β Occ."
+        for a_val, b_val in row:
+            s_row += f" {b_val:2d}"
+        rows.append(s_row)
+
+    s = f"\nGAS Occupation Configurations:\n{eq_dash}\n"
+    s += dash.join(rows)
+    s += f"\n{eq_dash}"
 
     logger.log_info1(s)
 

--- a/forte2/helpers/davidsonliu.py
+++ b/forte2/helpers/davidsonliu.py
@@ -195,6 +195,13 @@ class DavidsonLiuSolver:
         self.iter = 0
         self.converged = False
 
+        logger.log(
+            ("=" * 64)
+            + f"\nIter                 ⟨E⟩             max(ΔE)        max(r) basis\n"
+            + ("-" * 64),
+            self.log_level,
+        )
+
         for self.iter in range(self.maxiter):
             # 2. compute new sigma block if needed
             m_new = self.basis_size - self.sigma_size
@@ -305,9 +312,14 @@ class DavidsonLiuSolver:
                 self.basis_size += added2
                 msg = f" <- +{added2} random"
             logger.log(
-                f"{self.iter:4d}  ⟨E⟩ ={avg_e:18.12f}  max(ΔE) ={max_de:18.12f}  max(r) ={max_r:12.9f}  basis = {self.basis_size:4d} {msg}",
+                f"{self.iter:4d}  {avg_e:18.12f}  {max_de:18.12f}  {max_r:12.9f}  {self.basis_size:4d} {msg}",
                 self.log_level,
             )
+
+        logger.log(
+            ("=" * 64),
+            self.log_level,
+        )
 
         # compute final eigenpairs
         lamr = self.lam[: self.nroot]

--- a/forte2/helpers/memory.h
+++ b/forte2/helpers/memory.h
@@ -8,6 +8,9 @@
 
 namespace forte2 {
 
+/// @brief Express the amount of memory needed to store `n` elements of type T in megabytes
+template <typename T> int to_mb(size_t n) { return n * sizeof(T) / (1024 * 1024); }
+
 /// @brief A templated buffer class used to store elements of type T
 /// This class is a simple wrapper around std::vector<T> which provides a variable-size buffer.
 /// The buffer is initialized with a given size and is automatically resized when needed.

--- a/tests/ci/test_gasci_rhf.py
+++ b/tests/ci/test_gasci_rhf.py
@@ -273,7 +273,4 @@ def test_gasci_rhf_11():
 
     assert rhf.E == approx(erhf)       
     assert ci.E[0] == approx(eci)
-
-
-test_gasci_rhf_10()
-test_gasci_rhf_11()
+    

--- a/tests/ci/test_gasci_rhf.py
+++ b/tests/ci/test_gasci_rhf.py
@@ -189,3 +189,91 @@ def test_gasci_rhf_8():
     assert rhf.E == approx(-75.68026686304654)
     assert ci.E[0] == approx(-55.598443621487)
     assert ci.E[1] == approx(-55.526088426266)
+
+def test_gasci_rhf_9():
+    erhf = -76.05702512779526
+    eci = -76.063385164755
+
+    xyz = """
+    O   0.0000000000  -0.0000000000  -0.0662628033
+    H   0.0000000000  -0.7540256101   0.5259060578
+    H  -0.0000000000   0.7530256101   0.5260060578
+    """
+
+    system = System(
+        xyz=xyz, basis_set="cc-pVTZ", auxiliary_basis_set="def2-universal-jkfit"
+    )
+
+    rhf = RHF(charge=0, econv=1e-12, dconv=1e-12)(system)
+
+    ci = CI(
+        states=State(nel=10, multiplicity=1, ms=0.0, gas_min=[3], gas_max=[6]),
+        core_orbitals=[0, 1],
+        active_orbitals=[[2, 3, 4],[5, 6, 7]],
+        econv=1e-12,
+        # ci_algorithm='kh'
+    )(rhf)
+    ci.run()    
+
+    assert rhf.E == approx(erhf)
+    assert ci.E[0] == approx(eci)
+
+def test_gasci_rhf_10():
+    erhf = -76.05702512779526
+    eci = -76.0650697375
+
+    xyz = """
+    O   0.0000000000  -0.0000000000  -0.0662628033
+    H   0.0000000000  -0.7540256101   0.5259060578
+    H  -0.0000000000   0.7530256101   0.5260060578
+    """
+
+    system = System(
+        xyz=xyz, basis_set="cc-pVTZ", auxiliary_basis_set="def2-universal-jkfit"
+    )
+
+    rhf = RHF(charge=0, econv=1e-12, dconv=1e-6)(system)
+
+    ci = CI(
+        states=State(nel=10, multiplicity=1, ms=0.0, gas_min=[4], gas_max=[8]),
+        core_orbitals=[0],
+        active_orbitals=[[1, 2, 3, 4],[5, 6, 7]],    
+        econv=1e-10,
+        ci_algorithm='hz'
+    )(rhf)
+    ci.run()    
+
+    assert rhf.E == approx(erhf)       
+    assert ci.E[0] == approx(eci)
+
+def test_gasci_rhf_11():
+    erhf = -76.05702512779526
+    eci = -76.0650697375
+
+    xyz = """
+    O   0.0000000000  -0.0000000000  -0.0662628033
+    H   0.0000000000  -0.7540256101   0.5259060578
+    H  -0.0000000000   0.7530256101   0.5260060578
+    """
+
+    system = System(
+        xyz=xyz, basis_set="cc-pVTZ", auxiliary_basis_set="def2-universal-jkfit"
+    )
+
+    rhf = RHF(charge=0, econv=1e-12, dconv=1e-6)(system)
+
+    ci = CI(
+        states=State(nel=10, multiplicity=1, ms=0.0, gas_min=[4], gas_max=[8]),
+        core_orbitals=[0],
+        active_orbitals=[[1, 2, 3, 4],[5, 6, 7]],    
+        econv=1e-10,
+        ci_algorithm='kh'
+    )(rhf)
+    ci.run()    
+
+    assert rhf.E == approx(erhf)       
+    assert ci.E[0] == approx(eci)
+
+
+test_gasci_rhf_10()
+test_gasci_rhf_11()


### PR DESCRIPTION
This pull request refactors the CI sigma builder code to improve clarity and extensibility by replacing boolean spin arguments with a `Spin` enum, adds a method to query the current CI algorithm, and makes several related code and documentation updates. It also includes minor logging improvements and code cleanup.

**Nice printing of GAS configurations:**
* Now the occupation of GAS configurations is shown as a horizontal table to avoid cluttering the output. For example:
```
GAS Occupation Configurations:
==================================================
Config.      1  2  3  4  5  6  7  8  9 10 11 12 13
--------------------------------------------------
GAS1 α Occ.  1  1  2  2  2  3  3  3  3  4  4  4  4
GAS1 β Occ.  3  4  2  3  4  1  2  3  4  1  2  3  4
--------------------------------------------------
GAS2 α Occ.  3  3  2  2  2  1  1  1  1  0  0  0  0
GAS2 β Occ.  1  0  2  1  0  3  2  1  0  3  2  1  0
==================================================
```

**Spin argument refactor and related changes:**

* All functions in `CISigmaBuilder` and related helpers now use a `Spin` enum instead of a `bool` to specify spin (alpha/beta), improving code readability and maintainability. This affects method signatures, internal logic, and documentation in both header and implementation files (`ci_sigma_builder.h`, `ci_sigma_builder.cc`, `ci_sigma_builder_1rdm.cc`, `ci_sigma_builder_2rdm.cc`). [[1]](diffhunk://#diff-1d0dbdacd169c2090d16a89e8555a772d9cb06b87c74a510868495650169e27fL80-R88) [[2]](diffhunk://#diff-1d0dbdacd169c2090d16a89e8555a772d9cb06b87c74a510868495650169e27fL112-R120) [[3]](diffhunk://#diff-1d0dbdacd169c2090d16a89e8555a772d9cb06b87c74a510868495650169e27fL163-R171) [[4]](diffhunk://#diff-1d0dbdacd169c2090d16a89e8555a772d9cb06b87c74a510868495650169e27fL292-R326) [[5]](diffhunk://#diff-1d0dbdacd169c2090d16a89e8555a772d9cb06b87c74a510868495650169e27fL328-R343) [[6]](diffhunk://#diff-7411b14496e21b7be58c0af61f1cffa9e175a8e121565c0b73c3093752b68d8dL188-R199) [[7]](diffhunk://#diff-7411b14496e21b7be58c0af61f1cffa9e175a8e121565c0b73c3093752b68d8dL205-R214) [[8]](diffhunk://#diff-7411b14496e21b7be58c0af61f1cffa9e175a8e121565c0b73c3093752b68d8dL221-R233) [[9]](diffhunk://#diff-d0a1c399460884aaa53581719d5212d423bfd3ee52cd67eab89792d99d0cf245L9-R16) [[10]](diffhunk://#diff-d0a1c399460884aaa53581719d5212d423bfd3ee52cd67eab89792d99d0cf245L30-R46) [[11]](diffhunk://#diff-d0a1c399460884aaa53581719d5212d423bfd3ee52cd67eab89792d99d0cf245L65-R70) [[12]](diffhunk://#diff-3e621218ff3ca3d14827b391df02e75728473321eb905bfb346729a95a562436L11-R11) [[13]](diffhunk://#diff-3e621218ff3ca3d14827b391df02e75728473321eb905bfb346729a95a562436L28-R28)

* The new `Spin` enum is included via `#include "helpers/spin.h"` in `ci_sigma_builder.h`, and all relevant function calls and logic checks now use `is_alpha(spin)` and `is_beta(spin)` helpers. [[1]](diffhunk://#diff-1d0dbdacd169c2090d16a89e8555a772d9cb06b87c74a510868495650169e27fR9) [[2]](diffhunk://#diff-7411b14496e21b7be58c0af61f1cffa9e175a8e121565c0b73c3093752b68d8dL188-R199) [[3]](diffhunk://#diff-7411b14496e21b7be58c0af61f1cffa9e175a8e121565c0b73c3093752b68d8dL205-R214) [[4]](diffhunk://#diff-7411b14496e21b7be58c0af61f1cffa9e175a8e121565c0b73c3093752b68d8dL221-R233) [[5]](diffhunk://#diff-d0a1c399460884aaa53581719d5212d423bfd3ee52cd67eab89792d99d0cf245L9-R16) [[6]](diffhunk://#diff-d0a1c399460884aaa53581719d5212d423bfd3ee52cd67eab89792d99d0cf245L30-R46) [[7]](diffhunk://#diff-3e621218ff3ca3d14827b391df02e75728473321eb905bfb346729a95a562436L11-R11) [[8]](diffhunk://#diff-3e621218ff3ca3d14827b391df02e75728473321eb905bfb346729a95a562436L28-R28)

**CI algorithm query and Python API improvements:**

* Added a `get_algorithm()` method to `CISigmaBuilder` to return the current CI algorithm as a string, with Python bindings exposed in `ci_api.cc`. [[1]](diffhunk://#diff-7411b14496e21b7be58c0af61f1cffa9e175a8e121565c0b73c3093752b68d8dR55-R65) [[2]](diffhunk://#diff-1d0dbdacd169c2090d16a89e8555a772d9cb06b87c74a510868495650169e27fR39-R42) [[3]](diffhunk://#diff-532ee9bc533fa711a143fd1262c641dc4facfbc9733de7ce2e077225d65d6737R50-R51)

* The Python `CI` class now logs the selected CI algorithm using the new `get_algorithm()` method, improving transparency in the workflow.

**Hamiltonian and algorithm-specific refactoring:**

* Refactored the Hamiltonian application logic to use the `Spin` enum, renamed algorithm-specific methods for clarity (e.g., `H1_aa_gemm` → `H1_hz`, `H2_aaaa_gemm` → `H2_hz_same_spin`, `H2_aabb_gemm` → `H2_hz_opposite_spin`), and updated their usage throughout. [[1]](diffhunk://#diff-7411b14496e21b7be58c0af61f1cffa9e175a8e121565c0b73c3093752b68d8dL159-R181) [[2]](diffhunk://#diff-1d0dbdacd169c2090d16a89e8555a772d9cb06b87c74a510868495650169e27fL292-R326)

* Moved temporary block vectors (`Kblock1_`, `Kblock2_`) out of the Knowles-Handy section to general usage, reflecting their use in both algorithms. [[1]](diffhunk://#diff-1d0dbdacd169c2090d16a89e8555a772d9cb06b87c74a510868495650169e27fR281-R289) [[2]](diffhunk://#diff-1d0dbdacd169c2090d16a89e8555a772d9cb06b87c74a510868495650169e27fL292-R326)

**Code cleanup and documentation:**

* Removed the (empty) destructor from `CISigmaBuilder`, as it was unnecessary. [[1]](diffhunk://#diff-7411b14496e21b7be58c0af61f1cffa9e175a8e121565c0b73c3093752b68d8dL45-L51) [[2]](diffhunk://#diff-1d0dbdacd169c2090d16a89e8555a772d9cb06b87c74a510868495650169e27fL26)

* Updated docstrings and comments throughout the codebase to reflect the switch from `bool` to `Spin` and clarify parameter meanings. [[1]](diffhunk://#diff-1d0dbdacd169c2090d16a89e8555a772d9cb06b87c74a510868495650169e27fL80-R88) [[2]](diffhunk://#diff-1d0dbdacd169c2090d16a89e8555a772d9cb06b87c74a510868495650169e27fL112-R120) [[3]](diffhunk://#diff-1d0dbdacd169c2090d16a89e8555a772d9cb06b87c74a510868495650169e27fL163-R171) [[4]](diffhunk://#diff-1d0dbdacd169c2090d16a89e8555a772d9cb06b87c74a510868495650169e27fL292-R326)

**Miscellaneous:**

* Minor logging improvement: added a newline to the total timing log message for better readability.

* Removed commented-out code in the sigma builder function for clarity.