### PR TITLE
feat: On-the-fly Cholesky-decomposed integrals

### DIFF
--- a/forte2/__init__.py
+++ b/forte2/__init__.py
@@ -4,7 +4,6 @@ __author__ = "Forte2 Developers"
 from ._forte2 import *
 from ._forte2 import ints
 from ._forte2.ints import Basis, Shell
-from .integrals import integrals
 from .system import System, ModelSystem, HubbardModel
 from .state import State, RelState, MOSpace
 from .scf import RHF, ROHF, UHF, CUHF, GHF

--- a/forte2/api/integrals_api.cc
+++ b/forte2/api/integrals_api.cc
@@ -153,6 +153,7 @@ void export_basis_api(nb::module_& sub_m) {
         .def_prop_ro("center_first_and_last_shell",
                      [](const Basis& b) { return b.center_first_and_last(true); })
         .def("shell_slice_to_basis_slice", &Basis::shell_slice_to_basis_slice, "shell_slice"_a)
+        .def("basis_index_to_shell_index", &Basis::basis_index_to_shell_index, "basis_index"_a)
         .def_prop_ro("size", &Basis::size)
         .def_prop_ro("max_l", &Basis::max_l)
         .def_prop_ro("name", &Basis::name)
@@ -328,6 +329,11 @@ void export_two_electron_api(nb::module_& sub_m) {
     sub_m.def(
         "coulomb_4c_diagonal", [](const Basis& basis) { return coulomb_4c_diagonal(basis); },
         "basis"_a);
+
+    sub_m.def(
+        "coulomb_4c_row",
+        [](const Basis& basis, std::size_t row) { return coulomb_4c_row(basis, row); }, "basis"_a,
+        "row"_a);
 
     sub_m.def(
         "coulomb_3c",

--- a/forte2/api/integrals_api.cc
+++ b/forte2/api/integrals_api.cc
@@ -20,7 +20,7 @@
 #include "integrals/value_at_points.h"
 // Libcint-backed functions are optional
 #if FORTE2_USE_LIBCINT
-#  include "integrals/libcint_two_center.h"
+#include "integrals/libcint_two_center.h"
 #endif
 
 namespace nb = nanobind;
@@ -148,9 +148,11 @@ void export_basis_api(nb::module_& sub_m) {
         .def("__getitem__", &Basis::operator[], "i"_a)
         .def("__len__", &Basis::size)
         .def_prop_ro("shell_first_and_size", &Basis::shell_first_and_size)
-        .def_prop_ro("center_first_and_last", [](const Basis& b) { return b.center_first_and_last(false); })
+        .def_prop_ro("center_first_and_last",
+                     [](const Basis& b) { return b.center_first_and_last(false); })
         .def_prop_ro("center_first_and_last_shell",
                      [](const Basis& b) { return b.center_first_and_last(true); })
+        .def("shell_slice_to_basis_slice", &Basis::shell_slice_to_basis_slice, "shell_slice"_a)
         .def_prop_ro("size", &Basis::size)
         .def_prop_ro("max_l", &Basis::max_l)
         .def_prop_ro("name", &Basis::name)
@@ -316,6 +318,13 @@ void export_two_electron_api(nb::module_& sub_m) {
         "basis"_a);
 
     sub_m.def(
+        "coulomb_4c_by_shell_slices",
+        [](const Basis& basis, const std::vector<std::pair<std::size_t, std::size_t>>& shell_slices) {
+            return coulomb_4c_by_shell_slices(basis, basis, basis, basis, shell_slices);
+        },
+        "basis"_a, "shell_slices"_a);
+
+    sub_m.def(
         "coulomb_3c",
         [](const Basis& basis1, const Basis& basis2, const Basis& basis3) {
             return coulomb_3c(basis1, basis2, basis3);
@@ -391,7 +400,7 @@ void export_libcint_compute_api(nb::module_& sub_m) {
 // When libcint is disabled, define a no-op exporter
 void export_libcint_compute_api(nb::module_& sub_m) {
     // Intentionally empty: libcint-backed APIs are unavailable.
-    (void) sub_m;
+    (void)sub_m;
 }
 #endif
 } // namespace forte2

--- a/forte2/api/integrals_api.cc
+++ b/forte2/api/integrals_api.cc
@@ -319,10 +319,15 @@ void export_two_electron_api(nb::module_& sub_m) {
 
     sub_m.def(
         "coulomb_4c_by_shell_slices",
-        [](const Basis& basis, const std::vector<std::pair<std::size_t, std::size_t>>& shell_slices) {
+        [](const Basis& basis,
+           const std::vector<std::pair<std::size_t, std::size_t>>& shell_slices) {
             return coulomb_4c_by_shell_slices(basis, basis, basis, basis, shell_slices);
         },
         "basis"_a, "shell_slices"_a);
+
+    sub_m.def(
+        "coulomb_4c_diagonal", [](const Basis& basis) { return coulomb_4c_diagonal(basis); },
+        "basis"_a);
 
     sub_m.def(
         "coulomb_3c",

--- a/forte2/helpers/memory.h
+++ b/forte2/helpers/memory.h
@@ -11,6 +11,8 @@ namespace forte2 {
 /// @brief Express the amount of memory needed to store `n` elements of type T in megabytes
 template <typename T> int to_mb(size_t n) { return n * sizeof(T) / (1024 * 1024); }
 
+template <typename T> int to_size(double mb) { return static_cast<int>(mb * 1024 * 1024 / sizeof(T)); }
+
 /// @brief A templated buffer class used to store elements of type T
 /// This class is a simple wrapper around std::vector<T> which provides a variable-size buffer.
 /// The buffer is initialized with a given size and is automatically resized when needed.

--- a/forte2/integrals/__init__.py
+++ b/forte2/integrals/__init__.py
@@ -1,1 +1,2 @@
 from .integrals import *
+from .cholesky import CholeskyIntegrals

--- a/forte2/integrals/basis.cc
+++ b/forte2/integrals/basis.cc
@@ -54,6 +54,23 @@ std::vector<std::pair<std::size_t, std::size_t>> Basis::shell_first_and_size() c
     return result;
 }
 
+std::pair<std::size_t, std::size_t> Basis::shell_slice_to_basis_slice(std::pair<std::size_t, std::size_t> shell_slice) const {
+    if (shell_slice.first >= shells_.size() || shell_slice.second > shells_.size() ||
+        shell_slice.first >= shell_slice.second) {
+        throw std::out_of_range("Shell slice out of range.");
+    }
+    std::size_t first = 0;
+    for (std::size_t i = 0; i < shell_slice.first; ++i) {
+        first += shells_[i].size();
+    }
+    std::size_t last = first;
+    for (std::size_t i = shell_slice.first; i < shell_slice.second; ++i) {
+        last += shells_[i].size();
+    }
+    return {first, last};
+
+}
+
 std::vector<std::pair<std::size_t, std::size_t>> Basis::center_first_and_last(bool count_shell) const {
     std::vector<std::pair<std::size_t, std::size_t>> result;
     if (shells_.empty()) {

--- a/forte2/integrals/basis.cc
+++ b/forte2/integrals/basis.cc
@@ -54,7 +54,8 @@ std::vector<std::pair<std::size_t, std::size_t>> Basis::shell_first_and_size() c
     return result;
 }
 
-std::pair<std::size_t, std::size_t> Basis::shell_slice_to_basis_slice(std::pair<std::size_t, std::size_t> shell_slice) const {
+std::pair<std::size_t, std::size_t>
+Basis::shell_slice_to_basis_slice(std::pair<std::size_t, std::size_t> shell_slice) const {
     if (shell_slice.first >= shells_.size() || shell_slice.second > shells_.size() ||
         shell_slice.first >= shell_slice.second) {
         throw std::out_of_range("Shell slice out of range.");
@@ -68,10 +69,10 @@ std::pair<std::size_t, std::size_t> Basis::shell_slice_to_basis_slice(std::pair<
         last += shells_[i].size();
     }
     return {first, last};
-
 }
 
-std::vector<std::pair<std::size_t, std::size_t>> Basis::center_first_and_last(bool count_shell) const {
+std::vector<std::pair<std::size_t, std::size_t>>
+Basis::center_first_and_last(bool count_shell) const {
     std::vector<std::pair<std::size_t, std::size_t>> result;
     if (shells_.empty()) {
         return result;
@@ -95,6 +96,25 @@ std::vector<std::pair<std::size_t, std::size_t>> Basis::center_first_and_last(bo
     }
     result.emplace_back(first, last);
     return result;
+}
+
+std::pair<std::size_t, std::size_t>
+Basis::basis_index_to_shell_index(std::size_t basis_index) const {
+    if (basis_index >= size_) {
+        throw std::out_of_range("basis_index_to_shell_index: index out of range.");
+    }
+    std::size_t shell_index = 0;
+    std::size_t count = 0;
+    std::size_t count_prev = 0;
+    for (const auto& shell : shells_) {
+        count += shell.size();
+        if (basis_index < count) {
+            return {shell_index, basis_index - count_prev};
+        }
+        count_prev = count;
+        ++shell_index;
+    }
+    throw std::runtime_error("basis_index_to_shell_index: failed to find shell index.");
 }
 
 std::string shell_label(int l, int idx) {

--- a/forte2/integrals/basis.h
+++ b/forte2/integrals/basis.h
@@ -60,9 +60,15 @@ class Basis {
 
     /// @brief Convert a shell slice to a basis function slice.
     /// @param shell_slice A pair of the first and last shell indices.
-    /// @return A pair of the first and last basis function indices corresponding to the shell slice.
+    /// @return A pair of the first and last basis function indices corresponding to the shell
+    /// slice.
     std::pair<std::size_t, std::size_t>
     shell_slice_to_basis_slice(std::pair<std::size_t, std::size_t> shell_slice) const;
+
+    /// @brief Return the shell index of a given basis function index.
+    /// @param basis_index The basis function index.
+    /// @return A pair of the shell index and the index of the basis function within the shell.
+    std::pair<std::size_t, std::size_t> basis_index_to_shell_index(std::size_t basis_index) const;
 
   private:
     std::vector<libint2::Shell> shells_; // vector of shells in the basis set

--- a/forte2/integrals/basis.h
+++ b/forte2/integrals/basis.h
@@ -58,6 +58,12 @@ class Basis {
     std::vector<std::pair<std::size_t, std::size_t>>
     center_first_and_last(bool count_shell = false) const;
 
+    /// @brief Convert a shell slice to a basis function slice.
+    /// @param shell_slice A pair of the first and last shell indices.
+    /// @return A pair of the first and last basis function indices corresponding to the shell slice.
+    std::pair<std::size_t, std::size_t>
+    shell_slice_to_basis_slice(std::pair<std::size_t, std::size_t> shell_slice) const;
+
   private:
     std::vector<libint2::Shell> shells_; // vector of shells in the basis set
     size_t size_ = 0;                    // total number of basis functions

--- a/forte2/integrals/cholesky.py
+++ b/forte2/integrals/cholesky.py
@@ -1,0 +1,78 @@
+import numpy as np
+from forte2 import ints
+
+
+class CholeskyIntegrals:
+    def __init__(self, basis, memory=1000, delta=1e-12):
+        self.basis = basis
+        # convert MB to number of double elements
+        self.memory = memory * 1024 * 1024 / 8
+        self.delta = delta
+        self.nbf = len(basis)
+
+    def _compute_diagonal(self):
+        return ints.coulomb_4c_diagonal(self.basis)
+
+    def _compute_row(self, pivot):
+        return ints.coulomb_4c_row(self.basis, pivot)
+
+    def _compute(self):
+        n = self.nbf**2
+        Q = 0
+
+        # mimic the C++ int max for memory checks
+        max_rows = (self.memory - n) // (2 * n)
+
+        # initialize diagonal
+        diag = self._compute_diagonal()
+
+        L = []  # list of rows (each row is length n)
+        pivots = []
+
+        # main loop
+        while Q < n:
+            pivot = int(np.argmax(diag))
+            Dmax = float(diag[pivot])
+
+            if Dmax < self.delta or Dmax < 0:
+                break
+
+            pivots.append(pivot)
+            L_QQ = np.sqrt(Dmax)
+
+            if Q > max_rows:
+                raise RuntimeError("Cholesky: Memory constraint exceeded.")
+
+            # get new row (m|pivot)
+            row = self._compute_row(pivot)
+
+            # subtract previous contributions
+            for P in range(Q):
+                alpha = L[P][pivots[Q]]
+                row -= alpha * L[P]
+
+            # scale
+            row /= L_QQ
+
+            # zero the upper triangle (enforce Cholesky structure)
+            row[pivots] = 0.0
+
+            # set pivot element
+            row[pivot] = L_QQ
+
+            # update Schur complement diagonal
+            diag -= row * row
+
+            # force pivot entries to zero
+            diag[pivots] = 0.0
+
+            L.append(row)
+            Q += 1
+
+        # stack into final L
+        if Q == 0:
+            self.L_ = np.empty((0, n))
+        else:
+            self.L_ = np.vstack(L[:Q])
+
+        return self.L_

--- a/forte2/integrals/integrals.py
+++ b/forte2/integrals/integrals.py
@@ -323,7 +323,7 @@ def opVop(system, basis1=None, basis2=None):
     if system.use_gaussian_charges:
         # Requires libcint; raises a clear error if unavailable
         res = cint_opVop(system, basis1, basis2)
-        # Note: libcint returns [sigma_x, sigma_y, sigma_z, I2]. 
+        # Note: libcint returns [sigma_x, sigma_y, sigma_z, I2].
         # We reorder to [I2, sigma_x, sigma_y, sigma_z] (the same as libint2)
         return [res[3], res[0], res[1], res[2]]
     basis1, basis2 = _parse_basis_args_1e(system, basis1, basis2)
@@ -628,7 +628,9 @@ def _parse_basis_args_cint_2c2e(system, basis1, basis2, origin=None):
     # 1. both basis sets are None -> set both to system.auxiliary_basis
     # 2. basis1 is provided, basis2 is None -> set basis2 to basis1
     if basis1 is None and basis2 is None:
-        atm, bas, env = basis_to_cint_envs(system, system.auxiliary_basis, common_origin=origin)
+        atm, bas, env = basis_to_cint_envs(
+            system, system.auxiliary_basis, common_origin=origin
+        )
         shell_slice = [
             0,
             system.auxiliary_basis.nshells,
@@ -833,7 +835,9 @@ def cint_emultipole1(system, basis1=None, basis2=None, origin=None):
         The first electric multipole moment integrals
     """
     _require_libcint()
-    atm, bas, env, shell_slice = _parse_basis_args_cint_1e(system, basis1, basis2, origin)
+    atm, bas, env, shell_slice = _parse_basis_args_cint_1e(
+        system, basis1, basis2, origin
+    )
     res = ints.cint_int1e_r_sph(shell_slice, atm, bas, env)
     # C-layout, first index is the integral component (slowest changing)
     return _f2c(res)

--- a/forte2/integrals/two_electron.cc
+++ b/forte2/integrals/two_electron.cc
@@ -7,6 +7,13 @@ np_tensor4 coulomb_4c(const Basis& b1, const Basis& b2, const Basis& b3, const B
     return compute_two_electron_4c_multi<libint2::Operator::coulomb>(b1, b2, b3, b4);
 }
 
+np_tensor4 coulomb_4c_by_shell_slices(
+    const Basis& b1, const Basis& b2, const Basis& b3, const Basis& b4,
+    const std::vector<std::pair<std::size_t, std::size_t>>& shell_slices) {
+    return compute_two_electron_4c_by_shell_slices<libint2::Operator::coulomb>(
+        b1, b2, b3, b4, shell_slices);
+}
+
 np_tensor3 coulomb_3c(const Basis& b1, const Basis& b2, const Basis& b3) {
     return compute_two_electron_3c_multi_async<libint2::Operator::coulomb>(b1, b2, b3);
 }

--- a/forte2/integrals/two_electron.cc
+++ b/forte2/integrals/two_electron.cc
@@ -19,7 +19,7 @@ np_vector coulomb_4c_diagonal(const Basis& basis) {
 }
 
 np_vector coulomb_4c_row(const Basis& basis, std::size_t row) {
-    return compute_two_electron_4c_row<libint2::Operator::coulomb>(basis, row);
+    return compute_two_electron_4c_row_async<libint2::Operator::coulomb>(basis, row);
 }
 
 np_tensor3 coulomb_3c(const Basis& b1, const Basis& b2, const Basis& b3) {

--- a/forte2/integrals/two_electron.cc
+++ b/forte2/integrals/two_electron.cc
@@ -18,6 +18,10 @@ np_vector coulomb_4c_diagonal(const Basis& basis) {
     return compute_two_electron_4c_diagonal<libint2::Operator::coulomb>(basis);
 }
 
+np_vector coulomb_4c_row(const Basis& basis, std::size_t row) {
+    return compute_two_electron_4c_row<libint2::Operator::coulomb>(basis, row);
+}
+
 np_tensor3 coulomb_3c(const Basis& b1, const Basis& b2, const Basis& b3) {
     return compute_two_electron_3c_multi_async<libint2::Operator::coulomb>(b1, b2, b3);
 }

--- a/forte2/integrals/two_electron.cc
+++ b/forte2/integrals/two_electron.cc
@@ -14,6 +14,10 @@ np_tensor4 coulomb_4c_by_shell_slices(
         b1, b2, b3, b4, shell_slices);
 }
 
+np_vector coulomb_4c_diagonal(const Basis& basis) {
+    return compute_two_electron_4c_diagonal<libint2::Operator::coulomb>(basis);
+}
+
 np_tensor3 coulomb_3c(const Basis& b1, const Basis& b2, const Basis& b3) {
     return compute_two_electron_3c_multi_async<libint2::Operator::coulomb>(b1, b2, b3);
 }

--- a/forte2/integrals/two_electron.h
+++ b/forte2/integrals/two_electron.h
@@ -19,6 +19,19 @@ class Basis;
 np_tensor4 coulomb_4c(const Basis& basis1, const Basis& basis2, const Basis& basis3,
                       const Basis& basis4);
 
+///@brief Compute the coulomb integrals (b1 b2 | 1  / r_12 | b3 b4) for specified shell slices.
+/// @param basis1 The basis set in the bra for electron 1 center 1.
+/// @param basis2 The basis set in the bra for electron 1 center 2.
+/// @param basis3 The basis set in the ket for electron 2 center 3.
+/// @param basis4 The basis set in the ket for electron 2 center 4.
+/// @param shell_slices A vector of four pairs specifying the start and end shell indices for
+///        each basis set.
+/// @return A 4D ndarray of shape (n1, n2, n3, n4), where ni is the number of basis functions in
+///         basis_i
+np_tensor4 coulomb_4c_by_shell_slices(
+    const Basis& basis1, const Basis& basis2, const Basis& basis3, const Basis& basis4,
+    const std::vector<std::pair<std::size_t, std::size_t>>& shell_slices);
+
 /// @brief Compute the coulomb integrals (b1 | 1  / r_12 | b2 b3).
 /// @param basis1 The basis set in the bra for electron 1 center 1.
 /// @param basis2 The basis set in the ket for electron 2 center 2.

--- a/forte2/integrals/two_electron.h
+++ b/forte2/integrals/two_electron.h
@@ -37,6 +37,12 @@ np_tensor4 coulomb_4c_by_shell_slices(
 /// @return A 1D ndarray of length n*n, where n is the number of basis functions in the basis.
 np_vector coulomb_4c_diagonal(const Basis& basis);
 
+/// @brief Compute a row of the coulomb integrals ([i] [j] | 1 / r_12 | k l), where i, j are fixed
+/// @param basis The basis set for both electrons.
+/// @param row The row index corresponding to basis function indices (i, j).
+/// @return A 1D ndarray of length n*n, where n is the number of basis functions in the basis.
+np_vector coulomb_4c_row(const Basis& basis, std::size_t row);
+
 /// @brief Compute the coulomb integrals (b1 | 1  / r_12 | b2 b3).
 /// @param basis1 The basis set in the bra for electron 1 center 1.
 /// @param basis2 The basis set in the ket for electron 2 center 2.

--- a/forte2/integrals/two_electron.h
+++ b/forte2/integrals/two_electron.h
@@ -32,6 +32,11 @@ np_tensor4 coulomb_4c_by_shell_slices(
     const Basis& basis1, const Basis& basis2, const Basis& basis3, const Basis& basis4,
     const std::vector<std::pair<std::size_t, std::size_t>>& shell_slices);
 
+/// @brief Compute the diagonal of the coulomb integrals (i j | 1 / r_12 | i j).
+/// @param basis The basis set for both electrons.
+/// @return A 1D ndarray of length n*n, where n is the number of basis functions in the basis.
+np_vector coulomb_4c_diagonal(const Basis& basis);
+
 /// @brief Compute the coulomb integrals (b1 | 1  / r_12 | b2 b3).
 /// @param basis1 The basis set in the bra for electron 1 center 1.
 /// @param basis2 The basis set in the ket for electron 2 center 2.

--- a/forte2/integrals/two_electron_compute.h
+++ b/forte2/integrals/two_electron_compute.h
@@ -99,7 +99,7 @@ template <libint2::Operator Op, typename Params = NoParams>
 
     const auto end = std::chrono::high_resolution_clock::now();
     const auto elapsed = std::chrono::duration_cast<std::chrono::milliseconds>(end - start);
-    LOG_INFO1 << "[forte2] Two-electron integrals timing: " << elapsed.count() << " ms\n";
+    LOG_INFO2 << "[forte2] Two-electron integrals timing: " << elapsed.count() << " ms\n";
 
     return ints;
 }
@@ -375,7 +375,7 @@ template <libint2::Operator Op, typename Params = NoParams>
     libint2::finalize();
     const auto end = std::chrono::high_resolution_clock::now();
     const auto elapsed = std::chrono::duration_cast<std::chrono::milliseconds>(end - start);
-    LOG_INFO1 << "[forte2] Two-electron integrals row timing: " << elapsed.count() << " ms\n";
+    LOG_INFO2 << "[forte2] Two-electron integrals row timing: " << elapsed.count() << " ms\n";
     return ints;
 }
 
@@ -455,7 +455,7 @@ template <libint2::Operator Op, typename Params = NoParams>
 
     const auto end = std::chrono::high_resolution_clock::now();
     const auto elapsed = std::chrono::duration_cast<std::chrono::milliseconds>(end - start);
-    LOG_INFO1 << "[forte2] Three-center two-electron integrals timing: " << elapsed.count() / 1000.0
+    LOG_INFO2 << "[forte2] Three-center two-electron integrals timing: " << elapsed.count() / 1000.0
               << " s\n";
 
     return ints;
@@ -565,7 +565,7 @@ template <libint2::Operator Op, typename Params = NoParams>
 
     const auto end = std::chrono::high_resolution_clock::now();
     const auto elapsed = std::chrono::duration_cast<std::chrono::milliseconds>(end - start);
-    LOG_INFO1 << "[forte2] Three-center two-electron integrals timing: " << elapsed.count() / 1000.0
+    LOG_INFO2 << "[forte2] Three-center two-electron integrals timing: " << elapsed.count() / 1000.0
               << " s\n";
 
     return ints;
@@ -635,7 +635,7 @@ template <libint2::Operator Op, typename Params = NoParams>
 
     const auto end = std::chrono::high_resolution_clock::now();
     const auto elapsed = std::chrono::duration_cast<std::chrono::milliseconds>(end - start);
-    LOG_INFO1 << "[forte2] Two-center two-electron integrals timing: " << elapsed.count() / 1000.0
+    LOG_INFO2 << "[forte2] Two-center two-electron integrals timing: " << elapsed.count() / 1000.0
               << " s\n";
 
     return ints;

--- a/tests/integrals/test_two_electron.py
+++ b/tests/integrals/test_two_electron.py
@@ -1,6 +1,6 @@
 import numpy as np
 
-import forte2
+import forte2, forte2.integrals
 from forte2.helpers.comparisons import approx
 
 
@@ -111,3 +111,17 @@ def test_two_electron_integral_row():
         Vref_row = Vref[row, :]
         Vrow = forte2.ints.coulomb_4c_row(system.basis, row)
         assert np.allclose(Vrow, Vref_row, atol=1e-8, rtol=0)
+
+
+def test_two_electron_integral_cholesky():
+    xyz = "Pd 0 0 0"
+    system = forte2.System(xyz=xyz, basis_set="sto-3g", minao_basis_set=None)
+
+    Vref = forte2.ints.coulomb_4c(system.basis)
+    nbf = system.nbf
+    Vref = Vref.reshape((nbf**2,) * 2)
+
+    chol = forte2.integrals.CholeskyIntegrals(system.basis, memory=2000, delta=1e-7)
+    L = chol._compute()
+    Vchol = L.T @ L
+    assert np.linalg.norm(Vchol - Vref) < 1e-6

--- a/tests/integrals/test_two_electron.py
+++ b/tests/integrals/test_two_electron.py
@@ -1,3 +1,5 @@
+import numpy as np
+
 import forte2
 from forte2.helpers.comparisons import approx
 
@@ -39,3 +41,37 @@ H                     0.000000000000     0.711620616370     0.489330954643
     assert V[0, 3, 1, 5] == approx(0.004687753192919011)
     assert V[1, 0, 6, 2] == approx(0.056745507084677765)
     assert V[0, 5, 5, 3] == approx(0.012314281459575225)
+
+
+def test_two_electron_integrals_by_shell_slices():
+    xyz = """
+    O   0.000000000000     0.000000000000    -0.061664597388
+    H   0.000000000000    -0.711620616370     0.489330954643
+    H   0.000000000000     0.711620616370     0.489330954643
+    """
+
+    system = forte2.System(xyz=xyz, basis_set="sto-3g")
+
+    Vref = forte2.ints.coulomb_4c(system.basis)
+
+    # generate random slices for each of the four shells
+    lo = 0
+    hi = system.basis.nshells
+    rng = np.random.default_rng(42)
+
+    for _ in range(20):
+        shell_slices = []
+        slobjs = []
+        for _ in range(4):
+            start = rng.integers(lo, hi - 1)
+            end = rng.integers(start + 1, hi)
+            shell_slices.append((start, end))
+            slobjs.append(slice(*system.basis.shell_slice_to_basis_slice((start, end))))
+
+        Vslice = forte2.ints.coulomb_4c_by_shell_slices(system.basis, shell_slices)
+        assert np.allclose(
+            Vslice,
+            Vref[slobjs[0], slobjs[1], slobjs[2], slobjs[3]],
+            atol=1e-8,
+            rtol=0,
+        )

--- a/tests/integrals/test_two_electron.py
+++ b/tests/integrals/test_two_electron.py
@@ -121,11 +121,11 @@ def test_two_electron_integral_cholesky():
 
     Vref = forte2.integrals.coulomb_4c(system)
     nbf = system.nbf
-    Vref = Vref.reshape((nbf**2,) * 2)
 
     chol = forte2.integrals.CholeskyIntegrals(system.basis, memory=2000, delta=1e-4)
-    L = chol._compute()
-    Vchol = L.T @ L
+    chol.compute()
+    B = chol.B
+    Vchol = np.einsum("Bpq,Brs->pqrs", B, B)
     assert np.linalg.norm(Vchol - Vref) < 1e-3
 
 

--- a/tests/integrals/test_two_electron.py
+++ b/tests/integrals/test_two_electron.py
@@ -1,6 +1,8 @@
 import numpy as np
+import pytest
 
 import forte2, forte2.integrals
+from forte2.system import BSE_AVAILABLE
 from forte2.helpers.comparisons import approx
 
 
@@ -125,3 +127,16 @@ def test_two_electron_integral_cholesky():
     L = chol._compute()
     Vchol = L.T @ L
     assert np.linalg.norm(Vchol - Vref) < 1e-3
+
+
+@pytest.mark.skipif(not BSE_AVAILABLE, reason="BSE module is not available")
+def test_3c2e():
+    xyz = "Au 0 0 0"
+    system = forte2.System(
+        xyz=xyz,
+        basis_set="ano-rcc",
+        minao_basis_set=None,
+        auxiliary_basis_set="def2-universal-jkfit",
+    )
+    ref = forte2.integrals.coulomb_3c(system)
+    assert np.linalg.norm(ref) == approx(239.55734891969408)

--- a/tests/integrals/test_two_electron.py
+++ b/tests/integrals/test_two_electron.py
@@ -75,3 +75,19 @@ def test_two_electron_integrals_by_shell_slices():
             atol=1e-8,
             rtol=0,
         )
+
+
+def test_two_electron_integral_diagonal():
+    xyz = """
+    O   0.000000000000     0.000000000000    -0.061664597388
+    H   0.000000000000    -0.711620616370     0.489330954643
+    H   0.000000000000     0.711620616370     0.489330954643
+    """
+    system = forte2.System(xyz=xyz, basis_set="sto-3g")
+
+    Vref = forte2.ints.coulomb_4c(system.basis)
+    nbf = system.nbf
+    Vref = np.diag(Vref.reshape((nbf**2,) * 2))
+
+    Vdiag = forte2.ints.coulomb_4c_diagonal(system.basis)
+    assert np.allclose(Vdiag, Vref, atol=1e-8, rtol=0)

--- a/tests/integrals/test_two_electron.py
+++ b/tests/integrals/test_two_electron.py
@@ -91,3 +91,23 @@ def test_two_electron_integral_diagonal():
 
     Vdiag = forte2.ints.coulomb_4c_diagonal(system.basis)
     assert np.allclose(Vdiag, Vref, atol=1e-8, rtol=0)
+
+
+def test_two_electron_integral_row():
+    xyz = """
+    O   0.000000000000     0.000000000000    -0.061664597388
+    H   0.000000000000    -0.711620616370     0.489330954643
+    H   0.000000000000     0.711620616370     0.489330954643
+    """
+    system = forte2.System(xyz=xyz, basis_set="sto-3g")
+
+    Vref = forte2.ints.coulomb_4c(system.basis)
+    nbf = system.nbf
+    Vref = Vref.reshape((nbf**2,) * 2)
+    rng = np.random.default_rng(42)
+
+    for _ in range(20):
+        row = rng.integers(0, nbf**2)
+        Vref_row = Vref[row, :]
+        Vrow = forte2.ints.coulomb_4c_row(system.basis, row)
+        assert np.allclose(Vrow, Vref_row, atol=1e-8, rtol=0)

--- a/tests/integrals/test_two_electron.py
+++ b/tests/integrals/test_two_electron.py
@@ -6,14 +6,14 @@ from forte2.helpers.comparisons import approx
 
 def test_two_electron_integrals():
     xyz = """
-O                     0.000000000000     0.000000000000    -0.061664597388
-H                     0.000000000000    -0.711620616370     0.489330954643
-H                     0.000000000000     0.711620616370     0.489330954643
-"""
+    O 0.000000000000     0.000000000000    -0.061664597388
+    H 0.000000000000    -0.711620616370     0.489330954643
+    H 0.000000000000     0.711620616370     0.489330954643
+    """
 
     system = forte2.System(xyz=xyz, basis_set="sto-3g")
 
-    V = forte2.ints.coulomb_4c(system.basis)
+    V = forte2.integrals.coulomb_4c(system)
 
     # Test random integrals against the reference values
     assert V[4, 5, 0, 4] == approx(0.011203183573992602)
@@ -52,7 +52,7 @@ def test_two_electron_integrals_by_shell_slices():
 
     system = forte2.System(xyz=xyz, basis_set="sto-3g")
 
-    Vref = forte2.ints.coulomb_4c(system.basis)
+    Vref = forte2.integrals.coulomb_4c(system)
 
     # generate random slices for each of the four shells
     lo = 0
@@ -85,7 +85,7 @@ def test_two_electron_integral_diagonal():
     """
     system = forte2.System(xyz=xyz, basis_set="sto-3g")
 
-    Vref = forte2.ints.coulomb_4c(system.basis)
+    Vref = forte2.integrals.coulomb_4c(system)
     nbf = system.nbf
     Vref = np.diag(Vref.reshape((nbf**2,) * 2))
 
@@ -117,11 +117,11 @@ def test_two_electron_integral_cholesky():
     xyz = "Pd 0 0 0"
     system = forte2.System(xyz=xyz, basis_set="sto-3g", minao_basis_set=None)
 
-    Vref = forte2.ints.coulomb_4c(system.basis)
+    Vref = forte2.integrals.coulomb_4c(system)
     nbf = system.nbf
     Vref = Vref.reshape((nbf**2,) * 2)
 
-    chol = forte2.integrals.CholeskyIntegrals(system.basis, memory=2000, delta=1e-7)
+    chol = forte2.integrals.CholeskyIntegrals(system.basis, memory=2000, delta=1e-4)
     L = chol._compute()
     Vchol = L.T @ L
-    assert np.linalg.norm(Vchol - Vref) < 1e-6
+    assert np.linalg.norm(Vchol - Vref) < 1e-3


### PR DESCRIPTION
This PR implements an algorithm that computes the Cholesky-decomposed ERIs in-core in a memory-friendly manner.

To do so, two new integral routines are needed: one that computes the diagonals of the ERIs, i.e. ( p q | p q ), and one that computes a row of ERIs, ( [p] [q] | r s ), where [p] and [q] are fixed, and r, s are free. 

The second integral routine will be called approximately 5 * nbasis times, so it needs to be quite optimized. 

To that end, we (1) async-parallelize it, (2) exploit the permutational symmetry of r, s, so the shells are looped in an upper triangular way, and then the lower triangular is filled in without calling the integral engine.

This is still fairly slow for anything above ~60 basis functions, especially for heavily contracted basis sets like ANO-R0, so there's definitely room for improvement.