### PR TITLE
fix: pin Eigen version

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -13,7 +13,7 @@ dependencies:
     - cmake=3.26
     - numpy
     - scipy
-    - eigen
+    - eigen=3.4.0
     - boost
     - scikit-build-core>=0.10
     - pytest


### PR DESCRIPTION
Eigen was just updated to 5.0.1, but this apparently breaks compatibility with some of our dependencies. While that gets sorted out, this PR pins the Eigen version to the old 3.4.0.