### PR TITLE
Relativistic CCSD

### DIFF
--- a/forte2/__init__.py
+++ b/forte2/__init__.py
@@ -4,6 +4,7 @@ from ._forte2.ints import Basis, Shell
 from .system import System, ModelSystem, HubbardModel
 from .state import State, MOSpace
 from .scf import RHF, ROHF, UHF, CUHF, GHF
+from .cc import CCSD
 from .ci import CI
 from .x2c import x2c
 from .orbitals import AVAS, Cube, ASET

--- a/forte2/cc/__init__.py
+++ b/forte2/cc/__init__.py
@@ -1,0 +1,1 @@
+from .ccsd import CCSD

--- a/forte2/cc/cc.py
+++ b/forte2/cc/cc.py
@@ -51,7 +51,7 @@ class _SRCCBase(ABC):
     ### Jacobi parameters
     maxiter: int = 100
     econv: float = 1e-10
-    rconv: float = 1e-5
+    rconv: float = 1e-8
     energy_shift: float = 0.
 
     ### DIIS parameters
@@ -135,6 +135,10 @@ class _SRCCBase(ABC):
         )
         if self.converged:
             logger.log("\nCoupled-cluster calculation converged.\n", self.log_level)
+
+            logger.log(f"Reference Energy: {self.ints.E} hartree", self.log_level)
+            logger.log(f"Correlation Energy: {self.E} hartree", self.log_level)
+            logger.log(f"Total Coupled-Cluster Energy: {self.ints.E + self.E} hartree\n", self.log_level)
 
             logger.log_debug("Overwriting DF B tensors with their T1-transformed counterparts")
             self.ints.B = self.BT1

--- a/forte2/cc/cc.py
+++ b/forte2/cc/cc.py
@@ -185,6 +185,15 @@ class _SRCCBase(ABC):
                 + np.einsum("xme,ei,am->xai", self.BT1['ov'], t1, t1, optimize=True)
         )
 
+    def _build_energy(self):
+        t1 = self.T[0]
+        t2 = self.T[1]
+        self.E = (
+            np.einsum("me,em->", self.ints['ov'], t1, optimize=True)
+            + 0.5 * np.einsum("mnef,em,fn->", self.ints['oovv'], t1, t1, optimize=True)
+            + 0.25 * np.einsum("mnef,efmn->", self.ints['oovv'], t2, optimize=True)
+        )
+
     @abstractmethod
     def _build_energy_denominators(self): ...
     
@@ -193,9 +202,6 @@ class _SRCCBase(ABC):
 
     @abstractmethod
     def _build_update(self): ...  
-
-    @abstractmethod
-    def _build_energy(self): ... 
 
     @abstractmethod
     def _build_initial_guess(self): ...

--- a/forte2/cc/cc.py
+++ b/forte2/cc/cc.py
@@ -88,14 +88,14 @@ class _SRCCBase(ABC):
         )
 
         if self.first_run:
+            self._build_energy_denominators()
             self._build_initial_guess()
-            self._build_energy()
             self.first_run = False
 
+        # Compute initial guess energy
+        self._build_energy()
         logger.log(f"Initial CC Correlation Energy: {self.E} hartree", self.log_level)
 
-        # 5. Run Jacobi
-        # T, E = self.solver.solve(T, self.ints)
         self.converged = False
         E_old = 0.
 
@@ -135,6 +135,10 @@ class _SRCCBase(ABC):
         )
         if self.converged:
             logger.log("\nCoupled-cluster calculation converged.\n", self.log_level)
+
+            logger.log_debug("Overwriting DF B tensors with their T1-transformed counterparts")
+            self.ints.B = self.BT1
+
         else:
             logger.log("\nCoupled-cluster calculation did not converge.\n", self.log_level)
 
@@ -143,22 +147,25 @@ class _SRCCBase(ABC):
         return self
     
     def _cc_print_banner(self):
-        logger.log(("=" * 64), self.log_level)
-        logger.log(f"Coupled-Cluster Calculation: {self.method}", self.log_level)
+        logger.log(("-" * 64), self.log_level)
+        logger.log(f"Coupled-cluster calculation: {self.method}", self.log_level)
         logger.log(f"Number of occupied spinorbitals: {self.no}", self.log_level)
         logger.log(f"Number of unoccupied spinorbitals: {self.nu}", self.log_level)
         logger.log(f"Number of frozen core spinorbitals: {self.frozen}", self.log_level)
         logger.log(f"Number of frozen virtual spinorbitals: {self.virtual}", self.log_level)
-        logger.log(f"Energy Convergence: {self.econv}", self.log_level)
-        logger.log(f"Amplitude Convergence: {self.rconv}", self.log_level)
+        logger.log(f"Energy convergence: {self.econv}", self.log_level)
+        logger.log(f"Amplitude convergence: {self.rconv}", self.log_level)
         if self.do_diis:
