### PR TITLE
feat: SelectedCI 2-RDMs

### DIFF
--- a/forte2/_forte2/__init__.pyi
+++ b/forte2/_forte2/__init__.pyi
@@ -333,13 +333,25 @@ class SelectedCIHelper:
         """
 
     def a_1rdm(self, left_root: int, right_root: int) -> Annotated[NDArray[numpy.float64], dict(shape=(None, None))]:
-        """Compute alpha-spin 1-RDM between two roots"""
+        """Compute the alpha-spin 1-RDM between two roots"""
 
     def b_1rdm(self, left_root: int, right_root: int) -> Annotated[NDArray[numpy.float64], dict(shape=(None, None))]:
-        """Compute beta-spin 1-RDM between two roots"""
+        """Compute the beta-spin 1-RDM between two roots"""
 
     def sf_1rdm(self, left_root: int, right_root: int) -> Annotated[NDArray[numpy.float64], dict(shape=(None, None))]:
-        """Compute spin-free 1-RDM between two roots"""
+        """Compute the spin-free 1-RDM between two roots"""
+
+    def aa_2rdm(self, left_root: int, right_root: int) -> Annotated[NDArray[numpy.float64], dict(shape=(None, None))]:
+        """Compute the alpha-alpha 2-RDM between two roots"""
+
+    def bb_2rdm(self, left_root: int, right_root: int) -> Annotated[NDArray[numpy.float64], dict(shape=(None, None))]:
+        """Compute the beta-beta 2-RDM between two roots"""
+
+    def ab_2rdm(self, left_root: int, right_root: int) -> Annotated[NDArray[numpy.float64], dict(shape=(None, None, None, None))]:
+        """Compute the alpha-beta 2-RDM between two roots"""
+
+    def sf_2rdm(self, left_root: int, right_root: int) -> Annotated[NDArray[numpy.float64], dict(shape=(None, None, None, None))]:
+        """Compute the spin-free 2-RDM between two roots"""
 
     def dets(self) -> list[Determinant]:
         """Return the determinants in the variational space"""

--- a/forte2/api/sci_api.cc
+++ b/forte2/api/sci_api.cc
@@ -50,11 +50,19 @@ void export_sci_helper_api(nb::module_& m) {
         .def("compute_spin2", &SelectedCIHelper::compute_spin2,
              "Compute the expectation value of S^2 for each root and return as a list")
         .def("a_1rdm", &SelectedCIHelper::compute_a_1rdm, "left_root"_a, "right_root"_a,
-             "Compute alpha-spin 1-RDM between two roots")
+             "Compute the alpha-spin 1-RDM between two roots")
         .def("b_1rdm", &SelectedCIHelper::compute_b_1rdm, "left_root"_a, "right_root"_a,
-             "Compute beta-spin 1-RDM between two roots")
+             "Compute the beta-spin 1-RDM between two roots")
         .def("sf_1rdm", &SelectedCIHelper::compute_sf_1rdm, "left_root"_a, "right_root"_a,
-             "Compute spin-free 1-RDM between two roots")
+             "Compute the spin-free 1-RDM between two roots")
+        .def("aa_2rdm", &SelectedCIHelper::compute_aa_2rdm, "left_root"_a, "right_root"_a,
+             "Compute the alpha-alpha 2-RDM between two roots")
+        .def("bb_2rdm", &SelectedCIHelper::compute_bb_2rdm, "left_root"_a, "right_root"_a,
+             "Compute the beta-beta 2-RDM between two roots")
+        .def("ab_2rdm", &SelectedCIHelper::compute_ab_2rdm, "left_root"_a, "right_root"_a,
+             "Compute the alpha-beta 2-RDM between two roots")
+        .def("sf_2rdm", &SelectedCIHelper::compute_sf_2rdm, "left_root"_a, "right_root"_a,
+             "Compute the spin-free 2-RDM between two roots")
         .def("dets", &SelectedCIHelper::variational_dets,
              "Return the determinants in the variational space")
         .def("ndets", &SelectedCIHelper::num_dets_var,

--- a/forte2/sci/sci.py
+++ b/forte2/sci/sci.py
@@ -1069,9 +1069,11 @@ class SelectedCISolver(CIBase):
         NDArray
             Average spin-free two-particle RDM.
         """
