### PR TITLE
fix: integer overflow for large tensors

### DIFF
--- a/forte2/ci/ci_string_address.cc
+++ b/forte2/ci/ci_string_address.cc
@@ -1,5 +1,5 @@
 #include "ci_string_address.h"
-#include "helpers/sum.hpp"
+#include "helpers/numeric.hpp"
 
 namespace forte2 {
 

--- a/forte2/ci/ci_string_class.cc
+++ b/forte2/ci/ci_string_class.cc
@@ -1,6 +1,5 @@
 #include "determinant.h"
 #include "ci_string_class.h"
-// #include "helpers/sum.hpp"
 
 namespace forte2 {
 StringClass::StringClass(size_t symmetry, const std::vector<std::vector<int>>& orbital_symmetry,

--- a/forte2/helpers/ndarray.h
+++ b/forte2/helpers/ndarray.h
@@ -9,6 +9,8 @@
 #include <nanobind/nanobind.h>
 #include <nanobind/ndarray.h>
 
+#include <helpers/numeric.hpp>
+
 namespace nb = nanobind;
 
 // Aliases for ndarray types used in forte2
@@ -113,7 +115,7 @@ nb::ndarray<Type, T, nb::ndim<N>> make_ndarray(std::unique_ptr<std::vector<T>> v
 template <typename Type, typename T, int N, typename Order = void>
 auto make_ndarray(const std::array<size_t, N>& shape) {
     // compute the number of elements in the array
-    const auto size = std::accumulate(shape.begin(), shape.end(), 1, std::multiplies<size_t>());
+    const auto size = forte2::math::product(shape);
 
     // allocate a vector of the right size
     T* array_ptr = new T[size];
@@ -149,7 +151,7 @@ auto make_zeros(const std::array<size_t, N>& shape) {
 
     // get the data pointer and size
     auto data_ptr = array.data();
-    auto size = std::accumulate(shape.begin(), shape.end(), 1, std::multiplies<size_t>());
+    auto size = forte2::math::product(shape);
 
     // fill the data with zeros
     std::fill(data_ptr, data_ptr + size, static_cast<T>(0));

--- a/forte2/helpers/ndarray.h
+++ b/forte2/helpers/ndarray.h
@@ -9,7 +9,7 @@
 #include <nanobind/nanobind.h>
 #include <nanobind/ndarray.h>
 
-#include <helpers/numeric.hpp>
+#include "helpers/numeric.hpp"
 
 namespace nb = nanobind;
 

--- a/forte2/helpers/numeric.hpp
+++ b/forte2/helpers/numeric.hpp
@@ -11,5 +11,11 @@ template <typename Container> auto sum(const Container& c) -> typename Container
     return std::accumulate(std::begin(c), std::end(c), T(0));
 }
 
+template <typename Container> auto product(const Container& c) -> typename Container::value_type {
+    using T = typename Container::value_type;
+    return std::accumulate(std::begin(c), std::end(c), T(1), std::multiplies<T>());
+}
+
+
 } // namespace math
 } // namespace forte2


### PR DESCRIPTION
A subtle initialization bug in the allocation of `nb::ndarray`'s causes some large tensors to not be allocated correctly.

The old code for calculating the total size was:
```
const auto size = std::accumulate(shape.begin(), shape.end(), 1, std::multiplies<size_t>());
```
Let's say `std::array<std::size_t, 3> shape = {4740, 840, 840}`, but the returned `size` is `18446744072759128320`, not the expected `3344544000`. This is because the `1` in the `std::accumulate` is of type `int`, so `std::accumulate` internally uses an `int` accumulator. At the second multiplication, 3981600 * 840 (both still representable as `int`'s, is correctly multiplied by the `std::multiplies<size_t>` to give the expected answer 3344544000, but upon return to the accumulator, integer overflow happens, giving 3344544000 - 2^32 = -950423296. Upon return from `std::accumulate`, another type conversion to `std::size_t` happens, which through two's complement gives (2^64-1) -950423295 + 1 = 18446744072759128320.

The correct way to do this would have been
```
const auto size = std::accumulate(shape.begin(), shape.end(), std::size_t{1}, std::multiplies<size_t>());
```
or 
```
const auto size = std::accumulate(shape.begin(), shape.end(), 1zu, std::multiplies<size_t>());
```
Instead, a new generic type-safe `forte2::math::product` function has been created in `helpers/numeric.hpp`.