-            logger.log(f"DIIS Subspace Size: {self.diis_nvec}", self.log_level)
-            logger.log(f"DIIS Start: {self.diis_start}", self.log_level)
-            logger.log(f"DIIS Min: {self.diis_min}", self.log_level)
-        logger.log(("=" * 64), self.log_level)
+            logger.log(f"DIIS subspace size: {self.diis_nvec}", self.log_level)
+            logger.log(f"DIIS start: {self.diis_start}", self.log_level)
+            logger.log(f"DIIS min: {self.diis_min}", self.log_level)
+        logger.log(("-" * 64), self.log_level)
 
     def _cc_type(self):
         return type(self).__name__.upper()
+    
+    @abstractmethod
+    def _build_energy_denominators(self): ...
     
     @abstractmethod
     def _build_residual(self): ...   

--- a/forte2/cc/cc.py
+++ b/forte2/cc/cc.py
@@ -69,12 +69,8 @@ class _SRCCBase(ABC):
     def __post_init__(self):
         self.method = self._cc_type().upper()
 
-    def __call__(self, scf):
-        self.ints = SONormalOrderedIntegrals(scf, 
-                                             frozen=self.frozen, 
-                                             virtual=self.virtual,
-                                             build_nvirt=self.build_nvirt) 
-        self.no, self.nu = self.ints['ov'].shape
+    def __call__(self, parent_method):
+        self.parent_method = parent_method
         return self
 
     def run(self):

--- a/forte2/cc/cc.py
+++ b/forte2/cc/cc.py
@@ -1,0 +1,159 @@
+from dataclasses import dataclass, field
+from collections import OrderedDict
+from abc import ABC, abstractmethod
+
+import numpy as np
+
+from forte2.helpers.diis import DIIS
+from forte2.helpers import logger
+# from forte2.helpers.jacobi import JacobiSolver
+from forte2.jkbuilder import SRRestrictedMOIntegrals
+
+
+@dataclass
+class _SRCCBase(ABC):
+    """
+    A general single-reference coupled-cluster (CC) solver class to compute the ground
+    state (or lowest state of a particular symmetry). 
+    Although possible, is not recommended to instantiate this class directly.
+    Consider using the `SRCC` class instead.
+
+    Parameters
+    ----------
+    log_level : int, optional
+        The logging level for the CC solver. Defaults to the global logger's verbosity level.
+    maxiter : int, optional, default=100
+        The maximum number of iterations for the Davidson-Liu solver.
+    econv : float, optional, default=1e-10
+        The energy convergence threshold for the solver.
+    rconv : float, optional, default=1e-5
+        The residual convergence threshold for the solver.
+    energy_shift : float, optional, default=None
+        An energy shift to find roots around. If None, no shift is applied.
+
+    Attributes
+    ----------
+    E : float
+        The CC correlation energy.
+    T : NDArray
+        The flattened array of cluster amplitudes
+
+    """
+
+    scf: object | None = None
+    frozen: int = 0
+    virtual: int = 0
+    spinorbital: bool = True
+    log_level: int = field(default=logger.get_verbosity_level())
+
+    ### CC intermediates
+    intermediates: dict = field(default_factory=dict)
+
+    ### Jacobi parameters
+    maxiter: int = 100
+    econv: float = 1e-10
+    rconv: float = 1e-5
+    energy_shift: float = 0.
+
+    ### DIIS parameters
+    diis_start: int = 4
+    diis_nvec: int = 6
+    diis_min: int = 3
+    do_diis: bool = True
+
+    ### Non-init attributes
+    first_run: bool = field(default=True, init=False)
+    executed: bool = field(default=False, init=False)
+
+    def __post_init__(self):
+        if self.scf is not None:
+            self(scf=self.scf)
+
+    def __call__(self, scf):
+        self.ints = SRRestrictedMOIntegrals(scf, 
+                                            frozen=self.frozen, 
+                                            virtual=self.virtual, 
+                                            spinorbital=self.spinorbital)
+        self.no, self.nu = self.ints['ov'].shape
+        return self
+
+    def run(self):
+        # if not self.executed:
+        #     self._cc_solver_startup()
+
+        diis = DIIS(
+            diis_start=self.diis_start,
+            diis_nvec=self.diis_nvec,
+            diis_min=self.diis_min,
+            do_diis=self.do_diis,
+        )
+
+        if self.first_run:
+            self._build_initial_guess()
+            self._build_energy()
+            self.first_run = False
+
+        logger.log(f"Initial CC Correlation Energy: {self.E} hartree", self.log_level)
+
+        # 5. Run Jacobi
+        # T, E = self.solver.solve(T, self.ints)
+        self.converged = False
+        E_old = 0.
+
+        logger.log(
+            ("=" * 64)
+            + f"\nIter                 E             ΔE        |r|\n"
+            + ("-" * 64),
+            self.log_level,
+        )
+
+        for iter in range(self.maxiter):
+
+            # 1. Compute R_K = < K | (H e^T)_C | 0 >
+            self._build_residual()
+            # 2. Update T <- T + R_K / D_K
+            self._build_update()
+            # 3. Compute correlation energy E = < 0 | (H e^T)_C | 0 >
+            self._build_energy()
+            # 4. Compute convergence parameters
+            delta_e = self.E - E_old
+            # print the iteration
+            logger.log(
+                f"{iter:4d}  {self.E:18.12f}  {delta_e:18.12f}  {self.resnorm:12.9f}",
+                self.log_level,
+            )
+            # check exit conditions
+            if abs(delta_e) < self.econv and self.resnorm < self.rconv:
+                self.converged = True
+                break
+            E_old = self.E
+            # 5. DIIS update
+            self._diis_update(diis)
+
+        logger.log(
+            ("=" * 64),
+            self.log_level,
+        )
+        if self.converged:
+            logger.log("\nCoupled-cluster calculation converged.\n", self.log_level)
+        else:
+            logger.log("\nCoupled-cluster calculation did not converge.\n", self.log_level)
+
+        self.executed = True
+
+        return self
+    
+    @abstractmethod
+    def _build_residual(self): ...   
+
+    @abstractmethod
+    def _build_update(self): ...  
+
+    @abstractmethod
+    def _build_energy(self): ... 
+
+    @abstractmethod
+    def _build_initial_guess(self): ...
+
+    @abstractmethod
+    def _diis_update(self, diis): ... 