-        raise NotImplementedError(
-            "Average spin-free 2-RDM is not implemented for SelectedCI."
-        )
+        rdm2 = np.zeros((self.norb,) * 4)
+        for i, ci_solver in enumerate(self.sub_solvers):
+            for j in range(ci_solver.nroot):
+                rdm2 += ci_solver.make_sf_2rdm(j) * self.weights[i][j]
+        return rdm2
 
     def set_ints(self, scalar, oei, tei):
         """

--- a/forte2/sci/sci.py
+++ b/forte2/sci/sci.py
@@ -199,18 +199,15 @@ class _SelectedCISingleStateSolver:
             # These are the PT2 corrections due to the new perturbative determinants added in this cycle
             self.ept2_pt = self.sci_helper.ept2_pt()
 
-
             summary = "\nSummary of selection:"
-            summary += (
-                f"\n  {'Initial # of variational determinants:':<40}{old_ndets}"
-            )
+            summary += f"\n  {'Initial # of variational determinants:':<40}{old_ndets}"
             summary += (
                 f"\n  {'Variational added:':<40}{self.sci_helper.num_new_dets_var()}"
             )
-            summary += f"\n  {'Total variational determinants:':<40}{self.sci_helper.ndets()}"
             summary += (
-                f"\n  {'Perturbatively included:':<40}{self.sci_helper.num_new_dets_pt2()}"
+                f"\n  {'Total variational determinants:':<40}{self.sci_helper.ndets()}"
             )
+            summary += f"\n  {'Perturbatively included:':<40}{self.sci_helper.num_new_dets_pt2()}"
             summary += (
                 f"\n  {'Selection time:':<40}{self.sci_helper.selection_time():.3f} s\n"
             )
@@ -278,7 +275,8 @@ class _SelectedCISingleStateSolver:
                 break
         else:
             logger.log(
-                f"Selected CI did not converge in {self.sci_params.maxcycle} cycles.", self.log_level
+                f"Selected CI did not converge in {self.sci_params.maxcycle} cycles.",
+                self.log_level,
             )
 
         # final selection to update var' and pt2 contributions with the final CI coefficients
@@ -311,12 +309,8 @@ class _SelectedCISingleStateSolver:
         self.spin2_var = self.sci_helper.compute_spin2()
 
         summary = "\nSummary of selection:"
-        summary += (
-            f"\n  Variational added:     {self.sci_helper.num_new_dets_var()}"
-        )
-        summary += (
-            f"\n  Perturbative included: {self.sci_helper.num_new_dets_pt2()}"
-        )
+        summary += f"\n  Variational added:     {self.sci_helper.num_new_dets_var()}"
+        summary += f"\n  Perturbative included: {self.sci_helper.num_new_dets_pt2()}"
         summary += f"\n  Total determinants:    {self.sci_helper.ndets()}"
         summary += (
             f"\n  Selection time:        {self.sci_helper.selection_time():.3f} s\n"
@@ -810,6 +804,29 @@ class _SelectedCISingleStateSolver:
         if right_root is None:
             right_root = left_root
         return self.sci_helper.sf_1rdm(left_root, right_root)
+
+    def make_sf_2rdm(self, left_root: int, right_root: int | None = None):
+        """
+        Make the spin-free two-particle RDM for two CI roots.
+
+        Parameters
+        ----------
+        left_root : int
+            the CI root for the bra state.
+        right_root : int | None, optional (default=left_root)
+            the CI root for the ket state.
+
+        Returns
+        -------
+        NDArray
+            Spin-free two-particle RDM in chemist's notation.
+        """
+        assert (
+            not self.two_component
+        ), "make_sf_2rdm is only available for non-relativistic CI."
+        if right_root is None:
+            right_root = left_root
+        return self.sci_helper.sf_2rdm(left_root, right_root)
 
     def compute_natural_occupation_numbers(self):
         """

--- a/forte2/sci/sci.py
+++ b/forte2/sci/sci.py
@@ -342,6 +342,9 @@ class _SelectedCISingleStateSolver:
             )
         logger.log(table.footer(), self.log_level)
 
+        if self.do_test_rdms:
+            self._test_rdms()
+
         self.executed = True
 
         return self
@@ -628,14 +631,6 @@ class _SelectedCISingleStateSolver:
                     self.log_level,
                 )
 
-        # if not self.two_component:
-        #     h_tot, h_aabb, h_aaaa, h_bbbb = self.ci_sigma_builder.avg_build_time()
-        #     logger.log("\nAverage CI Sigma Builder time summary:", self.log_level)
-        #     logger.log(f"h_aabb time:    {h_aabb:.3f} s/build", self.log_level)
-        #     logger.log(f"h_aaaa time:    {h_aaaa:.3f} s/build", self.log_level)
-        #     logger.log(f"h_bbbb time:    {h_bbbb:.3f} s/build", self.log_level)
-        #     logger.log(f"total time:     {h_tot:.3f} s/build\n", self.log_level)
-
     def _do_exact_diagonalization(self):
         logger.log("Using CI algorithm: Exact Diagonalization", self.log_level)
 
