### PR TITLE
fix: x2c runtime param checking

### DIFF
--- a/forte2/x2c/x2c.py
+++ b/forte2/x2c/x2c.py
@@ -71,6 +71,12 @@ class X2CHelper:
             decontract=True,
         )
 
+        self.proj = scipy.linalg.solve(
+            integrals.overlap(self.system, self.xbasis),
+            integrals.overlap(self.system, self.xbasis, self.system.basis),
+            assume_a="pos",
+        )
+
         nbf_decon = len(self.xbasis)
         logger.log_info1(f"Number of decontracted basis functions: {nbf_decon}")
 
@@ -142,12 +148,7 @@ class X2CHelper:
         return h_fw
 
     def _get_projection_matrix(self):
-        proj = scipy.linalg.solve(
-            integrals.overlap(self.system, self.xbasis),
-            integrals.overlap(self.system, self.xbasis, self.system.basis),
-            assume_a="pos",
-        )
-        return proj if self.system.x2c_type == "sf" else block_diag_2x2(proj)
+        return self.proj if self.system.x2c_type == "sf" else block_diag_2x2(self.proj)
 
     def _get_Xorth(self):
         if self.system.x2c_type == "sf":

--- a/forte2/x2c/x2c.py
+++ b/forte2/x2c/x2c.py
@@ -50,11 +50,10 @@ class X2CHelper:
     def __init__(self, system, ortho_thresh=1e-8):
         self.system = system
         self.ortho_thresh = ortho_thresh
-        self.x2c_type = system.x2c_type.lower()
-        assert self.x2c_type in [
+        assert self.system.x2c_type in [
             "sf",
             "so",
-        ], f"Invalid x2c_type: {self.x2c_type}. Must be 'sf' or 'so'."
+        ], f"Invalid x2c_type: {self.system.x2c_type}. Must be 'sf' or 'so'."
         self.snso_type = system.snso_type.lower() if system.snso_type else None
         if self.snso_type is not None:
             assert self.snso_type in [
@@ -71,11 +70,9 @@ class X2CHelper:
             system.geom_helper,
             decontract=True,
         )
-        self.proj = self._get_projection_matrix()
 
         nbf_decon = len(self.xbasis)
         logger.log_info1(f"Number of decontracted basis functions: {nbf_decon}")
-        self.nbf = nbf_decon if self.system.x2c_type == "sf" else nbf_decon * 2
 
         self.S = integrals.overlap(self.system, self.xbasis)
         self.T = integrals.kinetic(self.system, self.xbasis)
@@ -119,12 +116,12 @@ class X2CHelper:
         _, Xorthm1 = self._get_Xorth()
         h_fw = Xorthm1.conj().T @ h_fw @ Xorthm1
 
-        if self.x2c_type.lower() == "so" and self.snso_type is not None:
-            nbf = self.nbf // 2
-            haa = h_fw[:nbf, :nbf]
-            hab = h_fw[:nbf, nbf:]
-            hba = h_fw[nbf:, :nbf]
-            hbb = h_fw[nbf:, nbf:]
+        if self.system.x2c_type.lower() == "so" and self.snso_type is not None:
+            north = self._get_northo() // 2
+            haa = h_fw[:north, :north]
+            hab = h_fw[:north, north:]
+            hba = h_fw[north:, :north]
+            hbb = h_fw[north:, north:]
             # the pauli representation of a spin-dependent operator.
             # h0 is spin-free, h1-3 are spin-dependent
             # SNSO is applied to the spin-dependent parts only.
@@ -139,7 +136,8 @@ class X2CHelper:
             h_fw = np.block([[h0 + h3, h1 - 1j * h2], [h1 + 1j * h2, h0 - h3]])
 
         # project back to the contracted basis
-        h_fw = self.proj.conj().T @ h_fw @ self.proj
+        proj = self._get_projection_matrix()
+        h_fw = proj.conj().T @ h_fw @ proj
 
         return h_fw
 
@@ -179,7 +177,7 @@ class X2CHelper:
         return S, T, V, W
 
     def _solve_dirac_eq(self, S, T, V, W):
