### PR TITLE
Fix SNSO, add convenience class for relativistic states

### DIFF
--- a/forte2/__init__.py
+++ b/forte2/__init__.py
@@ -2,7 +2,7 @@ from ._forte2 import *
 from ._forte2 import ints
 from ._forte2.ints import Basis, Shell
 from .system import System, ModelSystem, HubbardModel
-from .state import State, MOSpace
+from .state import State, RelState, MOSpace
 from .scf import RHF, ROHF, UHF, CUHF, GHF
 from .ci import CI
 from .x2c import x2c

--- a/forte2/state/__init__.py
+++ b/forte2/state/__init__.py
@@ -1,2 +1,2 @@
-from .state import State, StateAverageInfo
+from .state import State, RelState, StateAverageInfo
 from .mo_space import MOSpace, EmbeddingMOSpace

--- a/forte2/state/state.py
+++ b/forte2/state/state.py
@@ -13,9 +13,9 @@ class State:
 
     Parameters
     ----------
-    multiplicity : int
+    multiplicity : int, required for non-relativisitic states.
         Multiplicity of the state (2S+1).
-    ms : float
+    ms : float, required for non-relativisitic states.
         Spin projection (Ms) of the state.
     nel : int, optional
         Total number of electrons in the state. If not provided, it is calculated from the system and charge.