@@ -687,14 +682,9 @@ class _SelectedCISingleStateSolver:
             root_rdms["rdm2_ab"] = rdm2_ab
             root_rdms["rdm2_bb"] = rdm2_bb
 
-            rdm2_aa_full, _, rdm2_bb_full = self.make_sd_2rdm(root)
             # Convert to full-dimension RDMs
-            root_rdms["rdm2_aa_full"] = cpp_helpers.packed_tensor4_to_tensor4(
-                rdm2_aa_full
-            )
-            root_rdms["rdm2_bb_full"] = cpp_helpers.packed_tensor4_to_tensor4(
-                rdm2_bb_full
-            )
+            root_rdms["rdm2_aa_full"] = cpp_helpers.packed_tensor4_to_tensor4(rdm2_aa)
+            root_rdms["rdm2_bb_full"] = cpp_helpers.packed_tensor4_to_tensor4(rdm2_bb)
 
             root_rdms["rdm2_sf"] = self.make_sf_2rdm(root)
 
@@ -722,7 +712,7 @@ class _SelectedCISingleStateSolver:
                 f"CI energy from RDMs:           {rdms_energy:.12f} Eh", self.log_level
             )
             assert np.isclose(
-                self.E[root], rdms_energy
+                self.e_var[root], rdms_energy
             ), f"CI energy {self.E[root]} Eh does not match RDMs energy {rdms_energy} Eh"
 
             rdms_energy = (
@@ -736,7 +726,7 @@ class _SelectedCISingleStateSolver:
                 f"CI energy from expanded RDMs:  {rdms_energy:.12f} Eh", self.log_level
             )
 
-            assert self.E[root] == approx(rdms_energy)
+            assert self.e_var[root] == approx(rdms_energy)
 
             rdms_energy = (
                 self.ints.E
@@ -751,7 +741,7 @@ class _SelectedCISingleStateSolver:
                 f"CI energy from spin-free RDMs: {rdms_energy:.12f} Eh", self.log_level
             )
 
