### PR TITLE
fix: resolve bug where default basis set is removed after processing

### DIFF
--- a/forte2/system/build_basis.py
+++ b/forte2/system/build_basis.py
@@ -102,12 +102,14 @@ def build_basis(
 
 
 def _parse_custom_basis_assignment(geometry, basis_assignment):
-    default_basis = basis_assignment.pop("default", None)
+    # explicit_basis contains all entries except "default"
+    explicit_basis = basis_assignment.copy()
+    default_basis = explicit_basis.pop("default", None)
     atom_to_center = geometry.atom_to_center
     atom_counts = geometry.atom_counts
 
     assigned_basis = {}
-    for k, v in basis_assignment.items():
+    for k, v in explicit_basis.items():
         # "could be "O" or "O2" or "H2-12"
         m = re.match(r"([a-zA-Z]{1,2})([0-9]+)?-?([0-9]+)?", k).groups()
         # m[0]: atom symbol

--- a/forte2/system/system.py
+++ b/forte2/system/system.py
@@ -178,7 +178,9 @@ class System:
             )
 
     def _init_basis(self):
+        print(self.basis_set)
         self.basis = build_basis(self.basis_set, self.geom_helper)
+        print(self.basis_set)
         logger.log_info1(
             f"Parsed {self.natoms} atoms with basis set of {self.basis.size} functions."
         )

--- a/forte2/system/system.py
+++ b/forte2/system/system.py
@@ -178,9 +178,7 @@ class System:
             )
 
     def _init_basis(self):
-        print(self.basis_set)
         self.basis = build_basis(self.basis_set, self.geom_helper)
-        print(self.basis_set)
         logger.log_info1(
             f"Parsed {self.natoms} atoms with basis set of {self.basis.size} functions."
         )

--- a/tests/scf/test_x2c1e.py
+++ b/tests/scf/test_x2c1e.py
@@ -84,7 +84,7 @@ def test_boettger_hbr():
 
     system = System(
         xyz=xyz,
-        basis_set="decon-cc-pvdz",
+        basis_set={"Br": "decon-aug-cc-pvdz", "default": "cc-pvtz"},
         auxiliary_basis_set="cc-pvtz-jkfit",
         x2c_type="so",
         snso_type="dcb",
@@ -93,7 +93,7 @@ def test_boettger_hbr():
     scf.run()
     assert EH_TO_WN * (
         scf.eps[0][scf.nel - 2] - scf.eps[0][scf.nel - 3]
-    ) == pytest.approx(2898.7863319000467, abs=1e-4)
+    ) == pytest.approx(2953.1938408944357, abs=1e-4)
 
 
 def test_so_from_sf_water():


### PR DESCRIPTION
This bug escaped detection because `System.basis_set` is not used after being processed into `System.basis`, except for in X2C, but there were no X2C tests using default basis sets. This is now fixed and an X2C test using a default basis is added.