### PR TITLE
fix: GASSCF and GHF tests

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -47,7 +47,7 @@ jobs:
         pip list
 
     - name: Run Forte2 pytest tests
-      if: steps.compile-forte2.outcome == success() && !cancelled()
+      if: ${{ steps.compile-forte2.outcome == 'success' && !cancelled() }}
       run: |
         conda activate forte
         cd $HOME/work/forte2/forte2/tests

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -51,7 +51,7 @@ jobs:
       run: |
         conda activate forte
         cd $HOME/work/forte2/forte2/tests
-        if [[ "${{ github.event_name }}" == "schedule" || "${{ github.event_name }}" == "merge_group" ]]; then
+        if [[ "${{ github.event_name }}" == "schedule" || "${{ github.event_name }}" == "merge_group" || "${{github.event_name}}" == "pull_request"]]; then
           pytest -v --cov --cov-branch --cov-report=xml
         else
           pytest -v -m "not slow" --cov --cov-branch --cov-report=xml

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -47,11 +47,11 @@ jobs:
         pip list
 
     - name: Run Forte2 pytest tests
-      if: steps.compile-forte2.outcome == 'success' && '!cancelled()'
+      if: steps.compile-forte2.outcome == success() && !cancelled()
       run: |
         conda activate forte
         cd $HOME/work/forte2/forte2/tests
-        if [ "${{ github.event_name }}" == "schedule" ]; then
+        if [[ "${{ github.event_name }}" == "schedule" || "${{ github.event_name }}" == "merge_group" ]]; then
           pytest -v --cov --cov-branch --cov-report=xml
         else
           pytest -v -m "not slow" --cov --cov-branch --cov-report=xml

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -3,6 +3,7 @@ name: build
 on: 
   push:
   pull_request:
+    types: [opened, synchronize, reopened, labeled, unlabeled]
   schedule:
     - cron: '30 15 * * *'
   merge_group:
@@ -19,7 +20,6 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-latest, ubuntu-22.04, macos-latest, ubuntu-24.04-arm, ubuntu-22.04-arm]
-
 
     steps:
     - name: Checkout code
@@ -51,7 +51,7 @@ jobs:
       run: |
         conda activate forte
         cd $HOME/work/forte2/forte2/tests
-        if [[ "${{ github.event_name }}" == "schedule" || "${{ github.event_name }}" == "merge_group" || "${{github.event_name}}" == "pull_request" ]]; then
+        if [[ "${{ github.event_name }}" == "schedule" || "${{ github.event_name }}" == "merge_group" || ( "${{ github.event_name }}" == "pull_request" && "${{ contains(github.event.pull_request.labels.*.name, 'ready') }}" == "true" ) ]]; then
           pytest -v --cov --cov-branch --cov-report=xml
         else
           pytest -v -m "not slow" --cov --cov-branch --cov-report=xml

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -51,7 +51,7 @@ jobs:
       run: |
         conda activate forte
         cd $HOME/work/forte2/forte2/tests
-        if [[ "${{ github.event_name }}" == "schedule" || "${{ github.event_name }}" == "merge_group" || "${{github.event_name}}" == "pull_request"]]; then
+        if [[ "${{ github.event_name }}" == "schedule" || "${{ github.event_name }}" == "merge_group" || "${{github.event_name}}" == "pull_request" ]]; then
           pytest -v --cov --cov-branch --cov-report=xml
         else
           pytest -v -m "not slow" --cov --cov-branch --cov-report=xml

--- a/tests/mcopt/test_gasscf_active_frozen.py
+++ b/tests/mcopt/test_gasscf_active_frozen.py
@@ -7,7 +7,7 @@ from forte2.helpers.comparisons import approx
 @pytest.mark.slow
 def test_gasscf_ch4_active_frozen_1s():
     erhf = -40.19845141292726
-    emcscf = -29.570492567892
+    emcscf = -29.5706974100
 
     xyz = """
     C            0.052417904862     0.008091170764     0.039717608738
@@ -30,9 +30,7 @@ def test_gasscf_ch4_active_frozen_1s():
         State(nel=10, multiplicity=1, ms=0.0, gas_min=[1], gas_max=[1]),
         active_orbitals=[[0], [1, 2, 3, 4, 5, 6, 7, 8]],
         active_frozen_orbitals=[0],
-        econv=1e-8,
-        gconv=1e-7,
-        maxiter=100,
+        maxiter=500,
     )(rhf)
     mc.run()
 
@@ -66,8 +64,6 @@ def test_gasscf_ch4_active_frozen_1s_highest_active():
         State(nel=10, multiplicity=1, ms=0.0, gas_min=[1], gas_max=[1]),
         active_orbitals=[[0], [1, 2, 3, 4, 5, 6, 7, 8]],
         active_frozen_orbitals=[0, 8],
-        econv=1e-8,
-        gconv=1e-7,
         maxiter=100,
     )(rhf)
     mc.run()
@@ -79,7 +75,7 @@ def test_gasscf_ch4_active_frozen_1s_highest_active():
 @pytest.mark.slow
 def test_gasscf_ch4_active_frozen_1s_highest_active_noncontiguous():
     erhf = -40.19845141292726
-    emcscf = -29.544266400483
+    emcscf = -29.5444113658
 
     xyz = """
     C            0.052417904862     0.008091170764     0.039717608738
