### PR TITLE
Fix iterator bug for determinants with 32 orbitals or more

### DIFF
--- a/forte2/ci/bitarray.hpp
+++ b/forte2/ci/bitarray.hpp
@@ -142,15 +142,6 @@ template <size_t N> class BitArray {
             return copy;
         }
 
-        // TODO: This should be tested!
-        iterator operator+(difference_type n) const {
-            iterator result = *this;
-            const auto overage = result.index_ + (n % bits_per_word);
-            result.word_it_ += (n + overage) / bits_per_word;
-            result.index_ += overage % bits_per_word;
-            return result;
-        }
-
         bool operator==(const iterator& other) const {
             return (word_it_ == other.word_it_) and (index_ == other.index_);
         }

--- a/forte2/ci/ci_spin_adapter.cc
+++ b/forte2/ci/ci_spin_adapter.cc
@@ -221,6 +221,8 @@ auto CISpinAdapter::make_spin_couplings(int N, int twoS) -> std::vector<String> 
     std::vector<String> couplings;
     auto nup = (N + twoS) / 2;
     String coupling;
+    const auto coupling_second = std::next(coupling.begin(), 1); // to keep the first coupling as up
+    const auto coupling_end = std::next(coupling.begin(), N);
     // up = false = 0, down = true = 1
     // The coupling should always start with up
     for (int i = 0; i < nup; i++)
@@ -239,7 +241,7 @@ auto CISpinAdapter::make_spin_couplings(int N, int twoS) -> std::vector<String> 
         if (valid)
             couplings.push_back(coupling);
         // to keep the first coupling as up we only permute starting from the second element
-    } while (std::next_permutation(coupling.begin() + 1, coupling.begin() + N));
+    } while (std::next_permutation(coupling_second, coupling_end));
 
     return couplings;
 }
@@ -250,6 +252,8 @@ auto CISpinAdapter::make_determinant_occupations(int N, int twoMs) -> std::vecto
         return std::vector<String>(1, String());
     auto nup = (N + twoMs) / 2;
     String det_occ;
+    const auto det_occ_begin = det_occ.begin();
+    const auto det_occ_end = std::next(det_occ_begin, N);
     // true = 1 = up, false = 0 = down
     // The det_occ should always start with up
     for (int i = 0; i < nup; i++)
@@ -259,7 +263,7 @@ auto CISpinAdapter::make_determinant_occupations(int N, int twoMs) -> std::vecto
     /// Generate all permutations of the path
     do {
         det_occs.push_back(det_occ);
-    } while (std::next_permutation(det_occ.begin(), det_occ.begin() + N));
+    } while (std::next_permutation(det_occ_begin, det_occ_end));
     return det_occs;
 }
 

--- a/forte2/ci/ci_strings_makers.cc
+++ b/forte2/ci/ci_strings_makers.cc
@@ -31,13 +31,13 @@ StringList make_strings_with_occupation(size_t num_spaces, int nirrep,
         // enumerate all the possible strings in each GAS space
         for (size_t n = 0; n < num_spaces; n++) {
             String I;
+            I.clear();
             auto gas_norb = space_size[n];
             auto gas_ne = occupation[n];
             if ((gas_ne >= 0) and (gas_ne <= gas_norb)) {
                 const auto I_begin = I.begin();
-                const auto I_end = I.begin() + gas_norb;
+                const auto I_end = std::next(I.begin(), gas_norb);
 
-                I.clear();
                 for (int i = std::max(0, gas_norb - gas_ne); i < gas_norb; ++i)
                     I[i] = true; // Generate the string 000011111
 

--- a/forte2/ci/ci_strings_makers.cc
+++ b/forte2/ci/ci_strings_makers.cc
@@ -28,18 +28,20 @@ StringList make_strings_with_occupation(size_t num_spaces, int nirrep,
         std::vector<std::vector<String>> gas_space_string(num_spaces, std::vector<String>{});
         std::vector<std::vector<String>> full_strings(nirrep, std::vector<String>{});
 
-        // enumerate all the possible strings in each GAS space
+        // loop over all the GAS spaces
         for (size_t n = 0; n < num_spaces; n++) {
-            String I;
-            I.clear();
             auto gas_norb = space_size[n];
             auto gas_ne = occupation[n];
+            // generate all the strings for the n-th GAS space with gas_ne electrons in gas_norb
+            // orbitals
             if ((gas_ne >= 0) and (gas_ne <= gas_norb)) {
-                const auto I_begin = I.begin();
-                const auto I_end = std::next(I.begin(), gas_norb);
-
+                String I;
+                I.clear();
                 for (int i = std::max(0, gas_norb - gas_ne); i < gas_norb; ++i)
                     I[i] = true; // Generate the string 000011111
+
+                const auto I_begin = I.begin();
+                const auto I_end = std::next(I.begin(), gas_norb);
 
                 do {
                     String J;

--- a/forte2/ci/determinant_helpers.cc
+++ b/forte2/ci/determinant_helpers.cc
@@ -53,7 +53,7 @@ std::vector<std::vector<String>> make_strings(int n, int k, size_t nirrep,
     if ((k >= 0) and (k <= n)) { // check that (n > 0) makes sense.
         String I;
         const auto I_begin = I.begin();
-        const auto I_end = I.begin() + n;
+        const auto I_end = std::next(I.begin(), n);
         // Generate the string 00000001111111
         //                      {n-k}  { k }
         I.clear();

--- a/tests/ci/test_determinant_helpers.py
+++ b/tests/ci/test_determinant_helpers.py
@@ -121,3 +121,9 @@ def test_determinant_hilbert_space_edge_cases():
     expected = [det("aa00"), det("a0a0"), det("a00a"), det("0aa0"), det("0a0a")]
     assert len(dets) == 5
     assert sorted(dets) == sorted(expected)
+
+    dets = hilbert_space(35, 1, 0)
+    assert len(dets) == 35
+
+    dets = hilbert_space(64, 0, 1)
+    assert len(dets) == 64


### PR DESCRIPTION
This pull request replaces manual iterator arithmetic for the `BitArray` class (which had a bug when the number of orbitals was larger than 31). The old iterator is replaced with the safer `std::next`. New test cases have been added to increase coverage of edge cases.

**Iterator and permutation handling improvements:**

* Replaced manual pointer arithmetic with `std::next` in calls to `std::next_permutation` and related iterator assignments in `ci_spin_adapter.cc`, `ci_strings_makers.cc`, and `determinant_helpers.cc`, improving code clarity and reducing potential off-by-one errors.

**Code cleanup:**

* Removed a buggy implementation of `operator+` from the `BitArray::iterator` class in `bitarray.hpp`, simplifying the iterator implementation.

**Testing improvements:**

* Added new edge case tests to `test_determinant_helpers.py` for `hilbert_space` with larger input sizes, increasing test coverage and robustness.