@@ -155,6 +155,31 @@ class State:
     def get_ms_string(twice_ms: int) -> str:
         """Return a string representation of Ms based on its value."""
         return str(twice_ms // 2) if twice_ms % 2 == 0 else f"{twice_ms}/2"
+
+
+@dataclass
+class RelState(State):
+    """
+    A convenience class representing a relativistic electronic state.
+    Multiplicity and ms are no longer required, but will be used for initial guesses if provided.
+    """
+
+    multiplicity: int = None
+    ms: float = None
+
+    def __post_init__(self):
+        if self.nel is None:
+            assert self.system is not None, "Either nel or system must be provided."
+            self.nel = self.system.Zsum - self.charge
+        if self.system is None:
+            assert self.nel is not None, "Either nel or system must be provided."
+
+        if self.multiplicity is None or self.ms is None:
+            # adopt sensible defaults
+            self.ms = self.nel % 2 * 0.5
+            self.multiplicity = 1 if self.nel % 2 == 0 else 2
+
+        super().__post_init__()
 
 
 @dataclass

--- a/forte2/x2c/x2c.py
+++ b/forte2/x2c/x2c.py
@@ -84,6 +84,10 @@ def get_hcore_x2c(system, x2c_type="sf", snso_type=None):
         hab = h_fw[:nbf, nbf:]
         hba = h_fw[nbf:, :nbf]
         hbb = h_fw[nbf:, nbf:]
+        # the pauli representation of a spin-dependent operator. 
+        # h0 is spin-free, h1-3 are spin-dependent
+        # SNSO is applied to the spin-dependent parts only.
+        # see for example eq 4-6 of 10.1002/wcms.1436
         h0 = (haa + hbb) / 2
         h1 = (hab + hba) / 2
         h2 = (hab - hba) / (-2j)
@@ -223,6 +227,7 @@ def _apply_snso_scaling(ints, basis, atoms, snso_type):
         isize = basis[ishell].size
         li = int(basis[ishell].l)
         if li == 0:
+            iptr += isize
             continue
         Zi = atoms[center_given_shell(ishell)][0]
         if isinstance(Ql, dict):
@@ -233,6 +238,7 @@ def _apply_snso_scaling(ints, basis, atoms, snso_type):
             jsize = basis[jshell].size
             lj = int(basis[jshell].l)
             if lj == 0:
+                jptr += jsize
                 continue
             Zj = atoms[center_given_shell(jshell)][0]
             if isinstance(Ql, dict):

--- a/tests/ci/test_rel_ci.py
+++ b/tests/ci/test_rel_ci.py
@@ -1,6 +1,6 @@
 import numpy as np
 
-from forte2 import System, RHF, State, GHF
+from forte2 import System, RHF, RelState, GHF
 from forte2.scf.scf_utils import convert_coeff_spatial_to_spinor
 from forte2.helpers.comparisons import approx
 from forte2.ci import RelCI
@@ -25,7 +25,7 @@ def test_rel_ci_h2():
     scf.C[0] = C
     system.two_component = True
 
-    state = State(nel=2, multiplicity=1, ms=0.0)
+    state = RelState(nel=2)
     ci = RelCI(states=state, active_orbitals=4, do_test_rdms=True)(scf)
     ci.run()
     assert ci.E[0] == approx(-1.096071975854)
@@ -51,7 +51,7 @@ def test_rel_ci_hf():
     system.two_component = True
 
     ci = RelCI(
-        states=State(nel=10, multiplicity=1, ms=0.0),
+        states=RelState(nel=10),
         core_orbitals=2,
         active_orbitals=12,
         do_test_rdms=True,
@@ -77,7 +77,7 @@ def test_rel_ci_hf_ghf():
     )
     scf = GHF(charge=0)(system)
     ci = RelCI(
-        states=State(nel=10, multiplicity=1, ms=0.0),
+        states=RelState(nel=10),
         core_orbitals=2,
         active_orbitals=12,
         do_test_rdms=True,

--- a/tests/ci/test_rel_gasci.py
+++ b/tests/ci/test_rel_gasci.py
@@ -1,7 +1,7 @@
 import pytest
 import numpy as np
 
-from forte2 import System, RHF, CI, State, ROHF
+from forte2 import System, RHF, RelState, ROHF
 from forte2.ci import RelCI
 from forte2.scf.scf_utils import convert_coeff_spatial_to_spinor
 from forte2.helpers.comparisons import approx
@@ -31,7 +31,7 @@ def test_rel_gasci_rhf_1():
     rhf, system = prepare_rhf_coeff_for_relci(rhf, system)
     ci = RelCI(
         active_orbitals=[[0, 1], [2, 3]],
-        states=State(nel=2, multiplicity=1, ms=0.0, gas_min=[0], gas_max=[2]),
+        states=RelState(nel=2, gas_min=[0], gas_max=[2]),
         econv=1e-12,
     )(rhf)
     ci.run()
@@ -53,7 +53,7 @@ def test_rel_gasci_rhf_2():
     system.two_component = True
     ci = RelCI(
         active_orbitals=[[0, 1], [2, 3]],
-        states=State(nel=2, multiplicity=1, ms=0.0, gas_min=[1, 0], gas_max=[2, 1]),
+        states=RelState(nel=2, gas_min=[1, 0], gas_max=[2, 1]),
         nroots=2,
     )(rhf)
     ci.run()
@@ -83,7 +83,7 @@ def test_rel_gasci_rhf_3():
     system.two_component = True
     ci = RelCI(
         active_orbitals=[[0, 1], [2, 3]],
-        states=State(nel=2, multiplicity=1, ms=0.0, gas_min=[0, 0], gas_max=[2, 2]),
+        states=RelState(nel=2, gas_min=[0, 0], gas_max=[2, 2]),
     )(rhf)
     ci.run()
 
@@ -107,7 +107,7 @@ def test_rel_gasci_rhf_4():
     system.two_component = True
     ci = RelCI(
         active_orbitals=(10, 4),
-        states=State(nel=10, multiplicity=1, ms=0.0, gas_min=[6, 0], gas_max=[10, 4]),
+        states=RelState(nel=10, gas_min=[6, 0], gas_max=[10, 4]),
         econv=1e-12,
     )(rhf)
     ci.run()
@@ -132,7 +132,7 @@ def test_rel_gasci_rhf_5():
     system.two_component = True
     ci = RelCI(
         active_orbitals=(2, 12),
-        states=State(nel=10, multiplicity=1, ms=0.0, gas_min=[0], gas_max=[1]),
+        states=RelState(nel=10, gas_min=[0], gas_max=[1]),
         nroots=4,
         basis_per_root=10,
         ndets_per_guess=20,
@@ -160,7 +160,7 @@ def test_rel_gasci_rohf_3():
     rhf, system = prepare_rhf_coeff_for_relci(rhf, system)
     ci = RelCI(
         active_orbitals=(2, 12),
-        states=State(nel=10, multiplicity=3, ms=1.0, gas_min=[0], gas_max=[1]),
+        states=RelState(nel=10, gas_min=[0], gas_max=[1]),
     )(rhf)
     ci.run()
 

--- a/tests/orbopt/test_rel_casscf_hf.py
+++ b/tests/orbopt/test_rel_casscf_hf.py
@@ -1,7 +1,7 @@
 import pytest
 import numpy as np
 
-from forte2 import System, State, GHF
+from forte2 import System, RelState, GHF
 from forte2.helpers.comparisons import approx
 from forte2.orbopt import RelMCOptimizer
 
@@ -20,7 +20,7 @@ def test_rel_casscf_hf_equivalence_to_nonrel():
     )
     scf = GHF(charge=0, econv=1e-10)(system)
     mc = RelMCOptimizer(
-        states=State(nel=10, multiplicity=1, ms=0.0),
+        states=RelState(nel=10),
         core_orbitals=2,
         active_orbitals=12,
         do_diis=False,
@@ -49,7 +49,7 @@ def test_rel_casscf_hf_ghf():
     )
     scf = GHF(charge=0)(system)
     mc = RelMCOptimizer(
-        states=State(nel=10, multiplicity=1, ms=0.0),
+        states=RelState(nel=10),
         nroots=1,
         core_orbitals=2,
         active_orbitals=12,
@@ -77,7 +77,7 @@ def test_rel_casscf_na_ghf():
     )
     scf = GHF(charge=0)(system)
     mc = RelMCOptimizer(
-        states=State(nel=11, multiplicity=2, ms=0.5),
+        states=RelState(nel=11),
         nroots=8,
         core_orbitals=10,
         active_orbitals=8,

--- a/tests/scf/test_x2c1e.py
+++ b/tests/scf/test_x2c1e.py
@@ -92,7 +92,7 @@ def test_boettger_hbr():
     scf.run()
     assert EH_TO_WN * (
         scf.eps[0][scf.nel - 2] - scf.eps[0][scf.nel - 3]
-    ) == pytest.approx(2870.8987272457603, abs=1e-4)
+    ) == pytest.approx(2898.7863319000467, abs=1e-4)
 
 
 def test_so_from_sf_water():


### PR DESCRIPTION
This PR fixes the screened-nuclear spin-orbit scaling terms for the spin-orbit parts of the 1e x2c Hamiltonian. Also adds a convenience class `RelState` for specifying a relativistic electronic state without multiplicity and ms.