--- a/forte2/cc/cc.py
+++ b/forte2/cc/cc.py
@@ -64,6 +64,7 @@ class _SRCCBase(ABC):
     first_run: bool = field(default=True, init=False)
     executed: bool = field(default=False, init=False)
 
+    # Move RHF to call and params to init
     def __post_init__(self):
         self.method = self._cc_type().upper()
         if self.scf is not None:
@@ -106,7 +107,7 @@ class _SRCCBase(ABC):
             self.log_level,
         )
 
-        for iter in range(self.maxiter):
+        for it in range(self.maxiter):
 
             # 1. Compute R_K = < K | (H e^T)_C | 0 >
             self._build_residual()
@@ -118,7 +119,7 @@ class _SRCCBase(ABC):
             delta_e = self.E - E_old
             # print the iteration
             logger.log(
-                f"{iter:4d}  {self.E:18.12f}  {delta_e:18.12f}  {self.resnorm:12.9f}",
+                f"{it:4d}  {self.E:18.12f}  {delta_e:18.12f}  {self.resnorm:12.9f}",
                 self.log_level,
             )
             # check exit conditions

--- a/forte2/cc/cc.py
+++ b/forte2/cc/cc.py
@@ -7,7 +7,7 @@ import numpy as np
 from forte2.helpers.diis import DIIS
 from forte2.helpers import logger
 # from forte2.helpers.jacobi import JacobiSolver
-from forte2.jkbuilder import SRRestrictedMOIntegrals
+from forte2.jkbuilder import SONormalOrderedIntegrals
 
 
 @dataclass
@@ -43,11 +43,11 @@ class _SRCCBase(ABC):
     scf: object | None = None
     frozen: int = 0
     virtual: int = 0
-    spinorbital: bool = True
     log_level: int = field(default=logger.get_verbosity_level())
 
     ### CC intermediates
     intermediates: dict = field(default_factory=dict)
+    BT1: dict = field(default_factory=dict)
 
     ### Jacobi parameters
     maxiter: int = 100
@@ -70,10 +70,10 @@ class _SRCCBase(ABC):
             self(scf=self.scf)
 
     def __call__(self, scf):
-        self.ints = SRRestrictedMOIntegrals(scf, 
-                                            frozen=self.frozen, 
-                                            virtual=self.virtual, 
-                                            spinorbital=self.spinorbital)
+        self.ints = SONormalOrderedIntegrals(scf, 
+                                             frozen=self.frozen, 
+                                             virtual=self.virtual,
+                                             build_nvirt=2) 
         self.no, self.nu = self.ints['ov'].shape
         return self
 

--- a/forte2/cc/cc.py
+++ b/forte2/cc/cc.py
@@ -6,7 +6,6 @@ import numpy as np
 
 from forte2.helpers.diis import DIIS
 from forte2.helpers import logger
-# from forte2.helpers.jacobi import JacobiSolver
 from forte2.jkbuilder import SONormalOrderedIntegrals
 
 
@@ -66,6 +65,7 @@ class _SRCCBase(ABC):
     executed: bool = field(default=False, init=False)
 
     def __post_init__(self):
+        self.method = self._cc_type().upper()
         if self.scf is not None:
             self(scf=self.scf)
 
@@ -78,8 +78,7 @@ class _SRCCBase(ABC):
         return self
 
     def run(self):