-            assert self.E[root] == approx(rdms_energy)
+            assert self.e_var[root] == approx(rdms_energy)
 
             logger.log(
                 f"RDMs for root {root} validated successfully.\n", self.log_level
@@ -781,6 +771,32 @@ class _SelectedCISingleStateSolver:
         a = self.sci_helper.a_1rdm(left_root, right_root)
         b = self.sci_helper.b_1rdm(left_root, right_root)
         return a, b
+
+    def make_sd_2rdm(self, left_root: int, right_root: int | None = None):
+        r"""
+        Make the spin-dependent two-particle RDM for two CI roots.
+
+        Parameters
+        ----------
+        left_root : int
+            the CI root for the bra state.
+        right_root : int | None, optional (default=left_root)
+            the CI root for the ket state.
+
+        Returns
+        -------
+        tuple[NDArray, NDArray, NDArray]:
+            Spin-dependent two-particle RDMs (aa, ab, bb).
+        """
+        assert (
+            not self.two_component
+        ), "make_sd_2rdm is only available for non-relativistic CI."
+        if right_root is None:
+            right_root = left_root
+        aa = self.sci_helper.aa_2rdm(left_root, right_root)
+        ab = self.sci_helper.ab_2rdm(left_root, right_root)
+        bb = self.sci_helper.bb_2rdm(left_root, right_root)
+        return aa, ab, bb
 
     def make_sf_1rdm(self, left_root: int, right_root: int | None = None):
         """

--- a/forte2/sci/sci_helper.h
+++ b/forte2/sci/sci_helper.h
@@ -152,6 +152,38 @@ class SelectedCIHelper {
     ///        Gamma[p][q] = gamma(alpha)[p][q] + gamma(beta)[p][q]
     np_matrix compute_sf_1rdm(size_t left_root, size_t right_root) const;
 
+    /// @brief Compute the alpha-alpha two-electron reduced density matrix
+    /// @param left_root The left-hand side root index
+    /// @param right_root The right-hand side root index
+    /// @return The alpha-alpha two-electron reduced density matrix stored in a packed format as
+    ///         Gamma_aa[pq][rs] = <L| a^+_p a^+_q a_s a_r |R> with p>q and r>s
+    /// @note If the number of orbitals is less than 2, a matrix of shape (0, 0) is returned
+    np_matrix compute_aa_2rdm(size_t left_root, size_t right_root) const;
+
+    /// @brief Compute the beta-beta two-electron reduced density matrix
+    /// @param left_root The left-hand side root index
+    /// @param right_root The right-hand side root index
+    /// @return The beta-beta two-electron reduced density matrix stored in a packed format as
+    ///         Gamma_bb[pq][rs] = <L| b^+_p b^+_q b_s b_r |R> with p>q and r>s
+    /// @note If the number of orbitals is less than 2, a matrix of shape (0, 0) is returned
+    np_matrix compute_bb_2rdm(size_t left_root, size_t right_root) const;
+
+    /// @brief Compute the alpha-beta two-electron reduced density matrix
+    /// @param left_root The left-hand side root index
+    /// @param right_root The right-hand side root index
+    /// @return The alpha-beta two-electron reduced density matrix stored as
+    ///         Gamma_ab[p][q][r][s] = <L| a^+_p b^+_q b_s a_r |R> with p,r orbitals of spin alpha
+    ///         and q,s orbitals of spin beta
+    /// @note If the number of orbitals is 0, a tensor of shape (0, 0, 0, 0) is returned
+    np_tensor4 compute_ab_2rdm(size_t left_root, size_t right_root) const;
+
+    /// @brief Compute the spin-free two-electron reduced density matrix
+    /// @param left_root The left-hand side root index
+    /// @param right_root The right-hand side root index
+    /// @return The spin-free two-electron reduced density matrix stored as
+    ///         Gamma_sf[p][q][r][s] = Gamma_aa[pq][rs] + Gamma_bb[pq][rs] + Gamma_ab[p][r][q][s]
+    np_tensor4 compute_sf_2rdm(size_t left_root, size_t right_root) const;
+
   private:
     // == Class Private Methods ==
     /// @brief Compute the energies of all determinants in the variational space
@@ -189,7 +221,8 @@ class SelectedCIHelper {
     /// @brief Select new variational and PT2 determinants using a batch approach
     /// @param V_map The map to accumulate variational determinants and their contributions
     /// @param PT_map The map to accumulate PT2 determinants and their contributions
-    /// @param V_coeffs The vector to accumulate the coefficients of the variational determinants
+    /// @param V_coeffs The vector to accumulate the coefficients of the variational
+    /// determinants
     /// @param PT_coeffs The vector to accumulate the coefficients of the PT2 determinants
     /// @param var_threshold The threshold for variational selection
     /// @param pt2_threshold The threshold for PT2 selection

--- a/forte2/sci/sci_helper_sigma_build.cc
+++ b/forte2/sci/sci_helper_sigma_build.cc
@@ -3,6 +3,7 @@
 #include "helpers/ndarray.h"
 #include "helpers/np_vector_functions.h"
 #include "helpers/np_matrix_functions.h"
+#include "helpers/spin.h"
 
 #include <future>
 
@@ -12,7 +13,8 @@ namespace forte2 {
 
 namespace {
 
-// A helper function to run a loop in parallel over a given number of indices. The work function is called with the index as argument.
+// A helper function to run a loop in parallel over a given number of indices. The work function is
+// called with the index as argument.
 template <typename WorkFn>
 void run_parallel_indices(size_t count, size_t num_threads, WorkFn&& work) {
     if (num_threads <= 1 || count == 0) {
@@ -94,11 +96,11 @@ void SelectedCIHelper::find_matching_dets(std::span<double> basis, std::span<dou
         for (size_t jj{jstart}; jj < jend; ++jj) {
             const auto idx_j = list.sorted_dets_second_string(jj);
             if (const auto it = i_map.find(idx_j); it != i_map.end()) {
-                // NOTE: when find_matching_dets is called from different threads, 
+                // NOTE: when find_matching_dets is called from different threads,
                 // this increment is contention-free, because each thread is working
-                // on its own alpha string (i), and the sigma updates are on disjoint sets of determinants
-                // because they have different alpha strings
-                // Same logic applies to the other branch of this if statement
+                // on its own alpha string (i), and the sigma updates are on disjoint sets of
+                // determinants because they have different alpha strings Same logic applies to the
+                // other branch of this if statement
                 sigma[it->second] += int_sign * basis[det_permutation[jj]];
             }
         }
@@ -222,7 +224,7 @@ void SelectedCIHelper::H2ab(std::span<double> basis, std::span<double> sigma) co
                             const double sign = sign_p * sign_q * sign_r * sign_s;
                             // Check if the determinant with the new beta string exists
                             if (const auto it = i_map.find(k); it != i_map.end()) {
-                                // See the comment in find_matching_dets about why this increment is 
+                                // See the comment in find_matching_dets about why this increment is
                                 // contention-free when called from different threads
                                 sigma[it->second] += v_pqrs * sign * basis[det_permutation[jj]];
                             }
@@ -324,4 +326,145 @@ np_matrix SelectedCIHelper::compute_sf_1rdm(size_t left_root, size_t right_root)
     return sf_1rdm;
 }
 
+np_matrix SelectedCIHelper::compute_aa_2rdm(size_t left_root, size_t right_root) const {
+    // calculate the number of pairs of orbitals p > q
+    const size_t npairs = (norb_ * (norb_ - 1)) / 2;
+    auto rdm = make_zeros<nb::numpy, double, 2>({npairs, npairs});
+    double* rdm_data = rdm.data();
+
+    const auto first_string_size = ab_list_.first_string_size();
+    const auto& one_hole_first_strings = ab_list_.one_hole_first_strings();
+    // Loop over all unique alpha strings
+    for (size_t i{0}; i < first_string_size; ++i) {
+        const auto& sublist = ab_list_.two_hole_string_list()[i];
+        for (const auto& [p, q, hole_idx, sign_pq] : sublist) { // (p < q)
+            const size_t pq = pair_index_gt(p, q);
+            const auto& inv_sublist = ab_list_.two_hole_string_list_inv()[hole_idx];
+            for (const auto& [r, s, j, sign_rs] : inv_sublist) { // (r < s)
+                const size_t rs = pair_index_gt(r, s);
+                const double sign = sign_pq * sign_rs;
+                rdm_data[pq * npairs + rs] +=
+                    find_matching_dets_1rdm(left_root, right_root, ab_list_, i, j, sign);
+            }
+        }
+    }
+    return rdm;
+}
+
+np_matrix SelectedCIHelper::compute_bb_2rdm(size_t left_root, size_t right_root) const {
+    // calculate the number of pairs of orbitals p > q
+    const size_t npairs = (norb_ * (norb_ - 1)) / 2;
+    auto rdm = make_zeros<nb::numpy, double, 2>({npairs, npairs});
+    double* rdm_data = rdm.data();
+
+    const auto first_string_size = ba_list_.first_string_size();
+    const auto& one_hole_first_strings = ba_list_.one_hole_first_strings();
+    // Loop over all unique alpha strings
+    for (size_t i{0}; i < first_string_size; ++i) {
+        const auto& sublist = ba_list_.two_hole_string_list()[i];
+        for (const auto& [p, q, hole_idx, sign_pq] : sublist) { // (p < q)
+            const size_t pq = pair_index_gt(p, q);
+            const auto& inv_sublist = ba_list_.two_hole_string_list_inv()[hole_idx];
+            for (const auto& [r, s, j, sign_rs] : inv_sublist) { // (r < s)
+                const size_t rs = pair_index_gt(r, s);
+                const double sign = sign_pq * sign_rs;
+                rdm_data[pq * npairs + rs] +=
+                    find_matching_dets_1rdm(left_root, right_root, ba_list_, i, j, sign);
+            }
+        }
+    }
+    return rdm;
+}
+
+np_tensor4 SelectedCIHelper::compute_ab_2rdm(size_t left_root, size_t right_root) const {
+    local_timer timer;
+
+    auto rdm = make_zeros<nb::numpy, double, 4>({norb_, norb_, norb_, norb_});
+    double* rdm_data = rdm.data();
+
+    const auto first_string_size = ab_list_.first_string_size();
+    const auto& det_permutation = ab_list_.det_permutation();
+    // Loop over all unique alpha strings
+    for (size_t i{0}; i < first_string_size; ++i) {
+        const auto& i_map = ab_list_.second_string_to_det_index()[i];
+        const auto& sublist_a = ab_list_.one_hole_first_string_list()[i];
+        for (const auto& [p, hole_idx, sign_p] : sublist_a) {
+            const auto& inv_sublist_a = ab_list_.one_hole_first_string_list_inv()[hole_idx];
+            for (const auto& [q, j, sign_q] : inv_sublist_a) {
+                const auto& [jstart, jend] = ab_list_.range(j);
+                // Loop over all the beta strings with the same alpha string
+                for (size_t jj{jstart}; jj < jend; ++jj) {
+                    const auto idx_j = ab_list_.sorted_dets_second_string(jj);
+                    // Now loop over single excitations in the beta string
+                    const auto& sublist_b = ab_list_.one_hole_second_string_list()[idx_j];
+                    for (const auto& [r, hole_idx_b, sign_r] : sublist_b) {
+                        const auto& inv_sublist_b =
+                            ab_list_.one_hole_second_string_list_inv()[hole_idx_b];
+                        for (const auto& [s, k, sign_s] : inv_sublist_b) {
+                            const double sign = sign_p * sign_q * sign_r * sign_s;
+                            // Check if the determinant with the new beta string exists
+                            if (const auto it = i_map.find(k); it != i_map.end()) {
+                                rdm_data[p * norb3_ + r * norb2_ + q * norb_ + s] +=
+                                    sign * c_[nroots_ * it->second + left_root] *
+                                    c_[nroots_ * det_permutation[jj] + right_root];
+                            }
+                        }
+                    }
+                }
+            }
+        }
+    }
+    return rdm;
+}
+
+np_tensor4 SelectedCIHelper::compute_sf_2rdm(size_t left_root, size_t right_root) const {
+    auto rdm_sf = make_zeros<nb::numpy, double, 4>({norb_, norb_, norb_, norb_});
+
+    if (norb_ < 1) {
+        return rdm_sf; // No 2-RDM for less than 1 orbitals
+    }
+
+    auto rdm_sf_v = rdm_sf.view();
+    // Mixed-spin contribution (1 orbital or more)
+    {
+        auto rdm_ab = compute_ab_2rdm(left_root, right_root);
+        auto rdm_ab_v = rdm_ab.view();
+        for (size_t p{0}; p < norb_; ++p) {
+            for (size_t q{0}; q < norb_; ++q) {
+                for (size_t r{0}; r < norb_; ++r) {
+                    for (size_t s{0}; s < norb_; ++s) {
+                        rdm_sf_v(p, q, r, s) += rdm_ab_v(p, q, r, s) + rdm_ab_v(q, p, s, r);
+                    }
+                }
+            }
+        }
+    }
+
+    if (norb_ < 2) {
+        return rdm_sf; // No same-spin contributions to the 2-RDM for less than 2 orbitals
+    }
+
+    // To reduce the  memory footprint, we compute the aa and bb contributions in a packed
+    // format and one at a time.
+    for (auto spin : {Spin::Alpha, Spin::Beta}) {
+        auto rdm_ss = spin == Spin::Alpha ? compute_aa_2rdm(left_root, right_root)
+                                          : compute_bb_2rdm(left_root, right_root);
+        auto rdm_ss_v = rdm_ss.view();
+        for (size_t p{1}, pq{0}; p < norb_; ++p) {
+            for (size_t q{0}; q < p; ++q, ++pq) { // p > q
+                for (size_t r{1}, rs{0}; r < norb_; ++r) {
+                    for (size_t s{0}; s < r; ++s, ++rs) { // r > s
+                        auto element = rdm_ss_v(pq, rs);
+                        rdm_sf_v(p, q, r, s) += element;
+                        rdm_sf_v(q, p, r, s) -= element;
+                        rdm_sf_v(p, q, s, r) -= element;
+                        rdm_sf_v(q, p, s, r) += element;
+                    }
+                }
+            }
+        }
+    }
+
+    return rdm_sf;
+}
 } // namespace forte2

--- a/forte2/sci/sci_helper_sigma_build.cc
+++ b/forte2/sci/sci_helper_sigma_build.cc
@@ -377,8 +377,6 @@ np_matrix SelectedCIHelper::compute_bb_2rdm(size_t left_root, size_t right_root)
 }
 
 np_tensor4 SelectedCIHelper::compute_ab_2rdm(size_t left_root, size_t right_root) const {
-    local_timer timer;
-
     auto rdm = make_zeros<nb::numpy, double, 4>({norb_, norb_, norb_, norb_});
     double* rdm_data = rdm.data();
 
@@ -404,7 +402,7 @@ np_tensor4 SelectedCIHelper::compute_ab_2rdm(size_t left_root, size_t right_root
                             const double sign = sign_p * sign_q * sign_r * sign_s;
                             // Check if the determinant with the new beta string exists
                             if (const auto it = i_map.find(k); it != i_map.end()) {
-                                rdm_data[p * norb3_ + r * norb2_ + q * norb_ + s] +=
+                                rdm_data[q * norb3_ + r * norb2_ + p * norb_ + s] +=
                                     sign * c_[nroots_ * it->second + left_root] *
                                     c_[nroots_ * det_permutation[jj] + right_root];
                             }

--- a/forte2/sci/sci_helper_sigma_build.cc
+++ b/forte2/sci/sci_helper_sigma_build.cc
@@ -385,6 +385,8 @@ np_tensor4 SelectedCIHelper::compute_ab_2rdm(size_t left_root, size_t right_root
     // Loop over all unique alpha strings
     for (size_t i{0}; i < first_string_size; ++i) {
         const auto& i_map = ab_list_.second_string_to_det_index()[i];
+        // Loop over all single excitations in the alpha string.
+        // a+_q a_p |i_a> -> +/-|j_a>
         const auto& sublist_a = ab_list_.one_hole_first_string_list()[i];
         for (const auto& [p, hole_idx, sign_p] : sublist_a) {
             const auto& inv_sublist_a = ab_list_.one_hole_first_string_list_inv()[hole_idx];
@@ -393,13 +395,17 @@ np_tensor4 SelectedCIHelper::compute_ab_2rdm(size_t left_root, size_t right_root
                 // Loop over all the beta strings with the same alpha string
                 for (size_t jj{jstart}; jj < jend; ++jj) {
                     const auto idx_j = ab_list_.sorted_dets_second_string(jj);
-                    // Now loop over single excitations in the beta string
+                    // Loop over single excitations in the beta string.
+                    // a+_s a_r |j_b> -> +/-|k_b>
                     const auto& sublist_b = ab_list_.one_hole_second_string_list()[idx_j];
                     for (const auto& [r, hole_idx_b, sign_r] : sublist_b) {
                         const auto& inv_sublist_b =
                             ab_list_.one_hole_second_string_list_inv()[hole_idx_b];
                         for (const auto& [s, k, sign_s] : inv_sublist_b) {
                             const double sign = sign_p * sign_q * sign_r * sign_s;
+                            // Here we get (leaving note since this is a bit subtle):
+                            //     <j_a k_b|a+_r a_s a+_q a_p|i_a i_b>
+                            //   = <j_a k_b|a+_q a+_r a_s a_p|i_a i_b> = gamma2(q_a,r_b,p_a,s_b)
                             // Check if the determinant with the new beta string exists
                             if (const auto it = i_map.find(k); it != i_map.end()) {
                                 rdm_data[q * norb3_ + r * norb2_ + p * norb_ + s] +=

--- a/tests/sci/test_sci.py
+++ b/tests/sci/test_sci.py
@@ -2,7 +2,7 @@ import numpy as np
 import pytest
 
 from forte2 import System, State, Determinant, CIStrings
-from forte2.ci.ci import CI
+from forte2.ci import CI
 from forte2.scf import RHF
 from forte2.sci import SelectedCI
 from forte2.helpers.comparisons import approx

--- a/tests/sci/test_sci.py
+++ b/tests/sci/test_sci.py
@@ -74,6 +74,7 @@ def test_sci2():
             num_batches_per_thread=16,
         ),
         nroots=1,
+        do_test_rdms=True,
     )(rhf)
 
     sci.run()
@@ -113,6 +114,7 @@ def test_sci3():
             num_batches_per_thread=16,
         ),
         nroots=4,
+        do_test_rdms=True,
     )(rhf)
 
     sci.run()
@@ -140,6 +142,7 @@ def test_sci4():
         states=State(nel=6, multiplicity=1, ms=0.0),
         active_orbitals=list(range(12)),
         nroots=2,
+        do_test_rdms=True,
         sci_params=SelectedCIParams(
             selection_algorithm="hbci",
             var_threshold=1e-5,
@@ -450,6 +453,7 @@ def test_sci_water_valence_excitation():
         die_if_not_converged=False,
         nroots=2,
         davidson_liu_params=DavidsonLiuParams(e_tol=1e-10, r_tol=1e-5),
+        do_test_rdms=True,
     )(rhf)
     sci.run()
     assert sci.E[0] == pytest.approx(-76.12037086, abs=1e-6)

--- a/tests/sci/test_sci.py
+++ b/tests/sci/test_sci.py
@@ -301,17 +301,14 @@ def test_sci_make_rdms():
     ci.run()
 
     # Test the 1-RDM
-    sf_1rdm = sci.sub_solvers[0].make_sf_1rdm(0)
+    sf_1rdm = sci.make_average_sf_1rdm()
     sf_1rdm_ci = ci.make_average_1rdm()
     assert np.allclose(sf_1rdm, sf_1rdm_ci, atol=1e-8)
 
     # Test the 2-RDM
-    sf_2rdm = sci.sub_solvers[0].make_sf_2rdm(0)
+    sf_2rdm = sci.make_average_sf_2rdm()
     sf_2rdm_ci = ci.make_average_2rdm()
     assert np.allclose(sf_2rdm, sf_2rdm_ci, atol=1e-8)
-
-
-test_sci_make_rdms()
 
 
 def test_sci_semicanonical_final_orbital():

--- a/tests/sci/test_sci.py
+++ b/tests/sci/test_sci.py
@@ -290,6 +290,7 @@ def test_sci_make_rdms():
             selection_algorithm="hbci",
             var_threshold=1e-12,
             pt2_threshold=0.0,
+            guess_dets=[Determinant("22")],
         ),
     )(rhf)
     sci.run()
@@ -299,17 +300,14 @@ def test_sci_make_rdms():
     )(rhf)
     ci.run()
 
+    # Test the 1-RDM
     sf_1rdm = sci.sub_solvers[0].make_sf_1rdm(0)
     sf_1rdm_ci = ci.make_average_1rdm()
     assert np.allclose(sf_1rdm, sf_1rdm_ci, atol=1e-8)
 
+    # Test the 2-RDM
     sf_2rdm = sci.sub_solvers[0].make_sf_2rdm(0)
     sf_2rdm_ci = ci.make_average_2rdm()
-
-    print("SCI 2-RDM:")
-    print(sf_2rdm - sf_2rdm_ci)
-    # print("CI 2-RDM:")
-    # print(sf_2rdm_ci)
     assert np.allclose(sf_2rdm, sf_2rdm_ci, atol=1e-8)
 
 

--- a/tests/sci/test_sci.py
+++ b/tests/sci/test_sci.py
@@ -2,6 +2,7 @@ import numpy as np
 import pytest
 
 from forte2 import System, State, Determinant, CIStrings
+from forte2.ci.ci import CI
 from forte2.scf import RHF
 from forte2.sci import SelectedCI
 from forte2.helpers.comparisons import approx
@@ -276,6 +277,43 @@ def test_sci_make_sf_1rdm():
     assert rdm1.shape == (4, 4)
     assert np.trace(rdm1) == pytest.approx(4.0, abs=1e-8)
     assert sci.E[0] == approx(-2.180967812920)
+
+
+def test_sci_make_rdms():
+    """Test 1- and 2-RDMs from SelectedCI."""
+    rhf = _h4_rhf()
+
+    sci = SelectedCI(
+        states=State(nel=4, multiplicity=1, ms=0.0),
+        active_orbitals=list(range(4)),
+        sci_params=SelectedCIParams(
+            selection_algorithm="hbci",
+            var_threshold=1e-12,
+            pt2_threshold=0.0,
+        ),
+    )(rhf)
+    sci.run()
+
+    ci = CI(
+        states=State(nel=4, multiplicity=1, ms=0.0), active_orbitals=list(range(4))
+    )(rhf)
+    ci.run()
+
+    sf_1rdm = sci.sub_solvers[0].make_sf_1rdm(0)
+    sf_1rdm_ci = ci.make_average_1rdm()
+    assert np.allclose(sf_1rdm, sf_1rdm_ci, atol=1e-8)
+
+    sf_2rdm = sci.sub_solvers[0].make_sf_2rdm(0)
+    sf_2rdm_ci = ci.make_average_2rdm()
+
+    print("SCI 2-RDM:")
+    print(sf_2rdm - sf_2rdm_ci)
+    # print("CI 2-RDM:")
+    # print(sf_2rdm_ci)
+    assert np.allclose(sf_2rdm, sf_2rdm_ci, atol=1e-8)
+
+
+test_sci_make_rdms()
 
 
 def test_sci_semicanonical_final_orbital():


### PR DESCRIPTION
This pull request adds support for computing two-electron reduced density matrices (2-RDMs) in the SelectedCI module, including alpha-alpha, beta-beta, alpha-beta, and spin-free variants. It also introduces corresponding Python bindings and public APIs, implements the average spin-free 2-RDM, and adds thorough tests to ensure correctness. Additionally, some minor code cleanups and docstring improvements are included.
**2-RDM computations are not multithreaded at the moment**.

**New 2-RDM computation features:**

* Implemented methods in `SelectedCIHelper` for computing `aa_2rdm`, `bb_2rdm`, `ab_2rdm`, and `sf_2rdm`, with detailed documentation in `sci_helper.h` and full implementations in `sci_helper_sigma_build.cc`.
* Exposed these new 2-RDM methods to Python via the C++/Python API in `sci_api.cc`.
* Added a public Python API method `make_sf_2rdm` to `SelectedCI` for user access to the spin-free 2-RDM.

**Average spin-free 2-RDM support:**

* Implemented `make_average_sf_2rdm` in `SelectedCI`, enabling computation of the average spin-free 2-RDM across states, replacing the previous `NotImplementedError`.

**Testing and validation:**

* Added a new test `test_sci_make_rdms` to compare SelectedCI 1- and 2-RDMs against the reference CI implementation, ensuring numerical agreement.