-        dtype = np.float64 if self.x2c_type == "sf" else np.complex128
+        dtype = np.float64 if self.system.x2c_type == "sf" else np.complex128
         north = self._get_northo()
         D = np.zeros((north * 2,) * 2, dtype=dtype)
         M = np.zeros((north * 2,) * 2, dtype=dtype)

--- a/forte2/x2c/x2c.py
+++ b/forte2/x2c/x2c.py
@@ -117,11 +117,11 @@ class X2CHelper:
         h_fw = Xorthm1.conj().T @ h_fw @ Xorthm1
 
         if self.system.x2c_type.lower() == "so" and self.snso_type is not None:
-            north = self._get_northo() // 2
-            haa = h_fw[:north, :north]
-            hab = h_fw[:north, north:]
-            hba = h_fw[north:, :north]
-            hbb = h_fw[north:, north:]
+            nbf = len(self.xbasis)
+            haa = h_fw[:nbf, :nbf]
+            hab = h_fw[:nbf, nbf:]
+            hba = h_fw[nbf:, :nbf]
+            hbb = h_fw[nbf:, nbf:]
             # the pauli representation of a spin-dependent operator.
             # h0 is spin-free, h1-3 are spin-dependent
             # SNSO is applied to the spin-dependent parts only.

--- a/tests/mcopt/test_casscf_so.py
+++ b/tests/mcopt/test_casscf_so.py
@@ -1,3 +1,4 @@
+import pytest
 from forte2 import (
     System,
     AVAS,
@@ -8,7 +9,6 @@ from forte2 import (
 )
 from forte2.scf.scf_utils import convert_coeff_spatial_to_spinor
 from forte2.data import EH_TO_WN
-from forte2.helpers.comparisons import approx_loose
 
 
 def test_casscf_so():
@@ -45,4 +45,4 @@ def test_casscf_so():
     ci = RelCI(nel=35, nroots=6, core_orbitals=28, active_orbitals=8)(rhf)
     ci.run()
 
-    assert (ci.E[4] - ci.E[3]) * EH_TO_WN == approx_loose(3416.391762052979)
+    assert (ci.E[4] - ci.E[3]) * EH_TO_WN == pytest.approx(3416.391762052979, abs=1e-4)

--- a/tests/mcopt/test_casscf_so.py
+++ b/tests/mcopt/test_casscf_so.py
@@ -1,0 +1,48 @@
+from forte2 import (
+    System,
+    AVAS,
+    ROHF,
+    MCOptimizer,
+    State,
+    RelCI,
+)
+from forte2.scf.scf_utils import convert_coeff_spatial_to_spinor
+from forte2.data import EH_TO_WN
+from forte2.helpers.comparisons import approx_loose
+
+
+def test_casscf_so():
+    xyz = """
+    Br 0 0 0
+    """
+
+    system = System(
+        xyz=xyz,
+        basis_set="decon-cc-pVTZ",
+        auxiliary_basis_set="cc-pVQZ-JKFIT",
+        x2c_type="sf",
+    )
+
+    rhf = ROHF(charge=0, ms=0.5)(system)
+    avas = AVAS(
+        selection_method="separate",
+        num_active_docc=3,
+        num_active_uocc=0,
+        subspace=["Br(4s)", "Br(4p)"],
+    )(rhf)
+    mc = MCOptimizer(
+        states=State(nel=35, multiplicity=2, ms=0.5),
+        nroots=3,
+    )(avas)
+    mc.run()
+
+    system.two_component = True
+
+    C_2c = convert_coeff_spatial_to_spinor(system, mc.C)
+    rhf.C = C_2c
+    system.x2c_type = "so"
+    system.snso_type = "row-dependent"
+    ci = RelCI(nel=35, nroots=6, core_orbitals=28, active_orbitals=8)(rhf)
+    ci.run()
+
+    assert (ci.E[4] - ci.E[3]) * EH_TO_WN == approx_loose(3416.391762052979)


### PR DESCRIPTION
This PR unifies X2C param checking at runtime so that only the current system object is used to grab X2C options.