-        # if not self.executed:
-        #     self._cc_solver_startup()
+        self._cc_print_banner()
 
         diis = DIIS(
             diis_start=self.diis_start,
@@ -142,6 +141,24 @@ class _SRCCBase(ABC):
         self.executed = True
 
         return self
+    
+    def _cc_print_banner(self):
+        logger.log(("=" * 64), self.log_level)
+        logger.log(f"Coupled-Cluster Calculation: {self.method}", self.log_level)
+        logger.log(f"Number of occupied spinorbitals: {self.no}", self.log_level)
+        logger.log(f"Number of unoccupied spinorbitals: {self.nu}", self.log_level)
+        logger.log(f"Number of frozen core spinorbitals: {self.frozen}", self.log_level)
+        logger.log(f"Number of frozen virtual spinorbitals: {self.virtual}", self.log_level)
+        logger.log(f"Energy Convergence: {self.econv}", self.log_level)
+        logger.log(f"Amplitude Convergence: {self.rconv}", self.log_level)
+        if self.do_diis:
+            logger.log(f"DIIS Subspace Size: {self.diis_nvec}", self.log_level)
+            logger.log(f"DIIS Start: {self.diis_start}", self.log_level)
+            logger.log(f"DIIS Min: {self.diis_min}", self.log_level)
+        logger.log(("=" * 64), self.log_level)
+
+    def _cc_type(self):
+        return type(self).__name__.upper()
     
     @abstractmethod
     def _build_residual(self): ...   

--- a/forte2/cc/ccsd.py
+++ b/forte2/cc/ccsd.py
@@ -62,14 +62,6 @@ class CCSD(_SRCCBase):
         self.T = (t1, t2)
         self.resnorm = resnorm
 
-    def _build_energy(self):
-        t1, t2 = self.T
-        self.E = (
-            np.einsum("me,em->", self.ints['ov'], t1, optimize=True)
-            + 0.5 * np.einsum("mnef,em,fn->", self.ints['oovv'], t1, t1, optimize=True)
-            + 0.25 * np.einsum("mnef,efmn->", self.ints['oovv'], t2, optimize=True)
-        )
-
     def _build_initial_guess(self):
         _, d2 = self.denom
         t1 = np.zeros((self.nu, self.no))

--- a/forte2/cc/ccsd.py
+++ b/forte2/cc/ccsd.py
@@ -152,9 +152,11 @@ class CCSD(_SRCCBase):
         doubles_residual += 0.125 * np.einsum("mnij,abmn->abij", h_oooo, t2, optimize=True)
 
         # [TODO]: It would be nice to perform this computation in C++
+        # Loop over slices of unoccupied orbitals
         # vvvv term
         tic = time.time()
         self.BT1['vv'] = self.BT1['vv'].swapaxes(0, 1)
+        # v(abef) t(efij) = [B(ae)B(bf) - B(af)B(be)] t(efij)
         for a in range(t1.shape[0]):
            for b in range(a + 1, t1.shape[0]):
                # <ab||ef> = <x|ae><x|bf> - <x|af><x|be>

--- a/forte2/cc/ccsd.py
+++ b/forte2/cc/ccsd.py
@@ -1,0 +1,190 @@
+import numpy as np
+from forte2.cc.cc import _SRCCBase
+
+class CCSD(_SRCCBase):
+
+    def _diis_update(self, diis):
+        t1, t2 = self.T
+        r1, r2 = self.r
+
+        n1, n2 = np.prod(t1.shape), np.prod(t2.shape)
+
+        T_flatten = np.hstack((t1.flatten(), t2.flatten()))
+        R_flatten = np.hstack((r1.flatten(), r2.flatten()))
+        T_extrap = diis.update(T_flatten, R_flatten)
+        t1 = np.reshape(T_extrap[:n1], t1.shape)
+        t2 = np.reshape(T_extrap[n1:], t2.shape)
+        self.T = (t1, t2)
+
+    def _build_residual(self):
+        # CCS transformation
+        self._ccs_transformation()
+        # T1 residual
+        r1 = self._t1_residual()
+        # T2 residual
+        r2 = self._t2_residual()
+        self.r = (r1, r2)
+
+    def _build_update(self):
+        t1, t2 = self.T
+        r1, r2 = self.r
+        resnorm = 0.
+        for a in range(self.nu):
+            for i in range(self.no):
+                denom = self.ints['oo'][i, i] - self.ints['vv'][a, a]
+                dt = r1[a, i] / (denom - self.energy_shift)
+                t1[a, i] += dt
+                resnorm += np.abs(dt)
+        for a in range(self.nu):
+            for b in range(a + 1, self.nu):
+                for i in range(self.no):
+                    for j in range(i + 1, self.no):
+                        denom = self.ints['oo'][i, i] + self.ints['oo'][j, j] - self.ints['vv'][a, a] - self.ints['vv'][b, b]
+                        dt = r2[a, b, i, j] / (denom - self.energy_shift)
+                        t2[a, b, i, j] +=  dt
+                        t2[b, a, i, j] = -t2[a, b, i, j]
+                        t2[a, b, j, i] = -t2[a, b, i, j]
+                        t2[b, a, j, i] = t2[a, b, i, j]
+                        resnorm += np.abs(dt)
+        self.T = (t1, t2)
+        self.resnorm = resnorm
+
+    def _build_energy(self):
+        t1, t2 = self.T
+        self.E = (
+            np.einsum("me,em->", self.ints['ov'], t1, optimize=True)
+            + 0.5 * np.einsum("mnef,em,fn->", self.ints['oovv'], t1, t1, optimize=True)
+            + 0.25 * np.einsum("mnef,efmn->", self.ints['oovv'], t2, optimize=True)
+        )
+
+    def _build_initial_guess(self):
+        t1 = np.zeros((self.nu, self.no))
+        t2 = np.zeros((self.nu, self.nu, self.no, self.no))
+        for a in range(self.nu):
+            for b in range(a + 1, self.nu):
+                for i in range(self.no):
+                    for j in range(i + 1, self.no):
+                        denom = self.ints['oo'][i, i] + self.ints['oo'][j, j] - self.ints['vv'][a, a] - self.ints['vv'][b, b]
+                        t2[a, b, i, j] = self.ints['vvoo'][a, b, i, j] / (denom)
+
+                        t2[b, a, i, j] = -t2[a, b, i, j]
+                        t2[a, b, j, i] = -t2[a, b, i, j]
+                        t2[b, a, j, i] = t2[a, b, i, j]
+        self.T = (t1, t2)
+
+    def _t1_residual(self):
+        """
+        Compute the projection of the CCSD Hamiltonian on singles
+        X[a, i] = < ia | (H_N exp(T1+T2))_C | 0 >
+        """
+        t1, t2 = self.T
+
+        chi_vv = self.ints['vv'] + np.einsum("anef,fn->ae", self.ints['vovv'], t1, optimize=True)
+        chi_oo = self.ints['oo'] + np.einsum("mnif,fn->mi", self.ints['ooov'], t1, optimize=True)
+        h_ov = self.ints['ov'] + np.einsum("mnef,fn->me", self.ints['oovv'], t1, optimize=True)
+        h_oo = chi_oo + np.einsum("me,ei->mi", h_ov, t1, optimize=True)
+        h_ooov = self.ints['ooov'] + np.einsum("mnfe,fi->mnie", self.ints['oovv'], t1, optimize=True)
+        h_vovv = self.ints['vovv'] - np.einsum("mnfe,an->amef", self.ints['oovv'], t1, optimize=True)
+
+        singles_res = -np.einsum("mi,am->ai", h_oo, t1, optimize=True)
+        singles_res += np.einsum("ae,ei->ai", chi_vv, t1, optimize=True)
+        singles_res += np.einsum("anif,fn->ai", self.ints['voov'], t1, optimize=True)
+        singles_res += np.einsum("me,aeim->ai", h_ov, t2, optimize=True)
+        singles_res -= 0.5 * np.einsum("mnif,afmn->ai", h_ooov, t2, optimize=True)
+        singles_res += 0.5 * np.einsum("anef,efin->ai", h_vovv, t2, optimize=True)
+
+        singles_res += self.ints['vo']
+
+        return singles_res
+
+    def _t2_residual(self):
+        """Compute the projection of the CCSD Hamiltonian on doubles
+            X[a, b, i, j] = < ijab | (H_N exp(T1+T2))_C | 0 >
+        """
+        X = self.intermediates
+        t1, t2 = self.T
+        # intermediates
+        I_oo = X['oo'] + 0.5 * np.einsum("mnef,efin->mi", self.ints['oovv'], t2, optimize=True)
+        I_vv = X['vv'] - 0.5 * np.einsum("mnef,afmn->ae", self.ints['oovv'], t2, optimize=True)
+        I_voov = X['voov'] + 0.5 * np.einsum("mnef,afin->amie", self.ints['oovv'], t2, optimize=True)
+        I_oooo = X['oooo'] + 0.5 * np.einsum("mnef,efij->mnij", self.ints['oovv'], t2, optimize=True)
+        I_vooo = X['vooo'] + 0.5 * np.einsum('anef,efij->anij', self.ints['vovv'] + 0.5 * X['vovv'], t2, optimize=True)
+        tau = 0.5 * t2 + np.einsum('ai,bj->abij', t1, t1, optimize=True)
+
+        doubles_res = -0.5 * np.einsum("amij,bm->abij", I_vooo, t1, optimize=True)
+        doubles_res += 0.5 * np.einsum("abie,ej->abij", X['vvov'], t1, optimize=True)
+        doubles_res += 0.5 * np.einsum("ae,ebij->abij", I_vv, t2, optimize=True)
+        doubles_res -= 0.5 * np.einsum("mi,abmj->abij", I_oo, t2, optimize=True)
+        doubles_res += np.einsum("amie,ebmj->abij", I_voov, t2, optimize=True)
+        doubles_res += 0.25 * np.einsum("abef,efij->abij", self.ints['vvvv'], tau, optimize=True)
+        doubles_res += 0.125 * np.einsum("mnij,abmn->abij", I_oooo, t2, optimize=True)
+
+        doubles_res -= np.transpose(doubles_res, (1, 0, 2, 3)).conj()
+        doubles_res -= np.transpose(doubles_res, (0, 1, 3, 2)).conj()
+
+        doubles_res += self.ints['vvoo']
+
+        return doubles_res
+    
+    def _ccs_transformation(self):
+        """
+        Calculate the quantities related to the one-
+        and two-body components of the CCS similarity-transformed 
+        Hamiltonian, [H_N exp(T1)]_C, which serve as suitable 
+        intermediates for constructing the CCSD amplitude equations.
+            H1[:, :] ~ < p | [H_N exp(T1)]_C | q > (related to, not equal!)
+            H2[:, :, :, :] ~ < pq | [H_N exp(T1)]_C | rs > (related to, not equal!)
+        """
+        X = self.intermediates
+        t1, t2 = self.T
+
+        # 1-body components
+        temp = self.ints['ov'] + np.einsum("mnef,fn->me", self.ints['oovv'], t1, optimize=True)
+        X['ov'] = temp
+
+        temp = self.ints['vv'] + (
+            np.einsum("anef,fn->ae", self.ints['vovv'], t1, optimize=True)
+            - np.einsum("me,am->ae", X['ov'], t1, optimize=True)
+        ) 
+        X['vv'] = temp
+
+        temp = self.ints['oo'] + (
+            np.einsum("mnif,fn->mi", self.ints['ooov'], t1, optimize=True)
+            + np.einsum("me,ei->mi", X['ov'], t1, optimize=True)
+        ) 
+        X['oo'] = temp
+
+        # 2-body components
+        temp = np.einsum("mnfe,fi->mnie", self.ints['oovv'], t1, optimize=True) 
+        X['ooov'] = temp
+
+        temp = (
+                0.5 * self.ints['oooo'] 
+                + np.einsum("nmje,ei->mnij", self.ints['ooov'] + 0.5 * X['ooov'], t1, optimize=True) # no(4)nu(1)
+        )
+        temp -= np.transpose(temp, (0, 1, 3, 2)).conj()
+        X['oooo'] = temp
+
+        temp = -np.einsum("mnfe,an->amef", self.ints['oovv'], t1, optimize=True) # no(2)nu(3)
+        X['vovv'] = temp
+
+        temp = self.ints['voov'] + (
+                np.einsum("amfe,fi->amie", self.ints['vovv'] + 0.5 * X['vovv'], t1, optimize=True)
+                - np.einsum("nmie,an->amie", self.ints['ooov'] + 0.5 * X['ooov'], t1, optimize=True)
+        )
+        X['voov'] = temp
+
+        temp2 = self.ints['voov'] + 0.5 * np.einsum('amef,ei->amif', self.ints['vovv'], t1, optimize=True) # no(2)nu(3)
+        temp3 = self.ints['oooo'] + np.einsum('mnie,ej->mnij', X['ooov'], t1, optimize=True) # no(4)nu(1)
+        temp = 0.5 * self.ints['vooo'] + (
+            np.einsum('amie,ej->amij', temp2, t1, optimize=True)
+            -0.25 * np.einsum('mnij,am->anij', temp3, t1, optimize=True)
+        ) 
+        temp -= np.transpose(temp, (0, 1, 3, 2)).conj()
+        X['vooo'] = temp
+
+        temp2 = np.einsum('mnie,am->anie', self.ints['ooov'], t1, optimize=True)
+        temp = self.ints['vvov'] + np.einsum("anie,bn->abie", temp2, t1, optimize=True) # no(1)nu(4)
+        X['vvov'] = temp
+
+        self.intermediates = X

--- a/forte2/jkbuilder/__init__.py
+++ b/forte2/jkbuilder/__init__.py
@@ -1,2 +1,2 @@
 from .jkbuilder import FockBuilder
-from .mointegrals import RestrictedMOIntegrals
+from .mointegrals import RestrictedMOIntegrals, SRRestrictedMOIntegrals

--- a/forte2/jkbuilder/__init__.py
+++ b/forte2/jkbuilder/__init__.py
@@ -1,2 +1,2 @@
 from .jkbuilder import FockBuilder
-from .mointegrals import RestrictedMOIntegrals, SRRestrictedMOIntegrals
+from .mointegrals import RestrictedMOIntegrals, SONormalOrderedIntegrals 

--- a/forte2/jkbuilder/jkbuilder.py
+++ b/forte2/jkbuilder/jkbuilder.py
@@ -223,7 +223,7 @@ class FockBuilder:
             C3,
             C4,
             optimize=True,
-        )        
+        )
         if antisymmetrize:
             V -= np.einsum("ijkl->ijlk", V)
         return V