@@ -102,9 +98,7 @@ def test_gasscf_ch4_active_frozen_1s_highest_active_noncontiguous():
         State(nel=10, multiplicity=1, ms=0.0, gas_min=[1], gas_max=[1]),
         active_orbitals=[[0], [1, 2, 3, 4, 5, 6, 7, 9]],
         active_frozen_orbitals=[0, 9],
-        econv=1e-9,
-        gconv=1e-9,
-        maxiter=200,
+        maxiter=500,
     )(rhf)
     mc.run()
 

--- a/tests/mcopt/test_gasscf_simple.py
+++ b/tests/mcopt/test_gasscf_simple.py
@@ -98,7 +98,7 @@ def test_gasscf_2():
 @pytest.mark.slow
 def test_gasscf_3():
     erhf = -40.21254161940163
-    emcscf = -29.702820676605
+    emcscf = -29.7051233787
 
     xyz = """
     C            0.052417904862     0.008091170764     0.039717608738
@@ -122,7 +122,7 @@ def test_gasscf_3():
         active_orbitals=[[0], [1, 2, 3, 4, 5, 6, 7, 8]],
         econv=1e-8,
         gconv=1e-7,
-        maxiter=100,
+        maxiter=500,
     )(rhf)
     mc.run()
 
@@ -158,3 +158,4 @@ def test_gasscf_5():
 
     assert rhf.E == approx(erhf)
     assert mc.E == approx(emcscf)
+test_gasscf_3()

--- a/tests/mcopt/test_gasscf_simple.py
+++ b/tests/mcopt/test_gasscf_simple.py
@@ -158,4 +158,3 @@ def test_gasscf_5():
 
     assert rhf.E == approx(erhf)
     assert mc.E == approx(emcscf)
-test_gasscf_3()

--- a/tests/mcopt/test_sa_casscf_hf.py
+++ b/tests/mcopt/test_sa_casscf_hf.py
@@ -1,3 +1,5 @@
+import pytest
+
 from forte2 import System, RHF, MCOptimizer, State
 from forte2.helpers.comparisons import approx
 
@@ -34,10 +36,19 @@ def test_sa_casscf_hf():
     assert mc.E_ci[2] == approx(emcscf_root_3)
     assert mc.E_ci[3] == approx(emcscf_root_4)
 
+    # if energy is converged to ~1e-8, properties are converged to ~1e-4
     # transition dipole moment of 0->3 transition
-    assert abs(mc.ci_solver.tdm_per_solver[0][(0, 3)][2]) == approx(1.1357911621720147)
+    assert abs(mc.ci_solver.tdm_per_solver[0][(0, 3)][2]) == pytest.approx(
+        1.1357911621720147, abs=1e-4
+    )
     # transition oscillator strength of 0->3 transition
-    assert mc.ci_solver.fosc_per_solver[0][(0, 3)] == approx(0.4525407586932925)
+    assert mc.ci_solver.fosc_per_solver[0][(0, 3)] == pytest.approx(
+        0.4525407586932925, abs=1e-4
+    )
     # total dipole of state 0, 1
-    assert abs(mc.ci_solver.tdm_per_solver[0][(0, 0)][2]) == approx(0.7244112903260456)
-    assert abs(mc.ci_solver.tdm_per_solver[0][(1, 1)][2]) == approx(0.8239033452222257)
+    assert abs(mc.ci_solver.tdm_per_solver[0][(0, 0)][2]) == pytest.approx(
+        0.7244112903260456, abs=1e-4
+    )
+    assert abs(mc.ci_solver.tdm_per_solver[0][(1, 1)][2]) == pytest.approx(
+        0.8239033452222257, abs=1e-4
+    )

--- a/tests/scf/test_ghf.py
+++ b/tests/scf/test_ghf.py
@@ -59,8 +59,8 @@ def test_ghf_complex_perturbation():
 
 def test_j_adapted_ghf():
     # The two bases should yield the same result
-    eref = -399.12328000812687
-    s2ref = 0.7547419587209125
+    eref = -398.723752737950
+    s2ref = 1.0001601212478493
     xyz = """
     S 0 0 0
     H 0 0 1.1"""
@@ -71,7 +71,7 @@ def test_j_adapted_ghf():
         x2c_type="so",
         snso_type=None,
     )
-    scf = GHF(charge=0, j_adapt=False)(system)
+    scf = GHF(charge=1, j_adapt=False)(system)
     scf.run()
     assert scf.E == approx(eref)
     assert scf.S2 == approx(s2ref)
@@ -83,7 +83,7 @@ def test_j_adapted_ghf():
         x2c_type="so",
         snso_type=None,
     )
-    scf = GHF(charge=0, j_adapt=True)(system)
+    scf = GHF(charge=1, j_adapt=True)(system)
     scf.run()
     assert scf.E == approx(eref)
     assert scf.S2 == approx(s2ref)


### PR DESCRIPTION
Previously the long GASSCF tests didn't fully converge due to the RMS(grad) conditions passing too early (fixed in #143). Now they require more iterations (that's ok because they are slow tests), and this PR updates the reference GASSCF energies. 

A GHF test for a radical (doublet) is changed to a singlet, since GHF is known to be unstable for open-shell species.

This PR also updates the GitHub Actions config, making sure that the slow tests are run when entering the merge queue and when the "ready" label is added to a PR.