### PR TITLE
fix: more informative exceptions for negative active space electrons

### DIFF
--- a/forte2/api/ci_api.cc
+++ b/forte2/api/ci_api.cc
@@ -34,9 +34,8 @@ void export_ci_strings_api(nb::module_& m) {
                     throw nb::value_error("Number of alpha electrons must be non-negative.");
                 if (nb < 0)
                     throw nb::value_error("Number of beta electrons must be non-negative.");
-                new (self)
-                    CIStrings(static_cast<size_t>(na), static_cast<size_t>(nb), symmetry,
-                              std::move(orbital_symmetry), std::move(gas_min), std::move(gas_max));
+                new (self) CIStrings(static_cast<size_t>(na), static_cast<size_t>(nb), symmetry,
+                                     orbital_symmetry, gas_min, gas_max);
             },
             "na"_a, "nb"_a, "symmetry"_a, "orbital_symmetry"_a, "gas_min"_a, "gas_max"_a,
             "Initialize the CIStrings with number of alpha and beta electrons, symmetry, "

--- a/forte2/api/ci_api.cc
+++ b/forte2/api/ci_api.cc
@@ -25,12 +25,22 @@ void export_ci_strings_api(nb::module_& m) {
     nb::bind_vector<std::vector<forte2::Determinant>>(m, "DeterminantVector");
 
     nb::class_<CIStrings>(m, "CIStrings")
-        .def(nb::init<size_t, size_t, int, std::vector<std::vector<int>>, std::vector<int>,
-                      std::vector<int>>(),
-             "na"_a, "nb"_a, "symmetry"_a, "orbital_symmetry"_a, "gas_min"_a, "gas_max"_a,
-             "Initialize the CIStrings with number of alpha and beta electrons, symmetry, "
-             "orbital symmetry, minimum and maximum number of electrons in each GAS space, and "
-             "logging level")
+        .def(
+            "__init__",
+            [](CIStrings* self, Py_ssize_t na, Py_ssize_t nb, int symmetry,
+               std::vector<std::vector<int>> orbital_symmetry, std::vector<int> gas_min,
+               std::vector<int> gas_max) {
+                if (na < 0)
+                    throw nb::value_error("Number of alpha electrons must be non-negative.");
+                if (nb < 0)
+                    throw nb::value_error("Number of beta electrons must be non-negative.");
+                new (self)
+                    CIStrings(static_cast<size_t>(na), static_cast<size_t>(nb), symmetry,
+                              std::move(orbital_symmetry), std::move(gas_min), std::move(gas_max));
+            },
+            "na"_a, "nb"_a, "symmetry"_a, "orbital_symmetry"_a, "gas_min"_a, "gas_max"_a,
+            "Initialize the CIStrings with number of alpha and beta electrons, symmetry, "
+            "orbital symmetry, minimum and maximum number of electrons in each GAS space")
         .def_prop_ro("alfa_address", &CIStrings::alfa_address)
         .def_prop_ro("na", &CIStrings::na)
         .def_prop_ro("nb", &CIStrings::nb)

--- a/forte2/ci/ci.py
+++ b/forte2/ci/ci.py
@@ -153,8 +153,12 @@ class _CIBase:
 
     def _ci_solver_startup(self):
         if self.two_component:
+            _nactel = self.state.nel - self.ncore
+            assert (
+                _nactel >= 0
+            ), f"Number of active electrons {_nactel} must be non-negative."
             self.ci_strings = CIStrings(
-                self.state.nel - self.ncore,
+                _nactel,
                 0,
                 self.state.symmetry,
                 self.active_orbsym,
@@ -162,9 +166,17 @@ class _CIBase:
                 self.state.gas_max,
             )
         else:
+            _nactel_a = self.state.na - self.ncore
+            _nactel_b = self.state.nb - self.ncore
+            assert (
+                _nactel_a >= 0
+            ), f"Number of active α electrons {_nactel_a} must be non-negative."
+            assert (
+                _nactel_b >= 0
+            ), f"Number of active β electrons {_nactel_b} must be non-negative."
             self.ci_strings = CIStrings(
-                self.state.na - self.ncore,
-                self.state.nb - self.ncore,
+                _nactel_a,
+                _nactel_b,
                 self.state.symmetry,
                 self.active_orbsym,
                 self.gas_min,

--- a/forte2/mcopt/mc_optimizer.py
+++ b/forte2/mcopt/mc_optimizer.py
@@ -353,7 +353,8 @@ class MCOptimizer(ActiveSpaceSolver):
         )
 
         logger.log_info1("=" * width)
-        logger.log_info1(f"Orbital optimization converged in {self.iter} iterations.")
+        if self.converged:
+            logger.log_info1(f"Orbital optimization converged in {self.iter} iterations.")
         logger.log_info1(f"Final orbital optimized energy: {self.E_avg:.10f}")
 
         # undo _make_spaces_contiguous

--- a/tests/ci/test_ci_strings.py
+++ b/tests/ci/test_ci_strings.py
@@ -1,4 +1,21 @@
+import pytest
 from forte2 import CIStrings, State, MOSpace
+
+
+def test_ci_strings_input():
+    # negative number of electrons
+    with pytest.raises(ValueError):
+        ci_strings = CIStrings(-1, 0, 0, [[]], [], [])
+
+    with pytest.raises(ValueError):
+        ci_strings = CIStrings(-1, -1, 0, [[]], [], [])
+
+    with pytest.raises(ValueError):
+        ci_strings = CIStrings(1, -1, 0, [[]], [], [])
+
+    # wrong type (list instead of list[list]) for orbital_symmetry
+    with pytest.raises(TypeError):
+        ci_strings = CIStrings(1, 1, 0, [0], [], [])
 
 
 def test_ci_strings_singlet():


### PR DESCRIPTION
This PR does two things:
1. Catches negative active space electron numbers and throws an exception directly in the python `forte2.ci `module
2. Catches negative active space electron numbers and throws an exception in the nanobind `forte2._forte2.CIStrings` constructor.

Number 2 is needed for when `CIStrings` is explicitly used, because the int -> size_t conversion happens silently and an uninformative exception is thrown like below
```
1. __init__(self, na: int, nb: int, symmetry: int, orbital_symmetry: collections.abc.Sequence[collections.abc.Sequence[int]], gas_min: collections.abc.Sequence[int], gas_max: collections.abc.Sequence[int]) -> None 

Invoked with types: forte2._forte2.CIStrings, int, int, int, list, list, list
```