--- a/forte2/jkbuilder/jkbuilder.py
+++ b/forte2/jkbuilder/jkbuilder.py
@@ -205,6 +205,9 @@ class FockBuilder:
             Coefficient matrix for the third set of orbitals (index r).
         C4 : NDArray
             Coefficient matrix for the fourth set of orbitals (index s).
+        antisymmetrize : bool, optional, default=False
+            Whether to antisymmetrize the integrals. If True, the integrals are antisymmetrized as:
+            V[p,q,r,s] = :math:`\langle pq || rs \rangle = \langle pq | rs \rangle - \langle pq | sr \rangle`
 
         Returns
         -------

--- a/forte2/jkbuilder/jkbuilder.py
+++ b/forte2/jkbuilder/jkbuilder.py
@@ -182,7 +182,7 @@ class FockBuilder:
         J, K = self.build_JK([Cp])
         return J[0], K[0]
 
-    def two_electron_integrals_gen_block(self, C1, C2, C3, C4):
+    def two_electron_integrals_gen_block(self, C1, C2, C3, C4, antisymmetrize=False):
         r"""
         Compute the two-electron integrals for a given set of orbitals. This method is
         general and can handle different sets of orbitals for each index (p, q, r, s).
@@ -223,10 +223,12 @@ class FockBuilder:
             C3,
             C4,
             optimize=True,
-        )
+        )        
+        if antisymmetrize:
+            V -= np.einsum("ijkl->ijlk", V)
         return V
 
-    def two_electron_integrals_block(self, C):
+    def two_electron_integrals_block(self, C, antisymmetrize=False):
         r"""
         Compute the two-electron integrals for a given set of orbitals.
 
@@ -241,10 +243,13 @@ class FockBuilder:
         ----------
         C : NDArray
             Coefficient matrix for the set of orbitals.
+        antisymmetrize : bool, optional, default=False
+            Whether to antisymmetrize the integrals. If True, the integrals are antisymmetrized as:
+            V[p,q,r,s] = :math:`\langle pq || rs \rangle = \langle pq | rs \rangle - \langle pq | sr \rangle`
 
         Returns
         -------
         V : NDArray
             The two-electron integrals in the form of a 4D array.
         """
-        return self.two_electron_integrals_gen_block(C, C, C, C)
+        return self.two_electron_integrals_gen_block(C, C, C, C, antisymmetrize)

--- a/forte2/jkbuilder/jkbuilder.py
+++ b/forte2/jkbuilder/jkbuilder.py
@@ -20,8 +20,6 @@ class FockBuilder:
         If a ModelSystem is provided, it will decompose the 4D ERI tensor using Cholesky decomposition with complete pivoting.
     use_aux_corr : bool, optional, default=False
         If True, uses ``system.auxiliary_basis_set_corr`` instead of ``system.auxiliary_basis``.
-    spinorbital : bool, optional, default=False
-        If True, converts DF tensors to spinorbital basis prior to constructing integrals.
     """
 
     def __init__(self, system: System, use_aux_corr=False):
@@ -51,11 +49,6 @@ class FockBuilder:
             self.B, system.naux = self._build_B_cholesky(
                 system.basis, system.cholesky_tol
             )
-
-        # if spinorbital:
-        #     B_spinorb = np.zeros((self.B.shape[0], 2*nbf, 2*nbf))
-        #     B_spinorb[:, ::2, ::2] = B[:, 1::2, 1::2] = self.B
-        #     self.B = B_spinorb
 
     @staticmethod
     def _build_B_cholesky(basis, cholesky_tol):

--- a/forte2/jkbuilder/jkbuilder.py
+++ b/forte2/jkbuilder/jkbuilder.py
@@ -224,8 +224,8 @@ class FockBuilder:
             C4,
             optimize=True,
         )
-        if antisymmetrize:
-            V -= np.einsum("ijkl->ijlk", V)
+        # if antisymmetrize:
+        #     V -= np.einsum("ijkl->ijlk", V)
         return V
 
     def two_electron_integrals_block(self, C, antisymmetrize=False):

--- a/forte2/jkbuilder/mointegrals.py
+++ b/forte2/jkbuilder/mointegrals.py
@@ -8,6 +8,7 @@ from numpy.typing import NDArray
 from forte2.jkbuilder.jkbuilder import FockBuilder
 from forte2.system.system import System
 from forte2.helpers import logger
+from forte2.helpers.comparisons import approx_vtight
 
 
 @dataclass
@@ -185,7 +186,7 @@ class SONormalOrderedIntegrals:
         tic = time.time()
         self.get_twobody_ints(build_nvirt)
         logger.log_debug(f"[SOIntegrals] Building blocks (up to nvirt = {build_nvirt}) of two-electron spinorbital integrals: {time.time() - tic} seconds")
-        assert np.allclose(self.E, self.scf_energy_fock(F, B))
+        assert self.E == approx_vtight(self.scf_energy_fock(F, B))
         del B
 
     def __getitem__(self, key):

--- a/tests/cc/test_ccsd_rhf.py
+++ b/tests/cc/test_ccsd_rhf.py
@@ -1,6 +1,8 @@
+import pytest
 from forte2 import System, RHF, CCSD, ROHF
 from forte2.helpers.comparisons import approx
-
+from forte2 import set_verbosity_level
+# set_verbosity_level(5)
 
 def test_ccsd_1():
     xyz = f"""
@@ -8,10 +10,46 @@ def test_ccsd_1():
     C 0.0 0.0 {0.529177210903 * 2}
     """
 
-    system = System(xyz=xyz, basis_set="sto-6g", cholesky_tei=True, cholesky_tol=1.0e-010)
+    system = System(xyz=xyz, basis_set="sto-6g", cholesky_tei=True, cholesky_tol=1.0e-010, point_group="D2H", reorient=True)
 
     rhf = RHF(charge=0, econv=1e-12)(system).run()
 
     cc = CCSD(rhf, frozen=4, econv=1e-12).run()
 
     assert cc.E == approx(-0.243926801139)
+
+def test_ccsd_2():
+    xyz = f"""
+    F 0.0 0.0 -2.66816
+    F 0.0 0.0 2.66816
+    """
+
+    system = System(xyz=xyz, basis_set="cc-pvdz", cholesky_tei=True, cholesky_tol=1.0e-010, point_group="D2H", reorient=True, unit="bohr")
+
+    rhf = ROHF(charge=0, econv=1e-12, ms=1)(system).run()
+
+    cc = CCSD(rhf, frozen=4, econv=1e-12).run()
+
+    assert cc.E == approx(-0.53380816)
+
+
+@pytest.mark.skip(reason="Test is too large to be run")
+def test_ccsd_3():
+    xyz = """
+        O -2.877091949897 -1.507375565672 -0.398996049903
+        C -0.999392972049 -0.222326510867 0.093940021615
+        C 1.633098051399 -1.126399113321 0.723677865007
+        O -1.316707936360 2.330484008081 0.195537896270
+        N 3.588772131647 0.190046035276 -0.635572324857
+        H 1.738434758147 -3.192291478262 0.201142047999
+        H 1.805107822402 -0.972547254301 2.850386782716
+        H 3.367427816470 2.065392438845 -0.521139962778
+        H 5.288732713155 -0.301105855518 0.028508872837
+        H -3.050135067115 2.755707159769 -0.234244183166
+    """
+
+    system = System(xyz=xyz, basis_set="cc-pvdz", unit="bohr", auxiliary_basis_set="cc-pvqz-jkfit")
+
+    rhf = RHF(charge=0, econv=1.0e-010)(system).run()
+
+    cc = CCSD(rhf, frozen=10, econv=1.0e-010).run()

--- a/tests/cc/test_ccsd_rhf.py
+++ b/tests/cc/test_ccsd_rhf.py
@@ -1,0 +1,17 @@
+from forte2 import System, RHF, CCSD, ROHF
+from forte2.helpers.comparisons import approx
+
+
+def test_ccsd_1():
+    xyz = f"""
+    C 0.0 0.0 0.0
+    C 0.0 0.0 {0.529177210903 * 2}
+    """
+
+    system = System(xyz=xyz, basis_set="sto-6g", cholesky_tei=True, cholesky_tol=1.0e-010)
+
+    rhf = RHF(charge=0, econv=1e-12)(system).run()
+
+    cc = CCSD(rhf, frozen=4, econv=1e-12).run()
+
+    assert cc.E == approx(-0.243926801139)

--- a/tests/cc/test_ccsd_rhf.py
+++ b/tests/cc/test_ccsd_rhf.py
@@ -14,9 +14,11 @@ def test_ccsd_1():
 
     rhf = RHF(charge=0, econv=1e-12)(system).run()
 
-    cc = CCSD(rhf, frozen=4, econv=1e-12).run()
+    cc = CCSD(frozen=4, econv=1e-12)(rhf).run()
+    cc._build_hbar()
 
     assert cc.E == approx(-0.243926801139)
+
 
 def test_ccsd_2():
     xyz = f"""
@@ -26,14 +28,15 @@ def test_ccsd_2():
 
     system = System(xyz=xyz, basis_set="cc-pvdz", cholesky_tei=True, cholesky_tol=1.0e-010, point_group="D2H", reorient=True, unit="bohr")
 
-    rhf = ROHF(charge=0, econv=1e-12, ms=1)(system).run()
+    rohf = ROHF(charge=0, econv=1e-12, ms=1)(system).run()
 
-    cc = CCSD(rhf, frozen=4, econv=1e-12).run()
+    cc = CCSD(frozen=4, econv=1e-12)(rohf).run()
+    cc._build_hbar()
 
     assert cc.E == approx(-0.53380816)
 
 
-@pytest.mark.skip(reason="Test is too large to be run")
+@pytest.mark.skip(reason="Test is too large to be run very often.")
 def test_ccsd_3():
     xyz = """
         O -2.877091949897 -1.507375565672 -0.398996049903


### PR DESCRIPTION
This PR aims to add spinorbital DF-CCSD, with the intention of extending this code to handle fully relativistic GHF-based DF-CCSD.

Changes
---------
* `forte2/jkbuilder/mointegrals.py`
Added new class `SONormalOrderedIntegrals` that handles construction of one- and two-electron spinorbital integrals of the Hamiltonian in the normal-ordered form relative to HF in a DF framework. The key here is that we have flexibility in building blocks of the two-electron tensor containing up to four virtual indices. In practice (as in CCSD), we will not build blocks containing more than 2 virtual indices.
* `forte2/cc/cc.py`
Implements an abstract base class for single-reference CC solvers. This structure is inspired by `hf.py`. 
* `forte2/cc/ccsd.py`
A DF implementation of CCSD. As expected, timing analysis shows that the double loop required to construct the particle-particle-ladder (PPL) diagram in CCSD is the most expensive term. It would be good to implement this PPL term using batched matrix multiplication.