### PR TITLE
feat: CI 1-body transition RDM between different states

### DIFF
--- a/forte2/CMakeLists.txt
+++ b/forte2/CMakeLists.txt
@@ -116,6 +116,7 @@ nanobind_add_module(
   integrals/value_at_points.cc
   ci/ci_sigma_builder.cc
   ci/ci_sigma_builder_1rdm.cc
+  ci/ci_sigma_builder_1trdm.cc
   ci/ci_sigma_builder_2rdm.cc
   ci/ci_sigma_builder_3rdm.cc
   ci/ci_sigma_builder_test_rdms.cc

--- a/forte2/CMakeLists.txt
+++ b/forte2/CMakeLists.txt
@@ -105,6 +105,7 @@ nanobind_add_module(
   api/sparse_exp_api.cc
   api/sparse_operator_api.cc
   api/sparse_state_api.cc
+  api/sparse_rdms_api.cc
   api/sq_operator_string_api.cc
   helpers/combinatorial.cc
   helpers/string_algorithms.cc

--- a/forte2/__init__.py
+++ b/forte2/__init__.py
@@ -8,7 +8,7 @@ from .integrals import integrals
 from .system import System, ModelSystem, HubbardModel
 from .state import State, RelState, MOSpace
 from .scf import RHF, ROHF, UHF, CUHF, GHF
-from .ci import CI, RelCI
+from .ci import CI, RelCI, CISolver, RelCISolver
 from .x2c import x2c
 from .orbitals import AVAS, CubeGenerator, Cube, ASET, write_orbital_cubes
 from .mcopt import MCOptimizer, RelMCOptimizer

--- a/forte2/__init__.py
+++ b/forte2/__init__.py
@@ -11,7 +11,7 @@ from .scf import RHF, ROHF, UHF, CUHF, GHF
 from .ci import CI, RelCI, CISolver, RelCISolver
 from .x2c import x2c
 from .orbitals import AVAS, CubeGenerator, Cube, ASET, write_orbital_cubes
-from .mcopt import MCOptimizer, RelMCOptimizer
+from .mcopt import MCOptimizer
 from .props import get_1e_property, mulliken_population
 from .helpers import logger, set_verbosity_level, comparisons
 from .dsrg import DSRG_MRPT2, RelDSRG_MRPT2

--- a/forte2/_forte2/__init__.pyi
+++ b/forte2/_forte2/__init__.pyi
@@ -158,6 +158,9 @@ class CISigmaBuilder:
 
     def Hamiltonian(self, basis: Annotated[NDArray[numpy.float64], dict(shape=(None,))], sigma: Annotated[NDArray[numpy.float64], dict(shape=(None,))]) -> None: ...
 
+    def make_sparse_state(self, C: Annotated[NDArray[numpy.float64], dict(shape=(None,))]) -> SparseState:
+        """Convert a CI vector to a sparse state"""
+
     def sf_1rdm(self, C_left: Annotated[NDArray[numpy.float64], dict(shape=(None,))], C_right: Annotated[NDArray[numpy.float64], dict(shape=(None,))]) -> Annotated[NDArray[numpy.float64], dict(shape=(None, None))]:
         """Compute the spin-free one-electron reduced density matrix"""
 
@@ -199,6 +202,15 @@ class CISigmaBuilder:
 
     def bbb_3rdm(self, C_left: Annotated[NDArray[numpy.float64], dict(shape=(None,))], C_right: Annotated[NDArray[numpy.float64], dict(shape=(None,))]) -> Annotated[NDArray[numpy.float64], dict(shape=(None, None))]:
         """Compute the beta-beta-beta three-electron reduced density matrix"""
+
+    def a_1trdm(self, sigmabuilder_right: CISigmaBuilder, C_left: Annotated[NDArray[numpy.float64], dict(shape=(None,))], C_right: Annotated[NDArray[numpy.float64], dict(shape=(None,))]) -> Annotated[NDArray[numpy.float64], dict(shape=(None, None))]:
+        """Compute the alpha one-electron transition reduced density matrix"""
+
+    def b_1trdm(self, sigmabuilder_right: CISigmaBuilder, C_left: Annotated[NDArray[numpy.float64], dict(shape=(None,))], C_right: Annotated[NDArray[numpy.float64], dict(shape=(None,))]) -> Annotated[NDArray[numpy.float64], dict(shape=(None, None))]:
+        """Compute the beta one-electron transition reduced density matrix"""
+
+    def sf_1trdm(self, sigmabuilder_right: CISigmaBuilder, C_left: Annotated[NDArray[numpy.float64], dict(shape=(None,))], C_right: Annotated[NDArray[numpy.float64], dict(shape=(None,))]) -> Annotated[NDArray[numpy.float64], dict(shape=(None, None))]:
+        """Compute the spin-free one-electron transition reduced density matrix"""
 
     def avg_build_time(self) -> list[float]: ...
 
@@ -1037,6 +1049,48 @@ class SparseFactExp:
         """
 
     def apply_antiherm_deriv(self, sqop: SQOperatorString, t: complex, state: SparseState) -> tuple[SparseState, SparseState]: ...
+
+def compute_a_1rdm(state_left: SparseState, state_right: SparseState, norb: int) -> Annotated[NDArray[numpy.float64], dict(shape=(None, None))]:
+    """Compute the alpha 1-RDM between two SparseStates"""
+
+def compute_b_1rdm(state_left: SparseState, state_right: SparseState, norb: int) -> Annotated[NDArray[numpy.float64], dict(shape=(None, None))]:
+    """Compute the beta 1-RDM between two SparseStates"""
+
+def compute_aa_2rdm(state_left: SparseState, state_right: SparseState, norb: int) -> Annotated[NDArray[numpy.float64], dict(shape=(None, None, None, None))]:
+    """Compute the alpha-alpha 2-RDM between two SparseStates"""
+
+def compute_ab_2rdm(state_left: SparseState, state_right: SparseState, norb: int) -> Annotated[NDArray[numpy.float64], dict(shape=(None, None, None, None))]:
+    """Compute the alpha-beta 2-RDM between two SparseStates"""
+
+def compute_bb_2rdm(state_left: SparseState, state_right: SparseState, norb: int) -> Annotated[NDArray[numpy.float64], dict(shape=(None, None, None, None))]:
+    """Compute the beta-beta 2-RDM between two SparseStates"""
+
+def compute_aaa_3rdm(state_left: SparseState, state_right: SparseState, norb: int) -> Annotated[NDArray[numpy.float64], dict(shape=(None, None, None, None, None, None))]:
+    """Compute the alpha-alpha-alpha 3-RDM between two SparseStates"""
+
+def compute_aab_3rdm(state_left: SparseState, state_right: SparseState, norb: int) -> Annotated[NDArray[numpy.float64], dict(shape=(None, None, None, None, None, None))]:
+    """Compute the alpha-alpha-beta 3-RDM between two SparseStates"""
+
+def compute_abb_3rdm(state_left: SparseState, state_right: SparseState, norb: int) -> Annotated[NDArray[numpy.float64], dict(shape=(None, None, None, None, None, None))]:
+    """Compute the alpha-beta-beta 3-RDM between two SparseStates"""
+
+def compute_bbb_3rdm(state_left: SparseState, state_right: SparseState, norb: int) -> Annotated[NDArray[numpy.float64], dict(shape=(None, None, None, None, None, None))]:
+    """Compute the beta-beta-beta 3-RDM between two SparseStates"""
+
+def compute_aaaa_4rdm(state_left: SparseState, state_right: SparseState, norb: int) -> Annotated[NDArray[numpy.float64], dict(shape=(None, None, None, None, None, None, None, None))]:
+    """Compute the alpha-alpha-alpha-alpha 4-RDM between two SparseStates"""
+
+def compute_aaab_4rdm(state_left: SparseState, state_right: SparseState, norb: int) -> Annotated[NDArray[numpy.float64], dict(shape=(None, None, None, None, None, None, None, None))]:
+    """Compute the alpha-alpha-alpha-beta 4-RDM between two SparseStates"""
+
+def compute_aabb_4rdm(state_left: SparseState, state_right: SparseState, norb: int) -> Annotated[NDArray[numpy.float64], dict(shape=(None, None, None, None, None, None, None, None))]:
+    """Compute the alpha-alpha-beta-beta 4-RDM between two SparseStates"""
+
+def compute_abbb_4rdm(state_left: SparseState, state_right: SparseState, norb: int) -> Annotated[NDArray[numpy.float64], dict(shape=(None, None, None, None, None, None, None, None))]:
+    """Compute the alpha-beta-beta-beta 4-RDM between two SparseStates"""
+
+def compute_bbbb_4rdm(state_left: SparseState, state_right: SparseState, norb: int) -> Annotated[NDArray[numpy.float64], dict(shape=(None, None, None, None, None, None, None, None))]:
+    """Compute the beta-beta-beta-beta 4-RDM between two SparseStates"""
 
 class SQOperatorString:
     """A class to represent a string of creation/annihilation operators"""

--- a/forte2/_forte2/__init__.pyi
+++ b/forte2/_forte2/__init__.pyi
@@ -158,7 +158,7 @@ class CISigmaBuilder:
 
     def Hamiltonian(self, basis: Annotated[NDArray[numpy.float64], dict(shape=(None,))], sigma: Annotated[NDArray[numpy.float64], dict(shape=(None,))]) -> None: ...
 
-    def make_sparse_state(self, C: Annotated[NDArray[numpy.float64], dict(shape=(None,))]) -> SparseState:
+    def make_sparse_state(self, C: Annotated[NDArray[numpy.float64], dict(shape=(None,))], threshold: float = 1e-12) -> SparseState:
         """Convert a CI vector to a sparse state"""
 
     def sf_1rdm(self, C_left: Annotated[NDArray[numpy.float64], dict(shape=(None,))], C_right: Annotated[NDArray[numpy.float64], dict(shape=(None,))]) -> Annotated[NDArray[numpy.float64], dict(shape=(None, None))]:

--- a/forte2/api/ci_api.cc
+++ b/forte2/api/ci_api.cc
@@ -77,7 +77,7 @@ void export_ci_sigma_builder_api(nb::module_& m) {
         .def("slater_rules_csf", &CISigmaBuilder::slater_rules_csf, "dets"_a, "spin_adapter"_a,
              "I"_a, "J"_a)
         .def("Hamiltonian", &CISigmaBuilder::Hamiltonian, "basis"_a, "sigma"_a)
-        .def("make_sparse_state", &CISigmaBuilder::make_sparse_state, "C"_a,
+        .def("make_sparse_state", &CISigmaBuilder::make_sparse_state, "C"_a, "threshold"_a = 1e-12,
              "Convert a CI vector to a sparse state")
         // Spin-free RDMs and cumulants
         .def("sf_1rdm", &CISigmaBuilder::compute_sf_1rdm, "C_left"_a, "C_right"_a,

--- a/forte2/api/ci_api.cc
+++ b/forte2/api/ci_api.cc
@@ -77,6 +77,8 @@ void export_ci_sigma_builder_api(nb::module_& m) {
         .def("slater_rules_csf", &CISigmaBuilder::slater_rules_csf, "dets"_a, "spin_adapter"_a,
              "I"_a, "J"_a)
         .def("Hamiltonian", &CISigmaBuilder::Hamiltonian, "basis"_a, "sigma"_a)
+        .def("make_sparse_state", &CISigmaBuilder::make_sparse_state, "C"_a,
+             "Convert a CI vector to a sparse state")
         // Spin-free RDMs and cumulants
         .def("sf_1rdm", &CISigmaBuilder::compute_sf_1rdm, "C_left"_a, "C_right"_a,
              "Compute the spin-free one-electron reduced density matrix")
@@ -107,6 +109,12 @@ void export_ci_sigma_builder_api(nb::module_& m) {
              "Compute the alpha-beta-beta three-electron reduced density matrix")
         .def("bbb_3rdm", &CISigmaBuilder::compute_bbb_3rdm, "C_left"_a, "C_right"_a,
              "Compute the beta-beta-beta three-electron reduced density matrix")
+        .def("a_1trdm", &CISigmaBuilder::compute_a_1trdm, "sigmabuilder_right"_a, "C_left"_a,
+             "C_right"_a, "Compute the alpha one-electron transition reduced density matrix")
+        .def("b_1trdm", &CISigmaBuilder::compute_b_1trdm, "sigmabuilder_right"_a, "C_left"_a,
+             "C_right"_a, "Compute the beta one-electron transition reduced density matrix")
+        .def("sf_1trdm", &CISigmaBuilder::compute_sf_1trdm, "sigmabuilder_right"_a, "C_left"_a,
+             "C_right"_a, "Compute the spin-free one-electron transition reduced density matrix")
         .def("avg_build_time", &CISigmaBuilder::avg_build_time)
         .def("set_log_level", &CISigmaBuilder::set_log_level, "level"_a,
              "Set the logging level for the class")

--- a/forte2/api/forte2_api.cc
+++ b/forte2/api/forte2_api.cc
@@ -24,6 +24,7 @@ void export_sparse_operator_api(nb::module_& m);
 void export_sparse_operator_list_api(nb::module_& m);
 void export_sparse_exp_api(nb::module_& m);
 void export_sparse_fact_exp_api(nb::module_& m);
+void export_sparse_rdms_api(nb::module_& m);
 void export_sq_operator_string_api(nb::module_& m);
 
 NB_MODULE(_forte2, m) {
@@ -46,6 +47,7 @@ NB_MODULE(_forte2, m) {
     export_sparse_operator_list_api(m);
     export_sparse_exp_api(m);
     export_sparse_fact_exp_api(m);
+    export_sparse_rdms_api(m);
     export_sq_operator_string_api(m);
     m.attr("__version__") = "0.2.2";
     m.attr("__author__") = "Forte2 Developers";

--- a/forte2/api/sparse_rdms_api.cc
+++ b/forte2/api/sparse_rdms_api.cc
@@ -1,0 +1,46 @@
+#include <nanobind/nanobind.h>
+#include <nanobind/stl/string.h>
+#include <nanobind/stl/complex.h>
+#include <nanobind/stl/unordered_map.h>
+#include <nanobind/stl/vector.h>
+#include <nanobind/make_iterator.h>
+
+#include "sparse/sparse_rdms.h"
+
+namespace nb = nanobind;
+using namespace nb::literals;
+
+namespace forte2 {
+
+void export_sparse_rdms_api(nb::module_& m) {
+    m.def("compute_a_1rdm", &compute_a_1rdm, "state_left"_a, "state_right"_a, "norb"_a,
+          "Compute the alpha 1-RDM between two SparseStates");
+    m.def("compute_b_1rdm", &compute_b_1rdm, "state_left"_a, "state_right"_a, "norb"_a,
+          "Compute the beta 1-RDM between two SparseStates");
+    m.def("compute_aa_2rdm", &compute_aa_2rdm, "state_left"_a, "state_right"_a, "norb"_a,
+          "Compute the alpha-alpha 2-RDM between two SparseStates");
+    m.def("compute_ab_2rdm", &compute_ab_2rdm, "state_left"_a, "state_right"_a, "norb"_a,
+          "Compute the alpha-beta 2-RDM between two SparseStates");
+    m.def("compute_bb_2rdm", &compute_bb_2rdm, "state_left"_a, "state_right"_a, "norb"_a,
+          "Compute the beta-beta 2-RDM between two SparseStates");
+    m.def("compute_aaa_3rdm", &compute_aaa_3rdm, "state_left"_a, "state_right"_a, "norb"_a,
+          "Compute the alpha-alpha-alpha 3-RDM between two SparseStates");
+    m.def("compute_aab_3rdm", &compute_aab_3rdm, "state_left"_a, "state_right"_a, "norb"_a,
+          "Compute the alpha-alpha-beta 3-RDM between two SparseStates");
+    m.def("compute_abb_3rdm", &compute_abb_3rdm, "state_left"_a, "state_right"_a, "norb"_a,
+          "Compute the alpha-beta-beta 3-RDM between two SparseStates");
+    m.def("compute_bbb_3rdm", &compute_bbb_3rdm, "state_left"_a, "state_right"_a, "norb"_a,
+          "Compute the beta-beta-beta 3-RDM between two SparseStates");
+    m.def("compute_aaaa_4rdm", &compute_aaaa_4rdm, "state_left"_a, "state_right"_a, "norb"_a,
+          "Compute the alpha-alpha-alpha-alpha 4-RDM between two SparseStates");
+    m.def("compute_aaab_4rdm", &compute_aaab_4rdm, "state_left"_a, "state_right"_a, "norb"_a,
+          "Compute the alpha-alpha-alpha-beta 4-RDM between two SparseStates");
+    m.def("compute_aabb_4rdm", &compute_aabb_4rdm, "state_left"_a, "state_right"_a, "norb"_a,
+          "Compute the alpha-alpha-beta-beta 4-RDM between two SparseStates");
+    m.def("compute_abbb_4rdm", &compute_abbb_4rdm, "state_left"_a, "state_right"_a, "norb"_a,
+          "Compute the alpha-beta-beta-beta 4-RDM between two SparseStates");
+    m.def("compute_bbbb_4rdm", &compute_bbbb_4rdm, "state_left"_a, "state_right"_a, "norb"_a,
+          "Compute the beta-beta-beta-beta 4-RDM between two SparseStates");
+}
+
+} // namespace forte2

--- a/forte2/base_classes/active_space_solver.py
+++ b/forte2/base_classes/active_space_solver.py
@@ -16,7 +16,6 @@ class ActiveSpaceSolver(ABC, MOsMixin, SystemMixin, MOSpaceMixin):
     core_orbitals: list[int] = None
     active_orbitals: list[int] | list[list[int]] = None
     frozen_virtual_orbitals: list[int] = None
-    final_orbital: str = "semicanonical"
     die_if_not_converged: bool = False
 
     def __post_init__(self):
@@ -30,10 +29,6 @@ class ActiveSpaceSolver(ABC, MOsMixin, SystemMixin, MOSpaceMixin):
         self.ncis = self.sa_info.ncis
         self.weights = self.sa_info.weights
         self.weights_flat = self.sa_info.weights_flat
-        assert self.final_orbital in [
-            "semicanonical",
-            "original",
-        ], "final_orbital must be either 'semicanonical' or 'original'."
 
     def _startup(self, two_component=False):
         if not self.parent_method.executed:

--- a/forte2/base_classes/ci_base.py
+++ b/forte2/base_classes/ci_base.py
@@ -1,7 +1,5 @@
-from abc import ABC, abstractmethod
+from abc import abstractmethod
 from dataclasses import dataclass, field
-
-import numpy as np
 
 from .active_space_solver import ActiveSpaceSolver, RelActiveSpaceSolver
 

--- a/forte2/base_classes/ci_base.py
+++ b/forte2/base_classes/ci_base.py
@@ -8,7 +8,6 @@ from .active_space_solver import ActiveSpaceSolver, RelActiveSpaceSolver
 
 @dataclass
 class CIBase(ActiveSpaceSolver):
-
     ### Non-init attributes
     first_run: bool = field(default=True, init=False)
     executed: bool = field(default=False, init=False)
@@ -32,6 +31,12 @@ class CIBase(ActiveSpaceSolver):
     @abstractmethod
     def run(self): ...
 
+    @abstractmethod
+    def reset_eigensolver(self): ...
+
+    @abstractmethod
+    def get_convergence_status(self): ...
+
 
 @dataclass
 class RelCIBase(RelActiveSpaceSolver):
@@ -47,3 +52,9 @@ class RelCIBase(RelActiveSpaceSolver):
 
     @abstractmethod
     def run(self, use_asym_ints=False): ...
+
+    @abstractmethod
+    def reset_eigensolver(self): ...
+
+    @abstractmethod
+    def get_convergence_status(self): ...

--- a/forte2/ci/ci.py
+++ b/forte2/ci/ci.py
@@ -1723,7 +1723,13 @@ class RelCI(RelCISolver):
     do_transition_dipole: bool = False
     log_level: int = field(default=logger.get_verbosity_level())
 
-    __post_init__ = CI.__post_init__
+    def __post_init__(self):
+        super().__post_init__()
+        if self.final_orbital not in ["original", "semicanonical"]:
+            raise ValueError(
+                f"Invalid value for final_orbital: {self.final_orbital}. "
+                "Must be 'original' or 'semicanonical'."
+            )
 
     def run(self):
         super().run()

--- a/forte2/ci/ci.py
+++ b/forte2/ci/ci.py
@@ -1483,7 +1483,21 @@ class CISolver(CIBase):
     def compute_transition_properties(self, C=None):
         """
         Compute the transition dipole moments and oscillator strengths from the spin-free 1-TDMs.
-        The results are stored in `self.tdm_per_solver` and `self.fosc_per_solver`.
+        The results are stored in `self.transition_dipoles` and `self.oscillator_strengths`.
+
+        Parameters
+        ----------
+        C : NDArray, optional
+            The MO coefficients. If not provided, the MO coefficients from the first sub-solver are used.
+
+        Returns
+        -------
+        transition_dipoles : dict[tuple[int, int], NDArray]
+            A dictionary mapping pairs of CI roots (absolute_root_i, absolute_root_j) to their transition dipole moments.
+            This is also saved in `self.transition_dipoles`.
+        oscillator_strengths : dict[tuple[int, int], float]
+            A dictionary mapping pairs of CI roots (absolute_root_i, absolute_root_j) to their oscillator strengths.
+            This is also saved in `self.oscillator_strengths`.
         """
         if not self.executed:
             raise RuntimeError("CI solver has not been executed yet.")
@@ -1499,36 +1513,53 @@ class CISolver(CIBase):
         core_dip = get_1e_property(
             self.system, rdm_core, property_name="dipole", unit="au"
         )
-        self.tdm_per_solver = []
-        self.fosc_per_solver = []
-
-        for ici, ci_solver in enumerate(self.sub_solvers):
-            tdmdict = OrderedDict()
-            foscdict = OrderedDict()
-            for i in range(ci_solver.nroot):
-                rdm = ci_solver.make_1rdm(i)
-                # Different (back-)transformation rules for RDMs:
-                # O_{mu}^{nu} = C_{mu}^p <phi_p|O|phi^q> C^q_{nu} = C^H O[mo] C
-                # rdm^{mu}_{nu} = C^{mu}_p <a^p a_q> C^q_{nu} = C^* rdm[mo] C^T
-                rdm = np.einsum("ij,pi,qj->pq", rdm, Cact.conj(), Cact, optimize=True)
-                dip = get_1e_property(
-                    self.system, rdm, property_name="electric_dipole", unit="au"
-                )
-                tdmdict[(i, i)] = dip + core_dip
-                foscdict[(i, i)] = 0.0  # No oscillator strength for i->i transitions
-                for j in range(i + 1, ci_solver.nroot):
-                    tdm = ci_solver.make_1rdm(i, j)
+        self.transition_dipoles = OrderedDict()
+        self.oscillator_strengths = OrderedDict()
+        for ici in range(self.sa_info.nroots_sum):
+            istate, iroot_in_state = self._get_state_root(ici)
+            rdm = self.sub_solvers[istate].make_1rdm(iroot_in_state)
+            # Different (back-)transformation rules for RDMs:
+            # O_{mu}^{nu} = C_{mu}^p <phi_p|O|phi^q> C^q_{nu} = C^H O[mo] C
+            # rdm^{mu}_{nu} = C^{mu}_p <a^p a_q> C^q_{nu} = C^* rdm[mo] C^T
+            rdm = np.einsum("ij,pi,qj->pq", rdm, Cact.conj(), Cact, optimize=True)
+            dip = get_1e_property(
+                self.system, rdm, property_name="electric_dipole", unit="au"
+            )
+            self.transition_dipoles[(ici, ici)] = dip + core_dip
+            # No oscillator strength for i->i transitions
+            self.oscillator_strengths[(ici, ici)] = 0.0
+            for jci in range(ici + 1, self.sa_info.nroots_sum):
+                jstate, jroot_in_state = self._get_state_root(jci)
+                try:
+                    vte = (
+                        self.evals_per_solver[jstate][jroot_in_state]
+                        - self.evals_per_solver[istate][iroot_in_state]
+                    )
+                    # Reverse the order of states for negative VTE to ensure the transition dipole 
+                    # is always computed from lower to higher state.
+                    if vte < 0:
+                        _ici, _jci = jci, ici
+                        vte = -vte
+                    else:
+                        _ici, _jci = ici, jci
+                    tdm = self.make_1rdm(_ici, _jci)
                     tdm = np.einsum(
                         "ij,pi,qj->pq", tdm, Cact.conj(), Cact, optimize=True
                     )
                     tdip = get_1e_property(
                         self.system, tdm, property_name="electric_dipole", unit="au"
                     )
-                    tdmdict[(i, j)] = tdip
-                    vte = self.evals_per_solver[ici][j] - self.evals_per_solver[ici][i]
-                    foscdict[(i, j)] = (2 / 3) * vte * np.linalg.norm(tdip) ** 2
-            self.fosc_per_solver.append(foscdict)
-            self.tdm_per_solver.append(tdmdict)
+                    self.transition_dipoles[(_ici, _jci)] = tdip
+                    self.oscillator_strengths[(_ici, _jci)] = (
+                        (2 / 3) * vte * np.linalg.norm(tdip) ** 2
+                    )
+                except (ValueError, NotImplementedError):
+                    # ValueError: for non-relativistic CI if the two states have different na and nb,
+                    #   and thus cross-state RDMs are not supported.
+                    # NotImplementedError: for two-component CI, cross-state RDMs are not implemented yet.
+                    continue
+
+        return self.transition_dipoles, self.oscillator_strengths
 
     def get_convergence_status(self):
         """
@@ -1686,6 +1717,9 @@ class CISolver(CIBase):
                 f"Cross-state 2-RDMs are not supported. Got left_root in state {left_state} and right_root in state {right_state}."
             )
 
+    make_1rdm = make_sf_1rdm
+    make_2rdm = make_sf_2rdm
+
 
 @dataclass
 class CI(CISolver):
@@ -1746,8 +1780,8 @@ class CI(CISolver):
             self.compute_transition_properties()
             pretty_print_ci_transition_props(
                 self.sa_info,
-                self.tdm_per_solver,
-                self.fosc_per_solver,
+                self.transition_dipoles,
+                self.oscillator_strengths,
                 self.evals_per_solver,
             )
 
@@ -1778,6 +1812,8 @@ class RelCISolver(RelCIBase):
     reset_eigensolver = CISolver.reset_eigensolver
     set_maxiter = CISolver.set_maxiter
     get_convergence_status = CISolver.get_convergence_status
+    _get_state_root = CISolver._get_state_root
+    _validate_rdm_inputs = CISolver._validate_rdm_inputs
 
     def _startup(self):
         super()._startup()
@@ -1840,6 +1876,32 @@ class RelCISolver(RelCIBase):
         self.executed = True
         return self
 
+    def make_1rdm(self, left_root: int, right_root: int | None = None):
+        left_state, right_state, left_root_in_state, right_root_in_state = (
+            self._validate_rdm_inputs(left_root, right_root)
+        )
+        if left_state == right_state:
+            return self.sub_solvers[left_state].make_1rdm(
+                left_root_in_state, right_root_in_state
+            )
+        else:
+            raise NotImplementedError(
+                f"Cross-state 1-RDMs are not supported for RelCI. Got left_root in state {left_state} and right_root in state {right_state}."
+            )
+
+    def make_2rdm(self, left_root: int, right_root: int | None = None):
+        left_state, right_state, left_root_in_state, right_root_in_state = (
+            self._validate_rdm_inputs(left_root, right_root)
+        )
+        if left_state == right_state:
+            return self.sub_solvers[left_state].make_2rdm(
+                left_root_in_state, right_root_in_state
+            )
+        else:
+            raise NotImplementedError(
+                f"Cross-state 2-RDMs are not supported for RelCI. Got left_root in state {left_state} and right_root in state {right_state}."
+            )
+
 
 @dataclass
 class RelCI(RelCISolver):
@@ -1894,7 +1956,7 @@ class RelCI(RelCISolver):
             self.compute_transition_properties()
             pretty_print_ci_transition_props(
                 self.sa_info,
-                self.tdm_per_solver,
-                self.fosc_per_solver,
+                self.transition_dipoles,
+                self.oscillator_strengths,
                 self.evals_per_solver,
             )

--- a/forte2/ci/ci.py
+++ b/forte2/ci/ci.py
@@ -2,6 +2,7 @@ from dataclasses import dataclass, field
 from collections import OrderedDict
 
 import numpy as np
+from numpy.typing import NDArray
 
 from forte2 import (
     CIStrings,
@@ -1313,7 +1314,7 @@ class CISolver(CIBase):
 
         self.executed = True
         return self
-    
+
     def compute_average_energy(self):
         """
         Compute the average energy from the CI roots using the weights.
@@ -1545,6 +1546,135 @@ class CISolver(CIBase):
             else:
                 status.append(ci_solver.eigensolver.converged)
         return status
+
+    def _get_state_root(self, absolute_root) -> tuple[int, int]:
+        if absolute_root < 0 or absolute_root >= self.sa_info.nroots_sum:
+            raise ValueError(
+                f"absolute_root must be between 0 and {self.sa_info.nroots_sum - 1}, but got {absolute_root}."
+            )
+        return self.sa_info.absolute_root_map[absolute_root]
+
+    def _validate_rdm_inputs(self, left_root, right_root):
+        left_state, left_root_in_state = self._get_state_root(left_root)
+        if right_root is not None:
+            right_state, right_root_in_state = self._get_state_root(right_root)
+        else:
+            right_state = left_state
+            right_root_in_state = left_root_in_state
+
+        if left_state != right_state:
+            # check that they have the same na and nb
+            if (
+                self.sa_info.states[left_state].na
+                != self.sa_info.states[right_state].na
+                or self.sa_info.states[left_state].nb
+                != self.sa_info.states[right_state].nb
+            ):
+                raise ValueError(
+                    f"Cross-state RDMs are only supported for states with the same number of alpha and beta electrons."
+                )
+
+        return left_state, right_state, left_root_in_state, right_root_in_state
+
+    def make_sd_1rdm(
+        self,
+        left_root: int,
+        right_root: int | None = None,
+    ) -> tuple[NDArray, NDArray]:
+        """
+        Make the spin-dependent 1-RDMs
+        """
+        left_state, right_state, left_root_in_state, right_root_in_state = (
+            self._validate_rdm_inputs(left_root, right_root)
+        )
+        if left_state == right_state:
+            return self.sub_solvers[left_state].make_sd_1rdm(
+                left_root_in_state, right_root_in_state
+            )
+        else:
+            left_solver = self.sub_solvers[left_state]
+            right_solver = self.sub_solvers[right_state]
+            left_sb = left_solver.ci_sigma_builder
+            right_sb = right_solver.ci_sigma_builder
+
+            C_left = left_solver.csf_C_to_det_C(
+                left_solver.evecs[:, left_root_in_state]
+            )
+            C_right = right_solver.csf_C_to_det_C(
+                right_solver.evecs[:, right_root_in_state]
+            )
+
+            a_1trdm = left_sb.a_1trdm(right_sb, C_left, C_right)
+            b_1trdm = left_sb.b_1trdm(right_sb, C_left, C_right)
+            return a_1trdm, b_1trdm
+
+    def make_sd_2rdm(
+        self,
+        left_root: int,
+        right_root: int | None = None,
+    ) -> tuple[NDArray, NDArray, NDArray]:
+        left_state, right_state, left_root_in_state, right_root_in_state = (
+            self._validate_rdm_inputs(left_root, right_root)
+        )
+
+        if left_state != right_state:
+            raise ValueError(
+                f"Cross-state 2-RDMs are not supported. Got left_root in state {left_state} and right_root in state {right_state}."
+            )
+        return self.sub_solvers[left_state].make_sd_2rdm(
+            left_root_in_state, right_root_in_state
+        )
+
+    def make_sd_3rdm(
+        self,
+        left_root: int,
+        right_root: int | None = None,
+    ) -> tuple[NDArray, NDArray, NDArray, NDArray]:
+        left_state, right_state, left_root_in_state, right_root_in_state = (
+            self._validate_rdm_inputs(left_root, right_root)
+        )
+
+        if left_state != right_state:
+            raise ValueError(
+                f"Cross-state 3-RDMs are not supported. Got left_root in state {left_state} and right_root in state {right_state}."
+            )
+        return self.sub_solvers[left_state].make_sd_3rdm(
+            left_root_in_state, right_root_in_state
+        )
+
+    def make_sf_1rdm(
+        self,
+        left_root: int,
+        right_root: int | None = None,
+    ) -> NDArray:
+        left_state, right_state, left_root_in_state, right_root_in_state = (
+            self._validate_rdm_inputs(left_root, right_root)
+        )
+        if left_state == right_state:
+            return self.sub_solvers[left_state].make_sf_1rdm(
+                left_root_in_state, right_root_in_state
+            )
+        else:
+            a_1trdm, b_1trdm = self.make_sd_1rdm(left_root, right_root)
+            return a_1trdm + b_1trdm
+
+    def make_sf_2rdm(
+        self,
+        left_root: int,
+        right_root: int | None = None,
+    ) -> NDArray:
+        left_state, right_state, left_root_in_state, right_root_in_state = (
+            self._validate_rdm_inputs(left_root, right_root)
+        )
+
+        if left_state == right_state:
+            return self.sub_solvers[left_state].make_sf_2rdm(
+                left_root_in_state, right_root_in_state
+            )
+        else:
+            raise ValueError(
+                f"Cross-state 2-RDMs are not supported. Got left_root in state {left_state} and right_root in state {right_state}."
+            )
 
 
 @dataclass

--- a/forte2/ci/ci.py
+++ b/forte2/ci/ci.py
@@ -1272,7 +1272,8 @@ class CISolver(CIBase):
     ci_params: CIParams = field(default_factory=CIParams)
     davidson_liu_params: DavidsonLiuParams = field(default_factory=DavidsonLiuParams)
     do_test_rdms: bool = False
-    log_level: int = field(default=logger.get_verbosity_level())
+    # If used as a solver, log at warning level
+    log_level: int = field(default=logger.get_verbosity_level() + 1)
 
     def _startup(self):
         super()._startup()
@@ -1328,7 +1329,7 @@ class CISolver(CIBase):
 
         self.executed = True
         return self
-    
+
     def compute_average_energy(self):
         """
         Compute the average energy from the CI roots using the weights.
@@ -1572,6 +1573,15 @@ class CI(CISolver):
     die_if_not_converged: bool = True
     final_orbital: str = "original"
     do_transition_dipole: bool = False
+    log_level: int = field(default=logger.get_verbosity_level())
+
+    def __post_init__(self):
+        super().__post_init__()
+        if self.final_orbital not in ["original", "semicanonical"]:
+            raise ValueError(
+                f"Invalid value for final_orbital: {self.final_orbital}. "
+                "Must be 'original' or 'semicanonical'."
+            )
 
     def run(self):
         super().run()
@@ -1628,7 +1638,7 @@ class RelCISolver(RelCIBase):
     ci_params: CIParams = field(default_factory=CIParams)
 
     do_test_rdms: bool = False
-    log_level: int = field(default=logger.get_verbosity_level())
+    log_level: int = field(default=logger.get_verbosity_level() + 1)
 
     compute_average_energy = CISolver.compute_average_energy
     make_average_1rdm = CISolver.make_average_1rdm
@@ -1711,6 +1721,9 @@ class RelCISolver(RelCIBase):
 class RelCI(RelCISolver):
     final_orbital: str = "original"
     do_transition_dipole: bool = False
+    log_level: int = field(default=logger.get_verbosity_level())
+
+    __post_init__ = CI.__post_init__
 
     def run(self):
         super().run()

--- a/forte2/ci/ci.py
+++ b/forte2/ci/ci.py
@@ -1655,8 +1655,17 @@ class CISolver(CIBase):
                 left_root_in_state, right_root_in_state
             )
         else:
-            a_1trdm, b_1trdm = self.make_sd_1rdm(left_root, right_root)
-            return a_1trdm + b_1trdm
+            left_solver = self.sub_solvers[left_state]
+            right_solver = self.sub_solvers[right_state]
+            left_sb = left_solver.ci_sigma_builder
+            right_sb = right_solver.ci_sigma_builder
+            C_left = left_solver.csf_C_to_det_C(
+                left_solver.evecs[:, left_root_in_state]
+            )
+            C_right = right_solver.csf_C_to_det_C(
+                right_solver.evecs[:, right_root_in_state]
+            )
+            return left_sb.sf_1trdm(right_sb, C_left, C_right)
 
     def make_sf_2rdm(
         self,

--- a/forte2/ci/ci.py
+++ b/forte2/ci/ci.py
@@ -542,6 +542,24 @@ class _CISingleStateSolver:
 
         self.eigensolver.add_guesses(guess_mat)
 
+    def csf_C_to_det_C(self, csf_vec):
+        """
+        Convert a CI vector in the CSF basis to the determinant basis.
+
+        Parameters
+        ----------
+        csf_vec : NDArray
+            CI vector in the CSF basis.
+
+        Returns
+        -------
+        NDArray
+            CI vector in the determinant basis.
+        """
+        det_vec = np.zeros((self.ndet))
+        self.spin_adapter.csf_C_to_det_C(csf_vec, det_vec)
+        return det_vec
+
     def make_1rdm(self, left_root: int, right_root: int | None = None):
         """
         Make the one-particle RDM for two CI roots.
@@ -679,15 +697,11 @@ class _CISingleStateSolver:
             not self.two_component
         ), "make_sd_1rdm is only available for non-relativistic CI."
 
-        left_ci_vec_det = np.zeros((self.ndet))
-        self.spin_adapter.csf_C_to_det_C(self.evecs[:, left_root], left_ci_vec_det)
+        left_ci_vec_det = self.csf_C_to_det_C(self.evecs[:, left_root])
         if right_root is None:
             right_ci_vec_det = left_ci_vec_det
         else:
-            right_ci_vec_det = np.zeros((self.ndet))
-            self.spin_adapter.csf_C_to_det_C(
-                self.evecs[:, right_root], right_ci_vec_det
-            )
+            right_ci_vec_det = self.csf_C_to_det_C(self.evecs[:, right_root])
         a = self.ci_sigma_builder.a_1rdm(left_ci_vec_det, right_ci_vec_det)
         b = self.ci_sigma_builder.b_1rdm(left_ci_vec_det, right_ci_vec_det)
         return a, b
@@ -712,15 +726,11 @@ class _CISingleStateSolver:
             not self.two_component
         ), "make_sd_2rdm is only available for non-relativistic CI."
 
-        left_ci_vec_det = np.zeros((self.ndet))
-        self.spin_adapter.csf_C_to_det_C(self.evecs[:, left_root], left_ci_vec_det)
+        left_ci_vec_det = self.csf_C_to_det_C(self.evecs[:, left_root])
         if right_root is None:
             right_ci_vec_det = left_ci_vec_det
         else:
-            right_ci_vec_det = np.zeros((self.ndet))
-            self.spin_adapter.csf_C_to_det_C(
-                self.evecs[:, right_root], right_ci_vec_det
-            )
+            right_ci_vec_det = self.csf_C_to_det_C(self.evecs[:, right_root])
         aa = self.ci_sigma_builder.aa_2rdm(left_ci_vec_det, right_ci_vec_det)
         ab = self.ci_sigma_builder.ab_2rdm(left_ci_vec_det, right_ci_vec_det)
         bb = self.ci_sigma_builder.bb_2rdm(left_ci_vec_det, right_ci_vec_det)
@@ -746,15 +756,11 @@ class _CISingleStateSolver:
             not self.two_component
         ), "make_sd_3rdm is only available for non-relativistic CI."
 
-        left_ci_vec_det = np.zeros((self.ndet))
-        self.spin_adapter.csf_C_to_det_C(self.evecs[:, left_root], left_ci_vec_det)
+        left_ci_vec_det = self.csf_C_to_det_C(self.evecs[:, left_root])
         if right_root is None:
             right_ci_vec_det = left_ci_vec_det
         else:
-            right_ci_vec_det = np.zeros((self.ndet))
-            self.spin_adapter.csf_C_to_det_C(
-                self.evecs[:, right_root], right_ci_vec_det
-            )
+            right_ci_vec_det = self.csf_C_to_det_C(self.evecs[:, right_root])
 
         aaa = self.ci_sigma_builder.aaa_3rdm(left_ci_vec_det, right_ci_vec_det)
         aab = self.ci_sigma_builder.aab_3rdm(left_ci_vec_det, right_ci_vec_det)
@@ -782,15 +788,11 @@ class _CISingleStateSolver:
             not self.two_component
         ), "make_sf_1rdm is only available for non-relativistic CI."
 
-        left_ci_vec_det = np.zeros((self.ndet))
-        self.spin_adapter.csf_C_to_det_C(self.evecs[:, left_root], left_ci_vec_det)
+        left_ci_vec_det = self.csf_C_to_det_C(self.evecs[:, left_root])
         if right_root is None:
             right_ci_vec_det = left_ci_vec_det
         else:
-            right_ci_vec_det = np.zeros((self.ndet))
-            self.spin_adapter.csf_C_to_det_C(
-                self.evecs[:, right_root], right_ci_vec_det
-            )
+            right_ci_vec_det = self.csf_C_to_det_C(self.evecs[:, right_root])
         return self.ci_sigma_builder.sf_1rdm(left_ci_vec_det, right_ci_vec_det)
 
     def make_sf_2rdm(self, left_root: int, right_root: int | None = None):
@@ -813,15 +815,11 @@ class _CISingleStateSolver:
             not self.two_component
         ), "make_sf_2rdm is only available for non-relativistic CI."
 
-        left_ci_vec_det = np.zeros((self.ndet))
-        self.spin_adapter.csf_C_to_det_C(self.evecs[:, left_root], left_ci_vec_det)
+        left_ci_vec_det = self.csf_C_to_det_C(self.evecs[:, left_root])
         if right_root is None:
             right_ci_vec_det = left_ci_vec_det
         else:
-            right_ci_vec_det = np.zeros((self.ndet))
-            self.spin_adapter.csf_C_to_det_C(
-                self.evecs[:, right_root], right_ci_vec_det
-            )
+            right_ci_vec_det = self.csf_C_to_det_C(self.evecs[:, right_root])
         return self.ci_sigma_builder.sf_2rdm(left_ci_vec_det, right_ci_vec_det)
 
     def make_sf_3rdm(self, left_root: int, right_root: int | None = None):
@@ -844,15 +842,11 @@ class _CISingleStateSolver:
             not self.two_component
         ), "make_sf_3rdm is only available for non-relativistic CI."
 
-        left_ci_vec_det = np.zeros((self.ndet))
-        self.spin_adapter.csf_C_to_det_C(self.evecs[:, left_root], left_ci_vec_det)
+        left_ci_vec_det = self.csf_C_to_det_C(self.evecs[:, left_root])
         if right_root is None:
             right_ci_vec_det = left_ci_vec_det
         else:
-            right_ci_vec_det = np.zeros((self.ndet))
-            self.spin_adapter.csf_C_to_det_C(
-                self.evecs[:, right_root], right_ci_vec_det
-            )
+            right_ci_vec_det = self.csf_C_to_det_C(self.evecs[:, right_root])
         return self.ci_sigma_builder.sf_3rdm(left_ci_vec_det, right_ci_vec_det)
 
     def make_sf_2cumulant(self, left_root: int, right_root: int | None = None):
@@ -875,15 +869,11 @@ class _CISingleStateSolver:
             not self.two_component
         ), "make_sf_2cumulant is only available for non-relativistic CI."
 
-        left_ci_vec_det = np.zeros((self.ndet))
-        self.spin_adapter.csf_C_to_det_C(self.evecs[:, left_root], left_ci_vec_det)
+        left_ci_vec_det = self.csf_C_to_det_C(self.evecs[:, left_root])
         if right_root is None:
             right_ci_vec_det = left_ci_vec_det
         else:
-            right_ci_vec_det = np.zeros((self.ndet))
-            self.spin_adapter.csf_C_to_det_C(
-                self.evecs[:, right_root], right_ci_vec_det
-            )
+            right_ci_vec_det = self.csf_C_to_det_C(self.evecs[:, right_root])
         return self.ci_sigma_builder.sf_2cumulant(left_ci_vec_det, right_ci_vec_det)
 
     def make_sf_3cumulant(self, left_root: int, right_root: int | None = None):
@@ -906,15 +896,11 @@ class _CISingleStateSolver:
             not self.two_component
         ), "make_sf_3cumulant is only available for non-relativistic CI."
 
-        left_ci_vec_det = np.zeros((self.ndet))
-        self.spin_adapter.csf_C_to_det_C(self.evecs[:, left_root], left_ci_vec_det)
+        left_ci_vec_det = self.csf_C_to_det_C(self.evecs[:, left_root])
         if right_root is None:
             right_ci_vec_det = left_ci_vec_det
         else:
-            right_ci_vec_det = np.zeros((self.ndet))
-            self.spin_adapter.csf_C_to_det_C(
-                self.evecs[:, right_root], right_ci_vec_det
-            )
+            right_ci_vec_det = self.csf_C_to_det_C(self.evecs[:, right_root])
         return self.ci_sigma_builder.sf_3cumulant(left_ci_vec_det, right_ci_vec_det)
 
     def make_so_1rdm(self, left_root: int, right_root: int = None):
@@ -1225,8 +1211,7 @@ class _CISingleStateSolver:
 
         for i in range(self.nroot):
             top_dets = []
-            ci_det = np.zeros((self.ndet))
-            self.spin_adapter.csf_C_to_det_C(self.evecs[:, i], ci_det)
+            ci_det = self.csf_C_to_det_C(self.evecs[:, i])
             argsort = np.argsort(np.abs(ci_det))[::-1]  # descending in absolute coeff
             for j in range(n):
                 if j < len(argsort):

--- a/forte2/ci/ci_sigma_builder.cc
+++ b/forte2/ci/ci_sigma_builder.cc
@@ -360,7 +360,7 @@ np_matrix CISigmaBuilder::form_H_csf(const std::vector<Determinant>& dets,
     return H;
 }
 
-SparseState CISigmaBuilder::make_sparse_state(const np_vector& C) const {
+SparseState CISigmaBuilder::make_sparse_state(const np_vector& C, double threshold) const {
     SparseState state;
     auto C_span = vector::as_span<double>(C);
     if (C_span.size() != lists_.ndet()) {
@@ -368,7 +368,9 @@ SparseState CISigmaBuilder::make_sparse_state(const np_vector& C) const {
     }
     auto dets = lists_.make_determinants();
     for (size_t i{0}, maxi{dets.size()}; i < maxi; ++i) {
-        state[dets[i]] = C_span[i];
+        if (std::fabs(C_span[i]) > threshold) {
+            state[dets[i]] = C_span[i];
+        }
     }
     return state;
 }

--- a/forte2/ci/ci_sigma_builder.cc
+++ b/forte2/ci/ci_sigma_builder.cc
@@ -360,4 +360,17 @@ np_matrix CISigmaBuilder::form_H_csf(const std::vector<Determinant>& dets,
     return H;
 }
 
+SparseState CISigmaBuilder::make_sparse_state(const np_vector& C) const {
+    SparseState state;
+    auto C_span = vector::as_span<double>(C);
+    if (C_span.size() != lists_.ndet()) {
+        throw std::runtime_error("Size of CI vector does not match the number of determinants.");
+    }
+    auto dets = lists_.make_determinants();
+    for (size_t i{0}, maxi{dets.size()}; i < maxi; ++i) {
+        state[dets[i]] = C_span[i];
+    }
+    return state;
+}
+
 } // namespace forte2

--- a/forte2/ci/ci_sigma_builder.h
+++ b/forte2/ci/ci_sigma_builder.h
@@ -12,6 +12,8 @@
 #include "ci/slater_rules.h"
 #include "ci/ci_spin_adapter.h"
 
+#include "sparse/sparse_state.h"
+
 namespace forte2 {
 
 enum class CIAlgorithm {
@@ -96,6 +98,11 @@ class CISigmaBuilder {
                     hbbbb_timer_ / static_cast<double>(build_count_)};
         }
     }
+
+    /// @brief Convert a CI vector to a sparse state
+    /// @param C The CI vector to convert
+    /// @return The corresponding sparse state
+    SparseState make_sparse_state(const np_vector& C) const;
 
     /// @brief Compute the spin-dependent one-electron reduced density matrix
     /// @param C_left The left-hand side coefficients
@@ -263,6 +270,13 @@ class CISigmaBuilder {
 
     np_matrix compute_s_1trdm(const CISigmaBuilder& sigmabuilder_right, np_vector C_left,
                               np_vector C_right, Spin spin) const;
+
+    np_matrix compute_a_1trdm(CISigmaBuilder& sigmabuilder_right, np_vector C_left,
+                              np_vector C_right) const;
+    np_matrix compute_b_1trdm(CISigmaBuilder& sigmabuilder_right, np_vector C_left,
+                              np_vector C_right) const;
+    np_matrix compute_sf_1trdm(CISigmaBuilder& sigmabuilder_right, np_vector C_left,
+                               np_vector C_right) const;
 
   private:
     // == Class Private Variables ==

--- a/forte2/ci/ci_sigma_builder.h
+++ b/forte2/ci/ci_sigma_builder.h
@@ -261,6 +261,9 @@ class CISigmaBuilder {
     np_tensor4 compute_sf_2cumulant_debug(np_vector C_left, np_vector C_right) const;
     np_tensor6 compute_sf_3cumulant_debug(np_vector C_left, np_vector C_right) const;
 
+    np_matrix compute_s_1trdm(const CISigmaBuilder& sigmabuilder_right, np_vector C_left,
+                              np_vector C_right, Spin spin) const;
+
   private:
     // == Class Private Variables ==
 

--- a/forte2/ci/ci_sigma_builder.h
+++ b/forte2/ci/ci_sigma_builder.h
@@ -101,8 +101,9 @@ class CISigmaBuilder {
 
     /// @brief Convert a CI vector to a sparse state
     /// @param C The CI vector to convert
+    /// @param threshold The threshold for including determinants in the sparse state
     /// @return The corresponding sparse state
-    SparseState make_sparse_state(const np_vector& C) const;
+    SparseState make_sparse_state(const np_vector& C, double threshold = 1e-12) const;
 
     /// @brief Compute the spin-dependent one-electron reduced density matrix
     /// @param C_left The left-hand side coefficients
@@ -271,11 +272,11 @@ class CISigmaBuilder {
     np_matrix compute_s_1trdm(const CISigmaBuilder& sigmabuilder_right, np_vector C_left,
                               np_vector C_right, Spin spin) const;
 
-    np_matrix compute_a_1trdm(CISigmaBuilder& sigmabuilder_right, np_vector C_left,
+    np_matrix compute_a_1trdm(const CISigmaBuilder& sigmabuilder_right, np_vector C_left,
                               np_vector C_right) const;
-    np_matrix compute_b_1trdm(CISigmaBuilder& sigmabuilder_right, np_vector C_left,
+    np_matrix compute_b_1trdm(const CISigmaBuilder& sigmabuilder_right, np_vector C_left,
                               np_vector C_right) const;
-    np_matrix compute_sf_1trdm(CISigmaBuilder& sigmabuilder_right, np_vector C_left,
+    np_matrix compute_sf_1trdm(const CISigmaBuilder& sigmabuilder_right, np_vector C_left,
                                np_vector C_right) const;
 
   private:

--- a/forte2/ci/ci_sigma_builder_1trdm.cc
+++ b/forte2/ci/ci_sigma_builder_1trdm.cc
@@ -106,4 +106,23 @@ np_matrix CISigmaBuilder::compute_s_1trdm(const CISigmaBuilder& sigmabuilder_rig
     return rdm;
 }
 
+np_matrix CISigmaBuilder::compute_a_1trdm(CISigmaBuilder& sigmabuilder_right, np_vector C_left, np_vector C_right) const {
+    return compute_s_1trdm(sigmabuilder_right, C_left, C_right, Spin::Alpha);
+}
+
+np_matrix CISigmaBuilder::compute_b_1trdm(CISigmaBuilder& sigmabuilder_right, np_vector C_left, np_vector C_right) const {
+    return compute_s_1trdm(sigmabuilder_right, C_left, C_right, Spin::Beta);
+}
+
+np_matrix CISigmaBuilder::compute_sf_1trdm(CISigmaBuilder& sigmabuilder_right, np_vector C_left, np_vector C_right) const {
+    auto sf_1trdm = make_zeros<nb::numpy, double, 2>({lists_.norb(), lists_.norb()});
+    if (lists_.norb() > 0) {
+        auto a_1trdm = compute_a_1trdm(sigmabuilder_right, C_left, C_right);
+        auto b_1trdm = compute_b_1trdm(sigmabuilder_right, C_left, C_right);
+        matrix::daxpy<double>(1.0, a_1trdm, sf_1trdm);
+        matrix::daxpy<double>(1.0, b_1trdm, sf_1trdm);
+    }
+    return sf_1trdm;
+}
+
 } // namespace forte2

--- a/forte2/ci/ci_sigma_builder_1trdm.cc
+++ b/forte2/ci/ci_sigma_builder_1trdm.cc
@@ -35,6 +35,8 @@ np_matrix CISigmaBuilder::compute_s_1trdm(const CISigmaBuilder& sigmabuilder_rig
     if ((is_alpha(spin) and (na_left < 1)) or (is_beta(spin) and (nb_left < 1)) or (norb < 1))
         return rdm;
 
+    auto rdm_view = rdm.view();
+
     const auto& alfa_address_left = lists_left.alfa_address();
     const auto& beta_address_left = lists_left.beta_address();
     const auto& alfa_address_right = lists_right.alfa_address();
@@ -47,7 +49,6 @@ np_matrix CISigmaBuilder::compute_s_1trdm(const CISigmaBuilder& sigmabuilder_rig
     // need strings for the part that is affected by the a^+_p a_q operator.
     VOListMap vo_list = find_ov_string_map(lists_left, lists_right, spin);
 
-    auto rdm_data = rdm.data();
     auto Cl_span = vector::as_span<double>(C_left);
     auto Cr_span = vector::as_span<double>(C_right);
 
@@ -59,7 +60,8 @@ np_matrix CISigmaBuilder::compute_s_1trdm(const CISigmaBuilder& sigmabuilder_rig
         if (lists_right.block_size(nI) == 0)
             continue;
 
-        auto tr = gather_block(Cr_span, TR, spin, lists_left, class_Ia, class_Ib);
+        auto tr =
+            gather_block(Cr_span, sigmabuilder_right.TR, spin, lists_right, class_Ia, class_Ib);
 
         for (const auto& [nJ, class_Ja, class_Jb] : lists_left.determinant_classes()) {
             // check if the string class on which we don't act is the same for I and J
@@ -76,8 +78,7 @@ np_matrix CISigmaBuilder::compute_s_1trdm(const CISigmaBuilder& sigmabuilder_rig
             if (lists_left.block_size(nJ) == 0)
                 continue;
 
-            auto tl =
-                gather_block(Cl_span, sigmabuilder_right.TL, spin, lists_right, class_Ja, class_Jb);
+            auto tl = gather_block(Cl_span, TL, spin, lists_left, class_Ja, class_Jb);
 
             const auto& string_list_block = is_alpha(spin)
                                                 ? string_list[std::make_pair(class_Ib, class_Jb)]
@@ -86,11 +87,11 @@ np_matrix CISigmaBuilder::compute_s_1trdm(const CISigmaBuilder& sigmabuilder_rig
             const auto& pq_vo_list = is_alpha(spin) ? vo_list[std::make_pair(class_Ia, class_Ja)]
                                                     : vo_list[std::make_pair(class_Ib, class_Jb)];
 
-            const size_t maxL_left = is_alpha(spin) ? beta_address_left->strpcls(class_Ib)
-                                                    : alfa_address_left->strpcls(class_Ia);
+            const size_t maxL_left = is_alpha(spin) ? beta_address_left->strpcls(class_Jb)
+                                                    : alfa_address_left->strpcls(class_Ja);
 
-            const size_t maxL_right = is_alpha(spin) ? beta_address_right->strpcls(class_Jb)
-                                                     : alfa_address_right->strpcls(class_Ja);
+            const size_t maxL_right = is_alpha(spin) ? beta_address_right->strpcls(class_Ib)
+                                                     : alfa_address_right->strpcls(class_Ia);
 
             for (const auto& [pq, vo_list] : pq_vo_list) {
                 const auto& [p, q] = pq;
@@ -99,22 +100,25 @@ np_matrix CISigmaBuilder::compute_s_1trdm(const CISigmaBuilder& sigmabuilder_rig
                     for (const auto& [Ip, Jp] : string_list_block)
                         rdm_element += sign * tl[J * maxL_left + Jp] * tr[I * maxL_right + Ip];
                 }
-                rdm_data[p * norb + q] += rdm_element;
+                rdm_view(p, q) += rdm_element;
             }
         }
     }
     return rdm;
 }
 
-np_matrix CISigmaBuilder::compute_a_1trdm(CISigmaBuilder& sigmabuilder_right, np_vector C_left, np_vector C_right) const {
+np_matrix CISigmaBuilder::compute_a_1trdm(CISigmaBuilder& sigmabuilder_right, np_vector C_left,
+                                          np_vector C_right) const {
     return compute_s_1trdm(sigmabuilder_right, C_left, C_right, Spin::Alpha);
 }
 
-np_matrix CISigmaBuilder::compute_b_1trdm(CISigmaBuilder& sigmabuilder_right, np_vector C_left, np_vector C_right) const {
+np_matrix CISigmaBuilder::compute_b_1trdm(CISigmaBuilder& sigmabuilder_right, np_vector C_left,
+                                          np_vector C_right) const {
     return compute_s_1trdm(sigmabuilder_right, C_left, C_right, Spin::Beta);
 }
 
-np_matrix CISigmaBuilder::compute_sf_1trdm(CISigmaBuilder& sigmabuilder_right, np_vector C_left, np_vector C_right) const {
+np_matrix CISigmaBuilder::compute_sf_1trdm(CISigmaBuilder& sigmabuilder_right, np_vector C_left,
+                                           np_vector C_right) const {
     auto sf_1trdm = make_zeros<nb::numpy, double, 2>({lists_.norb(), lists_.norb()});
     if (lists_.norb() > 0) {
         auto a_1trdm = compute_a_1trdm(sigmabuilder_right, C_left, C_right);

--- a/forte2/ci/ci_sigma_builder_1trdm.cc
+++ b/forte2/ci/ci_sigma_builder_1trdm.cc
@@ -3,6 +3,7 @@
 #include "helpers/np_vector_functions.h"
 
 #include "ci_sigma_builder.h"
+#include "ci_strings_makers.h"
 
 namespace forte2 {
 
@@ -52,7 +53,7 @@ np_matrix CISigmaBuilder::compute_s_1trdm(const CISigmaBuilder& sigmabuilder_rig
     // <Ja|a^{+}_p a_q|Ia> CL_{Ja,K} CR_{Ia,K}
 
     // loop over blocks of matrix C
-    for (const auto& [nI, class_Ia, class_Ib] : lists_right->determinant_classes()) {
+    for (const auto& [nI, class_Ia, class_Ib] : lists_right.determinant_classes()) {
         if (lists_right->detpblk(nI) == 0)
             continue;
 

--- a/forte2/ci/ci_sigma_builder_1trdm.cc
+++ b/forte2/ci/ci_sigma_builder_1trdm.cc
@@ -48,23 +48,27 @@ np_matrix CISigmaBuilder::compute_s_1trdm(const CISigmaBuilder& sigmabuilder_rig
     VOListMap vo_list = find_ov_string_map(lists_left, lists_right, spin);
 
     auto rdm_data = rdm.data();
+    auto Cl_span = vector::as_span<double>(C_left);
+    auto Cr_span = vector::as_span<double>(C_right);
 
     // Here we compute the RDMs for the case of different irreps
     // <Ja|a^{+}_p a_q|Ia> CL_{Ja,K} CR_{Ia,K}
 
     // loop over blocks of matrix C
     for (const auto& [nI, class_Ia, class_Ib] : lists_right.determinant_classes()) {
-        if (lists_right->detpblk(nI) == 0)
+        if (lists_right.block_size(nI) == 0)
             continue;
 
-        auto Cr = C_right.gather_C_block(GenCIVector::get_CR(), alfa, alfa_address_right,
-                                         beta_address_right, class_Ia, class_Ib, false);
+        auto tr = gather_block(Cr_span, TR, spin, lists_left, class_Ia, class_Ib);
 
-        for (const auto& [nJ, class_Ja, class_Jb] : lists_left->determinant_classes()) {
+        // auto Cr = C_right.gather_C_block(GenCIVector::get_CR(), alfa, alfa_address_right,
+        //                                  beta_address_right, class_Ia, class_Ib, false);
+
+        for (const auto& [nJ, class_Ja, class_Jb] : lists_left.determinant_classes()) {
             // check if the string class on which we don't act is the same for I and J
             // here we cannot assume that the two classes must coincide. So we just check if
             // there are elements in the string list for the given pair of classes
-            if (alfa) {
+            if (is_alpha(spin)) {
                 if (string_list.count(std::make_pair(class_Ib, class_Jb)) == 0)
                     continue;
             } else {
@@ -72,26 +76,36 @@ np_matrix CISigmaBuilder::compute_s_1trdm(const CISigmaBuilder& sigmabuilder_rig
                     continue;
             }
 
-            if (lists_left->detpblk(nJ) == 0)
+            if (lists_left.block_size(nJ) == 0)
                 continue;
 
-            auto Cl = C_left.gather_C_block(GenCIVector::get_CL(), alfa, alfa_address_left,
-                                            beta_address_left, class_Ja, class_Jb, false);
+            auto tl =
+                gather_block(Cl_span, sigmabuilder_right.TL, spin, lists_right, class_Ja, class_Jb);
 
-            const auto& string_list_block = alfa ? string_list[std::make_pair(class_Ib, class_Jb)]
-                                                 : string_list[std::make_pair(class_Ia, class_Ja)];
+            // auto Cl = C_left.gather_C_block(GenCIVector::get_CL(), alfa, alfa_address_left,
+            //                                 beta_address_left, class_Ja, class_Jb, false);
 
-            const auto& pq_vo_list = alfa ? vo_list[std::make_pair(class_Ia, class_Ja)]
-                                          : vo_list[std::make_pair(class_Ib, class_Jb)];
+            const auto& string_list_block = is_alpha(spin)
+                                                ? string_list[std::make_pair(class_Ib, class_Jb)]
+                                                : string_list[std::make_pair(class_Ia, class_Ja)];
+
+            const auto& pq_vo_list = is_alpha(spin) ? vo_list[std::make_pair(class_Ia, class_Ja)]
+                                                    : vo_list[std::make_pair(class_Ib, class_Jb)];
+
+            const size_t maxL_left = is_alpha(spin) ? beta_address_left->strpcls(class_Ib)
+                                                    : alfa_address_left->strpcls(class_Ia);
+
+            const size_t maxL_right = is_alpha(spin) ? beta_address_right->strpcls(class_Jb)
+                                                     : alfa_address_right->strpcls(class_Ja); //???
 
             for (const auto& [pq, vo_list] : pq_vo_list) {
                 const auto& [p, q] = pq;
                 double rdm_element = 0.0;
                 for (const auto& [sign, I, J] : vo_list) {
                     for (const auto& [Ip, Jp] : string_list_block)
-                        rdm_element += sign * Cl[J][Jp] * Cr[I][Ip];
+                        rdm_element += sign * tl[J * maxL_left + Jp] * tr[I * maxL_right + Ip];
                 }
-                rdm_data[p * ncmo + q] += rdm_element;
+                rdm_data[p * norb + q] += rdm_element;
             }
         }
     }

--- a/forte2/ci/ci_sigma_builder_1trdm.cc
+++ b/forte2/ci/ci_sigma_builder_1trdm.cc
@@ -47,7 +47,7 @@ np_matrix CISigmaBuilder::compute_s_1trdm(const CISigmaBuilder& sigmabuilder_rig
     auto string_list = find_string_map(lists_left, lists_right, spin);
     // Compute the VO lists that map the strings of the right and left wave functions. We only
     // need strings for the part that is affected by the a^+_p a_q operator.
-    VOListMap vo_list = find_ov_string_map(lists_left, lists_right, spin);
+    VOListMap vo_list_map = find_ov_string_map(lists_left, lists_right, spin);
 
     auto Cl_span = vector::as_span<double>(C_left);
     auto Cr_span = vector::as_span<double>(C_right);
@@ -84,8 +84,8 @@ np_matrix CISigmaBuilder::compute_s_1trdm(const CISigmaBuilder& sigmabuilder_rig
                                                 ? string_list[std::make_pair(class_Ib, class_Jb)]
                                                 : string_list[std::make_pair(class_Ia, class_Ja)];
 
-            const auto& pq_vo_list = is_alpha(spin) ? vo_list[std::make_pair(class_Ia, class_Ja)]
-                                                    : vo_list[std::make_pair(class_Ib, class_Jb)];
+            const auto& pq_vo_list = is_alpha(spin) ? vo_list_map[std::make_pair(class_Ia, class_Ja)]
+                                                    : vo_list_map[std::make_pair(class_Ib, class_Jb)];
 
             const size_t maxL_left = is_alpha(spin) ? beta_address_left->strpcls(class_Jb)
                                                     : alfa_address_left->strpcls(class_Ja);
@@ -107,17 +107,17 @@ np_matrix CISigmaBuilder::compute_s_1trdm(const CISigmaBuilder& sigmabuilder_rig
     return rdm;
 }
 
-np_matrix CISigmaBuilder::compute_a_1trdm(CISigmaBuilder& sigmabuilder_right, np_vector C_left,
+np_matrix CISigmaBuilder::compute_a_1trdm(const CISigmaBuilder& sigmabuilder_right, np_vector C_left,
                                           np_vector C_right) const {
     return compute_s_1trdm(sigmabuilder_right, C_left, C_right, Spin::Alpha);
 }
 
-np_matrix CISigmaBuilder::compute_b_1trdm(CISigmaBuilder& sigmabuilder_right, np_vector C_left,
+np_matrix CISigmaBuilder::compute_b_1trdm(const CISigmaBuilder& sigmabuilder_right, np_vector C_left,
                                           np_vector C_right) const {
     return compute_s_1trdm(sigmabuilder_right, C_left, C_right, Spin::Beta);
 }
 
-np_matrix CISigmaBuilder::compute_sf_1trdm(CISigmaBuilder& sigmabuilder_right, np_vector C_left,
+np_matrix CISigmaBuilder::compute_sf_1trdm(const CISigmaBuilder& sigmabuilder_right, np_vector C_left,
                                            np_vector C_right) const {
     auto sf_1trdm = make_zeros<nb::numpy, double, 2>({lists_.norb(), lists_.norb()});
     if (lists_.norb() > 0) {

--- a/forte2/ci/ci_sigma_builder_1trdm.cc
+++ b/forte2/ci/ci_sigma_builder_1trdm.cc
@@ -61,9 +61,6 @@ np_matrix CISigmaBuilder::compute_s_1trdm(const CISigmaBuilder& sigmabuilder_rig
 
         auto tr = gather_block(Cr_span, TR, spin, lists_left, class_Ia, class_Ib);
 
-        // auto Cr = C_right.gather_C_block(GenCIVector::get_CR(), alfa, alfa_address_right,
-        //                                  beta_address_right, class_Ia, class_Ib, false);
-
         for (const auto& [nJ, class_Ja, class_Jb] : lists_left.determinant_classes()) {
             // check if the string class on which we don't act is the same for I and J
             // here we cannot assume that the two classes must coincide. So we just check if
@@ -82,9 +79,6 @@ np_matrix CISigmaBuilder::compute_s_1trdm(const CISigmaBuilder& sigmabuilder_rig
             auto tl =
                 gather_block(Cl_span, sigmabuilder_right.TL, spin, lists_right, class_Ja, class_Jb);
 
-            // auto Cl = C_left.gather_C_block(GenCIVector::get_CL(), alfa, alfa_address_left,
-            //                                 beta_address_left, class_Ja, class_Jb, false);
-
             const auto& string_list_block = is_alpha(spin)
                                                 ? string_list[std::make_pair(class_Ib, class_Jb)]
                                                 : string_list[std::make_pair(class_Ia, class_Ja)];
@@ -96,7 +90,7 @@ np_matrix CISigmaBuilder::compute_s_1trdm(const CISigmaBuilder& sigmabuilder_rig
                                                     : alfa_address_left->strpcls(class_Ia);
 
             const size_t maxL_right = is_alpha(spin) ? beta_address_right->strpcls(class_Jb)
-                                                     : alfa_address_right->strpcls(class_Ja); //???
+                                                     : alfa_address_right->strpcls(class_Ja);
 
             for (const auto& [pq, vo_list] : pq_vo_list) {
                 const auto& [p, q] = pq;

--- a/forte2/ci/ci_sigma_builder_1trdm.cc
+++ b/forte2/ci/ci_sigma_builder_1trdm.cc
@@ -1,0 +1,100 @@
+#include "helpers/timer.hpp"
+#include "helpers/np_matrix_functions.h"
+#include "helpers/np_vector_functions.h"
+
+#include "ci_sigma_builder.h"
+
+namespace forte2 {
+
+np_matrix CISigmaBuilder::compute_s_1trdm(const CISigmaBuilder& sigmabuilder_right,
+                                          np_vector C_left, np_vector C_right, Spin spin) const {
+    const auto& sigmabuilder_left = *this;
+
+    const auto& lists_left = sigmabuilder_left.lists_;
+    const auto& lists_right = sigmabuilder_right.lists_;
+
+    // Get the number of electrons
+    const auto na_left = lists_left.na();
+    const auto nb_left = lists_left.nb();
+    const auto na_right = lists_right.na();
+    const auto nb_right = lists_right.nb();
+    const auto norb = lists_left.norb();
+
+    if (lists_left.norb() != lists_right.norb()) {
+        throw std::runtime_error("FCI transition RDMs: The number of MOs must be the same in "
+                                 "the two wave functions.");
+    }
+
+    if (na_left != na_right or nb_left != nb_right) {
+        throw std::runtime_error("FCI transition RDMs: The number of alfa and beta electrons "
+                                 "must be the same in the "
+                                 "two wave functions.");
+    }
+    auto rdm = make_zeros<nb::numpy, double, 2>({norb, norb});
+    if ((is_alpha(spin) and (na_left < 1)) or (is_beta(spin) and (nb_left < 1)) or (norb < 1))
+        return rdm;
+
+    const auto& alfa_address_left = lists_left.alfa_address();
+    const auto& beta_address_left = lists_left.beta_address();
+    const auto& alfa_address_right = lists_right.alfa_address();
+    const auto& beta_address_right = lists_right.beta_address();
+
+    // Compute the lists that map the strings of the right and left wave functions. We only need
+    // strings for the part that is left untouched by the a^+_p a_q operator.
+    auto string_list = find_string_map(lists_left, lists_right, spin);
+    // Compute the VO lists that map the strings of the right and left wave functions. We only
+    // need strings for the part that is affected by the a^+_p a_q operator.
+    VOListMap vo_list = find_ov_string_map(lists_left, lists_right, spin);
+
+    auto rdm_data = rdm.data();
+
+    // Here we compute the RDMs for the case of different irreps
+    // <Ja|a^{+}_p a_q|Ia> CL_{Ja,K} CR_{Ia,K}
+
+    // loop over blocks of matrix C
+    for (const auto& [nI, class_Ia, class_Ib] : lists_right->determinant_classes()) {
+        if (lists_right->detpblk(nI) == 0)
+            continue;
+
+        auto Cr = C_right.gather_C_block(GenCIVector::get_CR(), alfa, alfa_address_right,
+                                         beta_address_right, class_Ia, class_Ib, false);
+
+        for (const auto& [nJ, class_Ja, class_Jb] : lists_left->determinant_classes()) {
+            // check if the string class on which we don't act is the same for I and J
+            // here we cannot assume that the two classes must coincide. So we just check if
+            // there are elements in the string list for the given pair of classes
+            if (alfa) {
+                if (string_list.count(std::make_pair(class_Ib, class_Jb)) == 0)
+                    continue;
+            } else {
+                if (string_list.count(std::make_pair(class_Ia, class_Ja)) == 0)
+                    continue;
+            }
+
+            if (lists_left->detpblk(nJ) == 0)
+                continue;
+
+            auto Cl = C_left.gather_C_block(GenCIVector::get_CL(), alfa, alfa_address_left,
+                                            beta_address_left, class_Ja, class_Jb, false);
+
+            const auto& string_list_block = alfa ? string_list[std::make_pair(class_Ib, class_Jb)]
+                                                 : string_list[std::make_pair(class_Ia, class_Ja)];
+
+            const auto& pq_vo_list = alfa ? vo_list[std::make_pair(class_Ia, class_Ja)]
+                                          : vo_list[std::make_pair(class_Ib, class_Jb)];
+
+            for (const auto& [pq, vo_list] : pq_vo_list) {
+                const auto& [p, q] = pq;
+                double rdm_element = 0.0;
+                for (const auto& [sign, I, J] : vo_list) {
+                    for (const auto& [Ip, Jp] : string_list_block)
+                        rdm_element += sign * Cl[J][Jp] * Cr[I][Ip];
+                }
+                rdm_data[p * ncmo + q] += rdm_element;
+            }
+        }
+    }
+    return rdm;
+}
+
+} // namespace forte2

--- a/forte2/ci/ci_sigma_builder_test_rdms.cc
+++ b/forte2/ci/ci_sigma_builder_test_rdms.cc
@@ -13,7 +13,7 @@ SparseState get_sparse_state(np_vector c, const CIStrings& lists) {
     auto c_span = vector::as_span<double>(c);
     SparseState state;
     auto dets = lists.make_determinants();
-    for (size_t i{0}, maxi{dets.size()}; i < maxi; ++i) {
+    for (std::size_t i{0}, maxi{dets.size()}; i < maxi; ++i) {
         state[dets[i]] = c_span[i];
     }
     return state;

--- a/forte2/ci/ci_strings_makers.cc
+++ b/forte2/ci/ci_strings_makers.cc
@@ -345,9 +345,9 @@ find_string_map(const CIStrings& list_left, const CIStrings& list_right, Spin sp
 
 VOListMap find_ov_string_map(const CIStrings& list_left, const CIStrings& list_right, Spin spin) {
     const auto& strings_right =
-        is_alpha(spin) ? list_right.beta_strings() : list_right.alfa_strings();
-    const auto& I_address = is_alpha(spin) ? list_right.beta_address() : list_right.alfa_address();
-    const auto& J_address = is_alpha(spin) ? list_left.beta_address() : list_left.alfa_address();
+        is_alpha(spin) ? list_right.alfa_strings() : list_right.beta_strings();
+    const auto& I_address = is_alpha(spin) ? list_right.alfa_address() : list_right.beta_address();
+    const auto& J_address = is_alpha(spin) ? list_left.alfa_address() : list_left.beta_address();
     auto vo_list = make_vo_list(strings_right, I_address, J_address);
     return vo_list;
 }

--- a/forte2/ci/ci_strings_makers.cc
+++ b/forte2/ci/ci_strings_makers.cc
@@ -321,10 +321,11 @@ H3List make_3h_list(const StringList& strings, std::shared_ptr<StringAddress> ad
 }
 
 std::map<std::pair<int, int>, std::vector<std::pair<int, int>>>
-find_string_map(const CIStrings& list_left, const CIStrings& list_right, bool alfa) {
+find_string_map(const CIStrings& list_left, const CIStrings& list_right, Spin spin) {
     std::map<std::pair<int, int>, std::vector<std::pair<int, int>>> m;
-    const auto& strings_right = alfa ? list_right.beta_strings() : list_right.alfa_strings();
-    const auto& address_left = alfa ? list_left.beta_address() : list_left.alfa_address();
+    const auto& strings_right =
+        is_alpha(spin) ? list_right.beta_strings() : list_right.alfa_strings();
+    const auto& address_left = is_alpha(spin) ? list_left.beta_address() : list_left.alfa_address();
     // loop over all the right string classes (I)
     for (int class_I{0}; const auto& string_class_right : strings_right) {
         // loop over all the right strings (I)
@@ -342,10 +343,11 @@ find_string_map(const CIStrings& list_left, const CIStrings& list_right, bool al
     return m;
 }
 
-VOListMap find_ov_string_map(const CIStrings& list_left, const CIStrings& list_right, bool alfa) {
-    const auto& strings_right = alfa ? list_right.alfa_strings() : list_right.beta_strings();
-    const auto& I_address = alfa ? list_right.alfa_address() : list_right.beta_address();
-    const auto& J_address = alfa ? list_left.alfa_address() : list_left.beta_address();
+VOListMap find_ov_string_map(const CIStrings& list_left, const CIStrings& list_right, Spin spin) {
+    const auto& strings_right =
+        is_alpha(spin) ? list_right.beta_strings() : list_right.alfa_strings();
+    const auto& I_address = is_alpha(spin) ? list_right.beta_address() : list_right.alfa_address();
+    const auto& J_address = is_alpha(spin) ? list_left.beta_address() : list_left.alfa_address();
     auto vo_list = make_vo_list(strings_right, I_address, J_address);
     return vo_list;
 }

--- a/forte2/ci/ci_strings_makers.h
+++ b/forte2/ci/ci_strings_makers.h
@@ -70,4 +70,9 @@ H3List make_3h_list(const StringList& strings, std::shared_ptr<StringAddress> ad
 H1List2 make_1h_list2(const StringList& strings, std::shared_ptr<StringAddress> address,
                       std::shared_ptr<StringAddress> address_1h);
 
+std::map<std::pair<int, int>, std::vector<std::pair<int, int>>>
+find_string_map(const CIStrings& list_left, const CIStrings& list_right, Spin spin);
+
+VOListMap find_ov_string_map(const CIStrings& list_left, const CIStrings& list_right, Spin spin);
+
 } // namespace forte2

--- a/forte2/ci/ci_strings_makers.h
+++ b/forte2/ci/ci_strings_makers.h
@@ -5,6 +5,9 @@
 #include "ci/ci_strings_defs.h"
 #include "ci/ci_string_address.h"
 #include "ci/ci_string_class.h"
+#include "ci/ci_strings.h"
+
+#include "helpers/spin.h"
 
 namespace forte2 {
 

--- a/forte2/ci/ci_utils.py
+++ b/forte2/ci/ci_utils.py
@@ -1,3 +1,5 @@
+from collections import OrderedDict
+
 import numpy as np
 
 from forte2 import CIStrings
@@ -199,9 +201,9 @@ def pretty_print_ci_dets(
 
 def pretty_print_ci_transition_props(
     sa_info: StateAverageInfo,
-    tdm_per_solver,
-    fosc_per_solver,
-    eigvals_per_solver,
+    transition_dipoles: OrderedDict,
+    oscillator_strengths: OrderedDict,
+    eigvals_per_solver: list[list[float]],
     thres=1e-4,
 ):
     """
@@ -212,9 +214,12 @@ def pretty_print_ci_transition_props(
     ----------
     sa_info : StateAverageInfo
         An instance of `StateAverageInfo` that holds information about the states and their properties.
-    tdm_per_solver : OrderedDict
+    transition_dipoles : OrderedDict
         A dictionary with keys as tuples (i, j) representing the initial and final states,
         and values as the transition dipole moments for each component (x, y, z).
+    oscillator_strengths : OrderedDict
+        A dictionary with keys as tuples (i, j) representing the initial and final states,
+        and values as the oscillator strengths for each transition.
     eigvals_per_solver : list[list[float]]
         A list of lists containing the eigenvalues (energies) for each CI solver.
     """
@@ -224,11 +229,10 @@ def pretty_print_ci_transition_props(
     logger.log_info1("=" * width)
     logger.log_info1(f"{'State':<12} {'Dipole moment':<30}")
     logger.log_info1("-" * width)
-    for ici in range(sa_info.ncis):
-        for iroot in range(sa_info.nroots[ici]):
-            dip = tdm_per_solver[ici][(iroot, iroot)]
-            dip_str = "[" + ", ".join(f"{d:>7.4f}" for d in dip) + "]"
-            logger.log_info1(f"{f'{iroot}':<12} {dip_str:<30}")
+    for iroot in range(sa_info.nroots_sum):
+        dip = transition_dipoles[(iroot, iroot)]
+        dip_str = "[" + ", ".join(f"{d:>7.4f}" for d in dip) + "]"
+        logger.log_info1(f"{f'{iroot}':<12} {dip_str:<30}")
     logger.log_info1("=" * width)
 
     logger.log_info1(f"\nBright transitions (oscillator strength > {thres:5.2e}):")
@@ -240,20 +244,23 @@ def pretty_print_ci_transition_props(
     )
     logger.log_info1("-" * width)
     nbright = 0
-    for ici in range(sa_info.ncis):
-        for k, v in tdm_per_solver[ici].items():
-            i, j = k
-            dip = v
-            vte = (eigvals_per_solver[ici][j] - eigvals_per_solver[ici][i]) * EH_TO_EV
-            osc = fosc_per_solver[ici][k]
-            if osc > thres:
-                nbright += 1
-                info = f"{f'{iroot+i}->{iroot+j}':<12} "
-                info += f"{osc:<10.6f} {vte:<10.6f} "
-                dip = "[" + ", ".join(f"{d:>7.4f}" for d in dip) + "]"
-                info += f"{dip:<30}"
-                logger.log_info1(info)
-        iroot += sa_info.nroots[ici]
+    for k, v in transition_dipoles.items():
+        i, j = k
+        dip = v
+        isolver, iroot_in_solver = sa_info.absolute_root_map[i]
+        jsolver, jroot_in_solver = sa_info.absolute_root_map[j]
+        vte = (
+            eigvals_per_solver[jsolver][jroot_in_solver]
+            - eigvals_per_solver[isolver][iroot_in_solver]
+        ) * EH_TO_EV
+        osc = oscillator_strengths[k]
+        if osc > thres:
+            nbright += 1
+            info = f"{f'{i}->{j}':<12} "
+            info += f"{osc:<10.6f} {vte:<10.6f} "
+            dip = "[" + ", ".join(f"{d:>7.4f}" for d in dip) + "]"
+            info += f"{dip:<30}"
+            logger.log_info1(info)
     if nbright == 0:
         logger.log_info1("No bright transitions found.")
     logger.log_info1("=" * width)

--- a/forte2/dsrg/dsrg_base.py
+++ b/forte2/dsrg/dsrg_base.py
@@ -3,7 +3,8 @@ from abc import ABC, abstractmethod
 
 import numpy as np
 
-from forte2.base_classes import SystemMixin, MOsMixin, MOSpaceMixin, ActiveSpaceSolver
+from forte2.base_classes import SystemMixin, MOsMixin, MOSpaceMixin, CIBase, RelCIBase
+from forte2.mcopt.mc_optimizer import MCOptimizerBase
 from forte2.helpers import logger
 from forte2.orbitals import Semicanonicalizer
 from forte2.ci.ci_utils import pretty_print_ci_summary
@@ -32,8 +33,8 @@ class DSRGBase(SystemMixin, MOsMixin, MOSpaceMixin, ABC):
     def __call__(self, parent_method):
         self.parent_method = parent_method
         assert isinstance(
-            self.parent_method, ActiveSpaceSolver
-        ), "Parent method must be an ActiveSpaceSolver."
+            self.parent_method, (CIBase, RelCIBase, MCOptimizerBase)
+        ), "Parent method must be an instance of CIBase, RelCIBase, or MCOptimizerBase."
         # This is to ensure that the CI vectors are converged after
         # the basis is changed to semicanonical orbitals.
         # We could handle it here, but it's cleaner to enforce it at the parent method level.

--- a/forte2/mcopt/__init__.py
+++ b/forte2/mcopt/__init__.py
@@ -1,1 +1,1 @@
-from .mc_optimizer import MCOptimizer, RelMCOptimizer
+from .mc_optimizer import MCOptimizer

--- a/forte2/mcopt/mc_optimizer.py
+++ b/forte2/mcopt/mc_optimizer.py
@@ -391,8 +391,8 @@ class MCOptimizerBase(ABC, SystemMixin, MOsMixin, MOSpaceMixin):
             self.ci_solver.compute_transition_properties(self.C[0])
             pretty_print_ci_transition_props(
                 self.ci_solver.sa_info,
-                self.ci_solver.tdm_per_solver,
-                self.ci_solver.fosc_per_solver,
+                self.ci_solver.transition_dipoles,
+                self.ci_solver.oscillator_strengths,
                 self.ci_solver.evals_per_solver,
             )
 

--- a/forte2/mcopt/mc_optimizer.py
+++ b/forte2/mcopt/mc_optimizer.py
@@ -25,7 +25,7 @@ from .orbital_optimizer import OrbOptimizer, RelOrbOptimizer
 
 
 @dataclass
-class MCOptimizer(ActiveSpaceSolver):
+class MCOptimizerBase(ActiveSpaceSolver):
     """
     Two-step optimizer for multi-configurational wavefunctions.
 
@@ -65,7 +65,7 @@ class MCOptimizer(ActiveSpaceSolver):
         Maximum number of microiterations for L-BFGS.
     max_rotation : float, optional, default=0.2
         Maximum orbital rotation size for L-BFGS.
-    ci_solver : CIBase | RelCIBase, optional
+    ci_solver : CIBase | RelCIBase | None, optional
         Custom CI solver to use in the optimization.
         If not provided, a default CISolver or RelCISolver will be used based on the `two_component` flag.
     ci_params : CIParams, optional
@@ -97,7 +97,7 @@ class MCOptimizer(ActiveSpaceSolver):
     max_rotation: float = 0.2
 
     ### CI solver parameters
-    ci_solver: CIBase | RelCIBase = field(default=None)
+    ci_solver: CIBase | RelCIBase | None = field(default=None)
     ci_params: CIParams = field(default_factory=CIParams)
     davidson_liu_params: DavidsonLiuParams = field(default_factory=DavidsonLiuParams)
 
@@ -203,7 +203,10 @@ class MCOptimizer(ActiveSpaceSolver):
                 die_if_not_converged=False,
                 ci_params=self.ci_params,
                 davidson_liu_params=self.davidson_liu_params,
-            )(self.parent_method)
+            )
+        self.ci_solver = self.ci_solver(
+            self.parent_method
+        )  # make sure to pass parent method to CI solver
         # iteration 0: one step of CI optimization to bootstrap the orbital optimization
         self.iter = 0
         self.ci_solver.run()
@@ -494,6 +497,8 @@ class MCOptimizer(ActiveSpaceSolver):
     def make_average_cumulants(self):
         return self.ci_solver.make_average_cumulants()
 
+
+class MCOptimizer(MCOptimizerBase):
     def make_sd_1rdm(
         self,
         left_root: int,
@@ -531,4 +536,4 @@ class MCOptimizer(ActiveSpaceSolver):
 
 
 @dataclass
-class RelMCOptimizer(RelActiveSpaceSolver, MCOptimizer): ...
+class RelMCOptimizer(RelActiveSpaceSolver, MCOptimizerBase): ...

--- a/forte2/mcopt/mc_optimizer.py
+++ b/forte2/mcopt/mc_optimizer.py
@@ -4,9 +4,11 @@ from numpy.typing import NDArray
 from dataclasses import dataclass, field
 
 from forte2.ci import CISolver, RelCISolver
-from forte2.base_classes.active_space_solver import (
+from forte2.base_classes import (
     ActiveSpaceSolver,
     RelActiveSpaceSolver,
+    CIBase,
+    RelCIBase,
 )
 from forte2.base_classes.params import DavidsonLiuParams, CIParams
 from forte2.orbitals import Semicanonicalizer
@@ -63,6 +65,9 @@ class MCOptimizer(ActiveSpaceSolver):
         Maximum number of microiterations for L-BFGS.
     max_rotation : float, optional, default=0.2
         Maximum orbital rotation size for L-BFGS.
+    ci_solver : CIBase | RelCIBase, optional
+        Custom CI solver to use in the optimization.
+        If not provided, a default CISolver or RelCISolver will be used based on the `two_component` flag.
     ci_params : CIParams, optional
         Parameters for the CI solver.
     davidson_liu_params : DavidsonLiuParams, optional
@@ -92,6 +97,7 @@ class MCOptimizer(ActiveSpaceSolver):
     max_rotation: float = 0.2
 
     ### CI solver parameters
+    ci_solver: CIBase | RelCIBase = field(default=None)
     ci_params: CIParams = field(default_factory=CIParams)
     davidson_liu_params: DavidsonLiuParams = field(default_factory=DavidsonLiuParams)
 
@@ -102,6 +108,14 @@ class MCOptimizer(ActiveSpaceSolver):
     converged: bool = field(default=False, init=False)
     executed: bool = field(default=False, init=False)
     two_component: bool = field(default=False, init=False)
+
+    def __post_init__(self):
+        super().__post_init__()
+        if self.ci_solver is not None:
+            if not isinstance(self.ci_solver, (CIBase, RelCIBase)):
+                raise ValueError(
+                    f"ci_solver must be an instance of CIBase or RelCIBase, but got {type(self.ci_solver)}."
+                )
 
     def __call__(self, method):
         self.parent_method = method
@@ -177,18 +191,19 @@ class MCOptimizer(ActiveSpaceSolver):
             and not self.freeze_inter_gas_rots,
         )
 
-        _CISolver = RelCISolver if self.two_component else CISolver
-        self.ci_solver = _CISolver(
-            states=self.states,
-            core_orbitals=self.mo_space.docc_orbitals,
-            active_orbitals=self.mo_space.active_orbitals,
-            nroots=self.sa_info.nroots,
-            weights=self.sa_info.weights,
-            log_level=self.ci_solver_verbosity,
-            die_if_not_converged=False,
-            ci_params=self.ci_params,
-            davidson_liu_params=self.davidson_liu_params,
-        )(self.parent_method)
+        if self.ci_solver is None:
+            _CISolver = RelCISolver if self.two_component else CISolver
+            self.ci_solver = _CISolver(
+                states=self.states,
+                core_orbitals=self.mo_space.docc_orbitals,
+                active_orbitals=self.mo_space.active_orbitals,
+                nroots=self.sa_info.nroots,
+                weights=self.sa_info.weights,
+                log_level=self.ci_solver_verbosity,
+                die_if_not_converged=False,
+                ci_params=self.ci_params,
+                davidson_liu_params=self.davidson_liu_params,
+            )(self.parent_method)
         # iteration 0: one step of CI optimization to bootstrap the orbital optimization
         self.iter = 0
         self.ci_solver.run()
@@ -479,100 +494,40 @@ class MCOptimizer(ActiveSpaceSolver):
     def make_average_cumulants(self):
         return self.ci_solver.make_average_cumulants()
 
-    def _get_state_root(self, absolute_root) -> tuple[int, int]:
-        if absolute_root < 0 or absolute_root >= self.sa_info.nroots_sum:
-            raise ValueError(
-                f"absolute_root must be between 0 and {self.sa_info.nroots_sum - 1}, but got {absolute_root}."
-            )
-        return self.sa_info.absolute_root_map[absolute_root]
-
-    def _validate_rdm_inputs(self, left_root, right_root):
-        left_state, left_root_in_state = self._get_state_root(left_root)
-        if right_root is not None:
-            right_state, right_root_in_state = self._get_state_root(right_root)
-        else:
-            right_state = left_state
-            right_root_in_state = left_root_in_state
-
-        if left_state != right_state:
-            raise ValueError(
-                f"Cross-state RDMs are not supported. Got left_root in state {left_state} and right_root in state {right_state}."
-            )
-        return left_state, right_state, left_root_in_state, right_root_in_state
-
     def make_sd_1rdm(
         self,
         left_root: int,
         right_root: int | None = None,
     ) -> tuple[NDArray, NDArray]:
-        """
-        Make the spin-dependent 1-RDMs
-        """
-        left_state, right_state, left_root_in_state, right_root_in_state = (
-            self._validate_rdm_inputs(left_root, right_root)
-        )
-        return self.ci_solver.sub_solvers[left_state].make_sd_1rdm(
-            left_root_in_state, right_root_in_state
-        )
+        return self.ci_solver.make_sd_1rdm(left_root, right_root)
 
     def make_sd_2rdm(
         self,
         left_root: int,
         right_root: int | None = None,
     ) -> tuple[NDArray, NDArray, NDArray]:
-        left_state, right_state, left_root_in_state, right_root_in_state = (
-            self._validate_rdm_inputs(left_root, right_root)
-        )
-
-        if left_state != right_state:
-            raise ValueError(
-                f"Cross-state RDMs are not supported. Got left_root in state {left_state} and right_root in state {right_state}."
-            )
-        return self.ci_solver.sub_solvers[left_state].make_sd_2rdm(
-            left_root_in_state, right_root_in_state
-        )
+        return self.ci_solver.make_sd_2rdm(left_root, right_root)
 
     def make_sd_3rdm(
         self,
         left_root: int,
         right_root: int | None = None,
     ) -> tuple[NDArray, NDArray, NDArray, NDArray]:
-        left_state, right_state, left_root_in_state, right_root_in_state = (
-            self._validate_rdm_inputs(left_root, right_root)
-        )
-
-        if left_state != right_state:
-            raise ValueError(
-                f"Cross-state RDMs are not supported. Got left_root in state {left_state} and right_root in state {right_state}."
-            )
-        return self.ci_solver.sub_solvers[left_state].make_sd_3rdm(
-            left_root_in_state, right_root_in_state
-        )
+        return self.ci_solver.make_sd_3rdm(left_root, right_root)
 
     def make_sf_1rdm(
         self,
         left_root: int,
         right_root: int | None = None,
     ) -> NDArray:
-        left_state, right_state, left_root_in_state, right_root_in_state = (
-            self._validate_rdm_inputs(left_root, right_root)
-        )
-        return self.ci_solver.sub_solvers[left_state].make_sf_1rdm(
-            left_root_in_state, right_root_in_state
-        )
+        return self.ci_solver.make_sf_1rdm(left_root, right_root)
 
     def make_sf_2rdm(
         self,
         left_root: int,
         right_root: int | None = None,
     ) -> NDArray:
-        left_state, right_state, left_root_in_state, right_root_in_state = (
-            self._validate_rdm_inputs(left_root, right_root)
-        )
-
-        return self.ci_solver.sub_solvers[left_state].make_sf_2rdm(
-            left_root_in_state, right_root_in_state
-        )
+        return self.ci_solver.make_sf_2rdm(left_root, right_root)
 
 
 @dataclass

--- a/forte2/mcopt/mc_optimizer.py
+++ b/forte2/mcopt/mc_optimizer.py
@@ -11,8 +11,6 @@ from forte2.base_classes import (
     SystemMixin,
     MOsMixin,
     MOSpaceMixin,
-    CIBase,
-    RelCIBase,
 )
 from forte2.orbitals import Semicanonicalizer
 from forte2.jkbuilder import RestrictedMOIntegrals, SpinorbitalIntegrals
@@ -34,31 +32,16 @@ class MCOptimizerBase(ABC, SystemMixin, MOsMixin, MOSpaceMixin):
 
     Parameters
     ----------
-    states : State | list[State]
-        The electronic states for which the CI is solved. Can be a single state or a list of states.
-        A state-averaged CI is performed if multiple states are provided.
-    nroots : int | list[int], optional, default=1
-        The number of roots to compute.
-        If a list is provided, each element corresponds to the number of roots for each state.
-        If a single integer is provided, `states` must be a single `State` object.
-    weights : list[float] | list[list[float]], optional
-        The weights for state averaging.
-        If a list of lists is provided, each sublist corresponds to the weights for each state.
-        The number of weights must match the number of roots for each state.
-        If not provided, equal weights are assumed for all states.
-        If a single list is provided, `states` must be a single `State` object.
-    mo_space : MOSpace, optional
-        A `MOSpace` object defining the partitioning of the molecular orbitals.
-        If not provided, CISolver must be called with a parent method that has MOSpaceMixin (e.g., AVAS).
-        If provided, it overrides the one from the parent method.
+    ci_solver : CIBase | RelCIBase
+        The CI solver to use. This should be an instance of a class that inherits from CIBase or RelCIBase.
     active_frozen_orbitals : list[int], optional
         List of active orbital indices to be frozen in the MCSCF optimization.
         If provided, all gradients involving these orbitals will be zeroed out.
     maxiter : int, optional, default=50
         Maximum number of macroiterations.
-    econv : float, optional, default=1e-8
+    e_tol : float, optional, default=1e-8
         Energy convergence tolerance.
-    gconv : float, optional, default=1e-7
+    g_tol : float, optional, default=1e-7
         Gradient convergence tolerance.
     die_if_not_converged : bool, optional, default=True
         If True, raises an error if the optimization does not converge.
@@ -68,12 +51,10 @@ class MCOptimizerBase(ABC, SystemMixin, MOsMixin, MOSpaceMixin):
         Maximum number of microiterations for L-BFGS.
     max_rotation : float, optional, default=0.2
         Maximum orbital rotation size for L-BFGS.
-    ci_params : CIParams, optional
-        Parameters for the CI solver.
-    davidson_liu_params : DavidsonLiuParams, optional
-        Parameters for the Davidson-Liu solver used in the CI optimization.
     do_transition_dipole : bool, optional, default=False
-        Whether to compute transition dipole moments.
+        Whether to compute and report transition dipole moments at the end of the optimization.
+    final_orbital : str, optional, default="semicanonical"
+        Whether to return the final orbitals in the semicanonical basis or the original basis.
 
     Notes
     -----
@@ -83,15 +64,15 @@ class MCOptimizerBase(ABC, SystemMixin, MOsMixin, MOSpaceMixin):
     An earlier implementation (CASSCF only) used J. Chem. Phys. 142, 224103 (2015).
     """
 
-    ci_solver: CIBase | RelCIBase | None = field(default=None)
+    ci_solver: CIBase | RelCIBase
 
     active_frozen_orbitals: list[int] = None
     freeze_inter_gas_rots: bool = False
 
     ### Macroiteration parameters
     maxiter: int = 50
-    econv: float = 1e-8
-    gconv: float = 1e-7
+    e_tol: float = 1e-8
+    g_tol: float = 1e-7
     die_if_not_converged: bool = True
 
     ### L-BFGS solver (microiteration) parameters
@@ -106,7 +87,7 @@ class MCOptimizerBase(ABC, SystemMixin, MOsMixin, MOSpaceMixin):
     converged: bool = field(default=False, init=False)
     executed: bool = field(default=False, init=False)
 
-    def _post_init__(self):
+    def __post_init__(self):
         if not isinstance(self.ci_solver, (CIBase, RelCIBase)):
             raise ValueError("ci_solver must be an instance of CIBase or RelCIBase.")
 
@@ -221,7 +202,7 @@ class MCOptimizerBase(ABC, SystemMixin, MOsMixin, MOSpaceMixin):
         # Initialize the LBFGS solver that finds the optimal orbital
         # at fixed CI expansion using the gradient and diagonal Hessian
         self.lbfgs_solver = LBFGS(
-            epsilon=self.gconv,
+            epsilon=self.g_tol,
             max_dir=self.max_rotation,
             step_length_method="max_correction",
             maxiter=self.micro_maxiter,
@@ -235,11 +216,11 @@ class MCOptimizerBase(ABC, SystemMixin, MOsMixin, MOSpaceMixin):
 
         logger.log_info1("Entering orbital optimization loop")
         logger.log_info1("\nConvergence criteria ('.' if satisfied, 'x' otherwise):")
-        logger.log_info1(f"  {'1. RMS(grad)':<32} < {self.gconv:.1e}")
+        logger.log_info1(f"  {'1. RMS(grad)':<32} < {self.g_tol:.1e}")
         logger.log_info1(
-            f"  {'2. max(abs(E_CI_i - E_CI_old_i))':<32} < {self.econv:.1e}"
+            f"  {'2. max(abs(E_CI_i - E_CI_old_i))':<32} < {self.e_tol:.1e}"
         )
-        logger.log_info1(f"  {'3. abs(E_avg - E_avg_old)':<32} < {self.econv:.1e}\n")
+        logger.log_info1(f"  {'3. abs(E_avg - E_avg_old)':<32} < {self.e_tol:.1e}\n")
 
         logger.log_info1("=" * width)
         logger.log_info1(
@@ -464,13 +445,13 @@ class MCOptimizerBase(ABC, SystemMixin, MOsMixin, MOSpaceMixin):
         return nrr
 
     def _check_convergence(self):
-        is_grad_conv = self.g_rms < self.gconv
+        is_grad_conv = self.g_rms < self.g_tol
 
         self.max_ci_de = np.max(np.abs(self.E_ci - self.E_ci_old))
-        is_ci_eigval_conv = self.max_ci_de < self.econv
+        is_ci_eigval_conv = self.max_ci_de < self.e_tol
 
         self.delta_ci_avg = self.E_avg - self.E_avg_old
-        is_ci_avg_conv = abs(self.delta_ci_avg) < self.econv
+        is_ci_avg_conv = abs(self.delta_ci_avg) < self.e_tol
 
         criteria = [
             is_grad_conv,

--- a/forte2/mcopt/mc_optimizer.py
+++ b/forte2/mcopt/mc_optimizer.py
@@ -4,11 +4,15 @@ from numpy.typing import NDArray
 from dataclasses import dataclass, field
 
 from forte2.ci import CISolver, RelCISolver
-from forte2.base_classes.active_space_solver import (
+from forte2.base_classes import (
     ActiveSpaceSolver,
     RelActiveSpaceSolver,
+    CIBase,
+    RelCIBase,
+    SystemMixin,
+    MOsMixin,
+    MOSpaceMixin,
 )
-from forte2.base_classes.params import DavidsonLiuParams, CIParams
 from forte2.orbitals import Semicanonicalizer
 from forte2.jkbuilder import RestrictedMOIntegrals, SpinorbitalIntegrals
 from forte2.helpers import logger, LBFGS
@@ -23,7 +27,7 @@ from .orbital_optimizer import OrbOptimizer, RelOrbOptimizer
 
 
 @dataclass
-class MCOptimizer(ActiveSpaceSolver):
+class MCOptimizer(SystemMixin, MOsMixin, MOSpaceMixin):
     """
     Two-step optimizer for multi-configurational wavefunctions.
 
@@ -78,6 +82,8 @@ class MCOptimizer(ActiveSpaceSolver):
     An earlier implementation (CASSCF only) used J. Chem. Phys. 142, 224103 (2015).
     """
 
+    ci_solver: CIBase | RelCIBase | None = field(default=None)
+
     active_frozen_orbitals: list[int] = None
     freeze_inter_gas_rots: bool = False
 
@@ -91,17 +97,26 @@ class MCOptimizer(ActiveSpaceSolver):
     micro_maxiter: int = 6
     max_rotation: float = 0.2
 
-    ### CI solver parameters
-    ci_params: CIParams = field(default_factory=CIParams)
-    davidson_liu_params: DavidsonLiuParams = field(default_factory=DavidsonLiuParams)
-
     ### Post-iteration
     do_transition_dipole: bool = False
+    final_orbital: str = "semicanonical"
 
     ### Non-init attributes
     converged: bool = field(default=False, init=False)
     executed: bool = field(default=False, init=False)
     two_component: bool = field(default=False, init=False)
+
+    def _post_init__(self):
+        if not isinstance(self.ci_solver, (CIBase, RelCIBase)):
+            raise ValueError("ci_solver must be an instance of CIBase or RelCIBase.")
+
+        if self.final_orbital not in [
+            "semicanonical",
+            "original",
+        ]:
+            raise ValueError(
+                "final_orbital must be either 'semicanonical' or 'original'."
+            )
 
     def __call__(self, method):
         self.parent_method = method
@@ -115,7 +130,20 @@ class MCOptimizer(ActiveSpaceSolver):
         return self
 
     def _startup(self):
-        super()._startup()
+        if not self.parent_method.executed:
+            self.parent_method.run()
+
+        SystemMixin.copy_from_upstream(self, self.parent_method)
+        MOsMixin.copy_from_upstream(self, self.parent_method)
+
+        # make sure to register parent_method
+        self.ci_solver = self.ci_solver(self.parent_method)
+        # iteration 0: one step of CI optimization to bootstrap the orbital optimization
+        self.iter = 0
+        self.ci_solver.run()
+        self.mo_space = self.ci_solver.mo_space
+        self.dtype = self.ci_solver.dtype
+
         # make the core, active, and virtual spaces contiguous
         # i.e., [core, gas1, gas2, ..., virt]
         perm = self.mo_space.orig_to_contig
@@ -177,21 +205,18 @@ class MCOptimizer(ActiveSpaceSolver):
             and not self.freeze_inter_gas_rots,
         )
 
-        _CISolver = RelCISolver if self.two_component else CISolver
-        self.ci_solver = _CISolver(
-            states=self.states,
-            core_orbitals=self.mo_space.docc_orbitals,
-            active_orbitals=self.mo_space.active_orbitals,
-            nroots=self.sa_info.nroots,
-            weights=self.sa_info.weights,
-            log_level=self.ci_solver_verbosity,
-            die_if_not_converged=False,
-            ci_params=self.ci_params,
-            davidson_liu_params=self.davidson_liu_params,
-        )(self.parent_method)
-        # iteration 0: one step of CI optimization to bootstrap the orbital optimization
-        self.iter = 0
-        self.ci_solver.run()
+        # _CISolver = RelCISolver if self.two_component else CISolver
+        # self.ci_solver = _CISolver(
+        #     states=self.states,
+        #     core_orbitals=self.mo_space.docc_orbitals,
+        #     active_orbitals=self.mo_space.active_orbitals,
+        #     nroots=self.sa_info.nroots,
+        #     weights=self.sa_info.weights,
+        #     log_level=self.ci_solver_verbosity,
+        #     die_if_not_converged=False,
+        #     ci_params=self.ci_params,
+        #     davidson_liu_params=self.davidson_liu_params,
+        # )(self.parent_method)
 
         # Initialize the LBFGS solver that finds the optimal orbital
         # at fixed CI expansion using the gradient and diagonal Hessian
@@ -361,7 +386,7 @@ class MCOptimizer(ActiveSpaceSolver):
             self.ci_solver.run()
 
         convergence_status = self.ci_solver.get_convergence_status()
-        if not all(convergence_status):
+        if convergence_status and not all(convergence_status):
             logger.log_warning(
                 f"CI solver did not converge for all roots: {convergence_status}"
             )
@@ -371,20 +396,20 @@ class MCOptimizer(ActiveSpaceSolver):
         return self
 
     def _post_process(self):
-        pretty_print_ci_summary(self.sa_info, self.ci_solver.evals_per_solver)
+        pretty_print_ci_summary(self.ci_solver.sa_info, self.ci_solver.evals_per_solver)
         self.ci_solver.compute_natural_occupation_numbers()
         pretty_print_ci_nat_occ_numbers(
-            self.sa_info, self.mo_space, self.ci_solver.nat_occs
+            self.ci_solver.sa_info, self.mo_space, self.ci_solver.nat_occs
         )
         top_dets = self.ci_solver.get_top_determinants()
-        pretty_print_ci_dets(self.sa_info, self.mo_space, top_dets)
+        pretty_print_ci_dets(self.ci_solver.sa_info, self.mo_space, top_dets)
         if not self.two_component:
             # TODO: enable AO composition for 2c
             self._print_ao_composition()
         if self.do_transition_dipole:
             self.ci_solver.compute_transition_properties(self.C[0])
             pretty_print_ci_transition_props(
-                self.sa_info,
+                self.ci_solver.sa_info,
                 self.ci_solver.tdm_per_solver,
                 self.ci_solver.fosc_per_solver,
                 self.ci_solver.evals_per_solver,
@@ -576,4 +601,4 @@ class MCOptimizer(ActiveSpaceSolver):
 
 
 @dataclass
-class RelMCOptimizer(RelActiveSpaceSolver, MCOptimizer): ...
+class RelMCOptimizer(MCOptimizer): ...

--- a/forte2/mcopt/mc_optimizer.py
+++ b/forte2/mcopt/mc_optimizer.py
@@ -1,12 +1,11 @@
+from abc import ABC
+from dataclasses import dataclass, field
+
 import numpy as np
 from numpy.typing import NDArray
 
-from dataclasses import dataclass, field
 
-from forte2.ci import CISolver, RelCISolver
 from forte2.base_classes import (
-    ActiveSpaceSolver,
-    RelActiveSpaceSolver,
     CIBase,
     RelCIBase,
     SystemMixin,
@@ -29,7 +28,7 @@ from .orbital_optimizer import OrbOptimizer, RelOrbOptimizer
 
 
 @dataclass
-class MCOptimizerBase(SystemMixin, MOsMixin, MOSpaceMixin):
+class MCOptimizerBase(ABC, SystemMixin, MOsMixin, MOSpaceMixin):
     """
     Two-step optimizer for multi-configurational wavefunctions.
 

--- a/forte2/mcopt/mc_optimizer.py
+++ b/forte2/mcopt/mc_optimizer.py
@@ -65,9 +65,6 @@ class MCOptimizerBase(ActiveSpaceSolver):
         Maximum number of microiterations for L-BFGS.
     max_rotation : float, optional, default=0.2
         Maximum orbital rotation size for L-BFGS.
-    ci_solver : CIBase | RelCIBase | None, optional
-        Custom CI solver to use in the optimization.
-        If not provided, a default CISolver or RelCISolver will be used based on the `two_component` flag.
     ci_params : CIParams, optional
         Parameters for the CI solver.
     davidson_liu_params : DavidsonLiuParams, optional
@@ -97,7 +94,6 @@ class MCOptimizerBase(ActiveSpaceSolver):
     max_rotation: float = 0.2
 
     ### CI solver parameters
-    ci_solver: CIBase | RelCIBase | None = field(default=None)
     ci_params: CIParams = field(default_factory=CIParams)
     davidson_liu_params: DavidsonLiuParams = field(default_factory=DavidsonLiuParams)
 
@@ -108,14 +104,6 @@ class MCOptimizerBase(ActiveSpaceSolver):
     converged: bool = field(default=False, init=False)
     executed: bool = field(default=False, init=False)
     two_component: bool = field(default=False, init=False)
-
-    def __post_init__(self):
-        super().__post_init__()
-        if self.ci_solver is not None:
-            if not isinstance(self.ci_solver, (CIBase, RelCIBase)):
-                raise ValueError(
-                    f"ci_solver must be an instance of CIBase or RelCIBase, but got {type(self.ci_solver)}."
-                )
 
     def __call__(self, method):
         self.parent_method = method
@@ -191,22 +179,18 @@ class MCOptimizerBase(ActiveSpaceSolver):
             and not self.freeze_inter_gas_rots,
         )
 
-        if self.ci_solver is None:
-            _CISolver = RelCISolver if self.two_component else CISolver
-            self.ci_solver = _CISolver(
-                states=self.states,
-                core_orbitals=self.mo_space.docc_orbitals,
-                active_orbitals=self.mo_space.active_orbitals,
-                nroots=self.sa_info.nroots,
-                weights=self.sa_info.weights,
-                log_level=self.ci_solver_verbosity,
-                die_if_not_converged=False,
-                ci_params=self.ci_params,
-                davidson_liu_params=self.davidson_liu_params,
-            )
-        self.ci_solver = self.ci_solver(
-            self.parent_method
-        )  # make sure to pass parent method to CI solver
+        _CISolver = RelCISolver if self.two_component else CISolver
+        self.ci_solver = _CISolver(
+            states=self.states,
+            core_orbitals=self.mo_space.docc_orbitals,
+            active_orbitals=self.mo_space.active_orbitals,
+            nroots=self.sa_info.nroots,
+            weights=self.sa_info.weights,
+            log_level=self.ci_solver_verbosity,
+            die_if_not_converged=False,
+            ci_params=self.ci_params,
+            davidson_liu_params=self.davidson_liu_params,
+        )(self.parent_method)
         # iteration 0: one step of CI optimization to bootstrap the orbital optimization
         self.iter = 0
         self.ci_solver.run()

--- a/forte2/mcopt/mc_optimizer.py
+++ b/forte2/mcopt/mc_optimizer.py
@@ -104,7 +104,6 @@ class MCOptimizer(SystemMixin, MOsMixin, MOSpaceMixin):
     ### Non-init attributes
     converged: bool = field(default=False, init=False)
     executed: bool = field(default=False, init=False)
-    two_component: bool = field(default=False, init=False)
 
     def _post_init__(self):
         if not isinstance(self.ci_solver, (CIBase, RelCIBase)):
@@ -193,7 +192,7 @@ class MCOptimizer(SystemMixin, MOsMixin, MOSpaceMixin):
         #       (this is typically done iteratively with micro-iterations using L-BFGS)
         #     2. minimize energy wrt CI expansion at current orbitals
         #       (this is just the diagonalization of the active-space CI Hamiltonian)
-        _OrbOptimizer = RelOrbOptimizer if self.two_component else OrbOptimizer
+        _OrbOptimizer = RelOrbOptimizer if self.system.two_component else OrbOptimizer
         self.orb_opt = _OrbOptimizer(
             self._C,
             (self.core, self.actv, self.virt),
@@ -364,7 +363,7 @@ class MCOptimizer(SystemMixin, MOsMixin, MOSpaceMixin):
             self.C[0] = semi.C_semican[:, self.mo_space.contig_to_orig].copy()
 
             # recompute the CI vectors in the semicanonical basis
-            if self.two_component:
+            if self.system.two_component:
                 ints = SpinorbitalIntegrals(
                     system=self.system,
                     C=self.C[0],
@@ -403,7 +402,7 @@ class MCOptimizer(SystemMixin, MOsMixin, MOSpaceMixin):
         )
         top_dets = self.ci_solver.get_top_determinants()
         pretty_print_ci_dets(self.ci_solver.sa_info, self.mo_space, top_dets)
-        if not self.two_component:
+        if not self.system.two_component:
             # TODO: enable AO composition for 2c
             self._print_ao_composition()
         if self.do_transition_dipole:
@@ -598,7 +597,3 @@ class MCOptimizer(SystemMixin, MOsMixin, MOSpaceMixin):
         return self.ci_solver.sub_solvers[left_state].make_sf_2rdm(
             left_root_in_state, right_root_in_state
         )
-
-
-@dataclass
-class RelMCOptimizer(MCOptimizer): ...

--- a/forte2/orbitals/iao.py
+++ b/forte2/orbitals/iao.py
@@ -139,7 +139,7 @@ class IBO(IAO):
         The occupied molecular orbital coefficients.
     maxiter : int, optional, default=10
         The maximum number of iterations for the IBO optimization.
-    gconv : float, optional, default=1e-8
+    g_tol : float, optional, default=1e-8
         The RMS gradient convergence criterion for the IBO optimization.
 
     Notes
@@ -151,10 +151,10 @@ class IBO(IAO):
     https://sites.psu.edu/knizia/software/
     """
 
-    def __init__(self, system: System, C_occ: np.ndarray, maxiter=10, gconv=1e-8):
+    def __init__(self, system: System, C_occ: np.ndarray, maxiter=10, g_tol=1e-8):
         super().__init__(system, C_occ)
         self.maxiter = maxiter
-        self.gconv = gconv
+        self.g_tol = g_tol
         self.C_ibo = self._make_ibo()
 
     def _make_ibo(self):
@@ -194,13 +194,13 @@ class IBO(IAO):
                     )
                     C_occ_iao[:, i] = i_new.copy()
                     C_occ_iao[:, j] = j_new.copy()
-            if np.sqrt(grad) < self.gconv:
+            if np.sqrt(grad) < self.g_tol:
                 logger.log_info1(f"\nIBO converged after {ibo_iter} iterations.")
                 break
             ibo_iter += 1
         else:
             raise RuntimeError(
-                f"IBO did not converge after {self.maxiter} iterations. Change `maxiter` or `gconv`."
+                f"IBO did not converge after {self.maxiter} iterations. Change `maxiter` or `g_tol`."
             )
 
         # (nbf, nminao) @ (nminao, nocc) = (nbf, nocc)

--- a/forte2/scf/scf_base.py
+++ b/forte2/scf/scf_base.py
@@ -25,10 +25,10 @@ class SCFBase(ABC, SystemMixin, MOsMixin):
         How many DIIS error vectors to keep.
     diis_min : int, optional, default=3
         Minimum number of DIIS vectors to perform extrapolation.
-    econv : float, optional, default=1e-9
-        Energy convergence threshold.
-    dconv : float, optional, default=1e-6
-        RMS density change convergence threshold.
+    e_tol : float, optional, default=1e-9
+        Energy convergence tolerance.
+    d_tol : float, optional, default=1e-6
+        RMS density change convergence tolerance.
     maxiter : int, optional, default=100
         Maximum iteration for SCF.
     guess_type : str, optional, default="minao"
@@ -64,8 +64,8 @@ class SCFBase(ABC, SystemMixin, MOsMixin):
     diis_start: int = 1
     diis_nvec: int = 8
     diis_min: int = 2
-    econv: float = 1e-9
-    dconv: float = 1e-6
+    e_tol: float = 1e-9
+    d_tol: float = 1e-6
     maxiter: int = 100
     guess_type: str = "minao"
     level_shift: float = None
@@ -150,8 +150,8 @@ class SCFBase(ABC, SystemMixin, MOsMixin):
         logger.log_info1(f"Number of basis functions: {self.nbf}")
         logger.log_info1(f"Number of orthogonalized basis functions: {self.nmo}")
         logger.log_info1(f"Number of auxiliary basis functions: {self.naux}")
-        logger.log_info1(f"Energy convergence criterion: {self.econv:e}")
-        logger.log_info1(f"Density convergence criterion: {self.dconv:e}")
+        logger.log_info1(f"Energy convergence criterion: {self.e_tol:e}")
+        logger.log_info1(f"Density convergence criterion: {self.d_tol:e}")
         logger.log_info1(f"DIIS acceleration: {diis.do_diis}")
         logger.log_info1(f"\n==> {self.method} SCF ROUTINE <==")
         self.iter = 0
@@ -200,7 +200,7 @@ class SCFBase(ABC, SystemMixin, MOsMixin):
                 f"{iter+1:4d} {self.E:20.12f} {deltaE:12.4e} {deltaD:12.4e} {np.linalg.norm(AO_grad):12.4e} {self.S2:10.5f} {diis.status:>5s}"
             )
 
-            if np.abs(deltaE) < self.econv and deltaD < self.dconv:
+            if np.abs(deltaE) < self.e_tol and deltaD < self.d_tol:
                 logger.log_info1("=" * width)
                 logger.log_info1(f"{self.method} iterations converged\n")
                 # perform final iteration

--- a/forte2/sci/__init__.py
+++ b/forte2/sci/__init__.py
@@ -1,1 +1,1 @@
-from .sci import SelectedCI
+from .sci import SelectedCI, SelectedCISolver

--- a/forte2/sci/sci.py
+++ b/forte2/sci/sci.py
@@ -81,7 +81,7 @@ class _SelectedCISingleStateSolver:
     active_orbsym: list[int] = field(default_factory=list)
     two_component: bool = False
     do_test_rdms: bool = False
-    log_level: int = field(default=logger.get_verbosity_level())
+    log_level: int = field(default=logger.get_verbosity_level() + 1)
     die_if_not_converged: bool = False
 
     ### Non-init attributes
@@ -91,6 +91,10 @@ class _SelectedCISingleStateSolver:
     executed: bool = field(default=False, init=False)
 
     def __post_init__(self):
+        if self.two_component:
+            raise NotImplementedError(
+                "Two-component selected CI is not yet implemented."
+            )
         self.norb = self.mo_space.nactv
         self.ncore = self.mo_space.ncore + self.mo_space.nfrozen_core
         self.ngas = self.mo_space.ngas
@@ -165,13 +169,13 @@ class _SelectedCISingleStateSolver:
 
         old_energy = 0.0
         for cycle in range(self.sci_params.maxcycle):
-            logger.log_info1(f"\n{'=' * 67}")
-            logger.log_info1(f"Selected CI Cycle {cycle + 1}")
-            logger.log_info1(f"{'=' * 67}")
+            logger.log(f"\n{'=' * 67}", self.log_level)
+            logger.log(f"Selected CI Cycle {cycle + 1}", self.log_level)
+            logger.log(f"{'=' * 67}", self.log_level)
 
-            logger.log_info1(f"Algorithm: {self.sci_params.selection_algorithm}")
-            logger.log_info1(f"  var_threshold = {self.sci_params.var_threshold}")
-            logger.log_info1(f"  pt2_threshold = {self.sci_params.pt2_threshold}")
+            logger.log(f"Algorithm: {self.sci_params.selection_algorithm}", self.log_level)
+            logger.log(f"  var_threshold = {self.sci_params.var_threshold}", self.log_level)
+            logger.log(f"  pt2_threshold = {self.sci_params.pt2_threshold}", self.log_level)
 
             old_ndets = self.sci_helper.ndets()
 
@@ -280,13 +284,13 @@ class _SelectedCISingleStateSolver:
             )
 
         # final selection to update var' and pt2 contributions with the final CI coefficients
-        logger.log_info1(f"\n{'=' * 67}")
-        logger.log_info1(f"Final Selected CI Cycle")
-        logger.log_info1(f"{'=' * 67}")
+        logger.log(f"\n{'=' * 67}", self.log_level)
+        logger.log(f"Final Selected CI Cycle", self.log_level)
+        logger.log(f"{'=' * 67}", self.log_level)
 
-        logger.log_info1(f"Algorithm: {self.sci_params.selection_algorithm}")
-        logger.log_info1(f"  var_threshold = {self.sci_params.var_threshold}")
-        logger.log_info1(f"  pt2_threshold = {self.sci_params.pt2_threshold}")
+        logger.log(f"Algorithm: {self.sci_params.selection_algorithm}", self.log_level)
+        logger.log(f"  var_threshold = {self.sci_params.var_threshold}", self.log_level)
+        logger.log(f"  pt2_threshold = {self.sci_params.pt2_threshold}", self.log_level)
 
         if self.sci_params.selection_algorithm.lower() == "hbci_ref":
             self.sci_helper.select_hbci_ref(
@@ -404,7 +408,7 @@ class _SelectedCISingleStateSolver:
                 S2guess[j, i] = np.conj(S2guess[i, j])
 
         svals, svecs = np.linalg.eigh(S2guess)
-        logger.log_info1(f"S^2 values of the guess determinants: {svals}")
+        logger.log(f"S^2 values of the guess determinants: {svals}", self.log_level)
         # find the multiplicity of the eigenvalue closest to S(S+1)
         S = (self.state.multiplicity - 1) / 2
         target_s2 = S * (S + 1)
@@ -414,7 +418,7 @@ class _SelectedCISingleStateSolver:
         # find the indices of the eigenvalues that are not close to target_s2
         not_close_idx = [i for i in range(len(svals)) if i not in close_idx]
 
-        logger.log_info1(
+        logger.log(
             f"Target S(S+1) = {target_s2}, found {len(close_idx)} eigenvalues close to it."
         )
 
@@ -439,36 +443,47 @@ class _SelectedCISingleStateSolver:
             else evecs[:, : self.nroot].copy()
         )
         energies = evals[: self.nroot].copy()
-        logger.log_info1(f"Initial guess energies: {energies}")
-        logger.log_info1(f"Initial guess states:")
+        logger.log(f"Initial guess energies: {energies}", self.log_level)
+        logger.log(f"Initial guess states:", self.log_level)
         for r in range(c.shape[1]):
-            logger.log_info1(f"  Root {r}:")
+            logger.log(f"  Root {r}:", self.log_level)
             for i in range(c.shape[0]):
                 if abs(c[i, r]) > 1e-4:
-                    logger.log_info1(
-                        f"    {self.sci_params.guess_dets[i].str(self.norb)}: {c[i, r]:20.12f}"
+                    logger.log(
+                        f"    {self.sci_params.guess_dets[i].str(self.norb)}: {c[i, r]:20.12f}",
+                        self.log_level,
                     )
         return self.sci_params.guess_dets, c, energies, S2project_out
 
     def _generate_initial_guess_dets(self, window_occ, window_vir):
-        logger.log("Generating initial determinant guess")
+        logger.log("Generating initial determinant guess", self.log_level)
 
-        if self.two_component:
-            na = self.state.nel
-            nb = 0
-            ncore = self.state.nel - window_occ
-            ncel = ncore
-        else:
-            na = self.state.na
-            nb = self.state.nb
-            ncore = self.state.nel // 2 - window_occ
-            ncel = 2 * ncore
+        na_active = self.state.na - self.ncore
+        nb_active = self.state.nb - self.ncore
+        nel_active = na_active + nb_active
+
+        if window_occ + window_vir == 0:
+            logger.log_warning(
+                "No guess determinants provided and guess occupation windows set to 0. "
+                "Using the Hartree-Fock determinant as the only guess."
+                "This is not recommended if spin penalty is used."
+            )
+            # use the Hartree-Fock determinant as the guess
+            d0 = Determinant.zero()
+            for i in range(na_active):
+                d0.set_na(i, True)
+            for i in range(nb_active):
+                d0.set_nb(i, True)
+            return [d0]
+
+        nocc = nel_active // 2 - window_occ
+        noccel = 2 * nocc
 
         nactv = window_occ + window_vir
-        if ncel == 0:
+        if noccel == 0:
             ci_strings = CIStrings(
-                na,
-                nb,
+                na_active,
+                nb_active,
                 0,
                 [[0] * nactv],
                 [],
@@ -477,12 +492,12 @@ class _SelectedCISingleStateSolver:
         else:
 
             ci_strings = CIStrings(
-                na,
-                nb,
+                na_active,
+                nb_active,
                 0,
-                [[0] * ncore, [0] * nactv],
-                [ncel],
-                [ncel],
+                [[0] * nocc, [0] * nactv],
+                [noccel],
+                [noccel],
             )
         return ci_strings.make_determinants()
 
@@ -983,7 +998,7 @@ class SelectedCISolver(CIBase):
     sci_params: SelectedCIParams = field(default_factory=SelectedCIParams)
     davidson_liu_params: DavidsonLiuParams = field(default_factory=DavidsonLiuParams)
     do_test_rdms: bool = False
-    log_level: int = field(default=logger.get_verbosity_level())
+    log_level: int = field(default=logger.get_verbosity_level() + 1)
 
     def _startup(self):
         super()._startup()
@@ -1061,7 +1076,7 @@ class SelectedCISolver(CIBase):
         """
         return np.dot(self.weights_flat, self.evals_flat)
 
-    def make_average_sf_1rdm(self):
+    def make_average_1rdm(self):
         """
         Make the average spin-free one-particle RDM from the CI vectors.
 
@@ -1076,7 +1091,7 @@ class SelectedCISolver(CIBase):
                 rdm1 += ci_solver.make_sf_1rdm(j) * self.weights[i][j]
         return rdm1
 
-    def make_average_sf_2rdm(self):
+    def make_average_2rdm(self):
         """
         Make the average spin-free two-particle RDM from the CI vectors.
 
@@ -1187,6 +1202,13 @@ class SelectedCISolver(CIBase):
             self.fosc_per_solver.append(foscdict)
             self.tdm_per_solver.append(tdmdict)
 
+    def reset_eigensolver(self):
+        # sCI eigensolver gets reset every iteration anyway
+        pass
+
+    def get_convergence_status(self):
+        pass
+
 
 @dataclass
 class SelectedCI(SelectedCISolver):
@@ -1198,6 +1220,7 @@ class SelectedCI(SelectedCISolver):
     die_if_not_converged: bool = True
     final_orbital: str = "original"
     do_transition_dipole: bool = False
+    log_level: int = field(default=logger.get_verbosity_level())
 
     def run(self):
         super().run()

--- a/forte2/sci/sci.py
+++ b/forte2/sci/sci.py
@@ -1230,7 +1230,7 @@ class SelectedCI(SelectedCISolver):
                 system=self.system,
                 mo_space=self.mo_space,
             )
-            semi.semi_canonicalize(g1=self.make_average_sf_1rdm(), C_contig=self.C[0])
+            semi.semi_canonicalize(g1=self.make_average_1rdm(), C_contig=self.C[0])
             self.C[0] = semi.C_semican.copy()
 
             # recompute the CI vectors in the semicanonical basis

--- a/forte2/sci/sci.py
+++ b/forte2/sci/sci.py
@@ -173,9 +173,15 @@ class _SelectedCISingleStateSolver:
             logger.log(f"Selected CI Cycle {cycle + 1}", self.log_level)
             logger.log(f"{'=' * 67}", self.log_level)
 
-            logger.log(f"Algorithm: {self.sci_params.selection_algorithm}", self.log_level)
-            logger.log(f"  var_threshold = {self.sci_params.var_threshold}", self.log_level)
-            logger.log(f"  pt2_threshold = {self.sci_params.pt2_threshold}", self.log_level)
+            logger.log(
+                f"Algorithm: {self.sci_params.selection_algorithm}", self.log_level
+            )
+            logger.log(
+                f"  var_threshold = {self.sci_params.var_threshold}", self.log_level
+            )
+            logger.log(
+                f"  pt2_threshold = {self.sci_params.pt2_threshold}", self.log_level
+            )
 
             old_ndets = self.sci_helper.ndets()
 
@@ -419,7 +425,8 @@ class _SelectedCISingleStateSolver:
         not_close_idx = [i for i in range(len(svals)) if i not in close_idx]
 
         logger.log(
-            f"Target S(S+1) = {target_s2}, found {len(close_idx)} eigenvalues close to it."
+            f"Target S(S+1) = {target_s2}, found {len(close_idx)} eigenvalues close to it.",
+            self.log_level,
         )
 
         # project the guess determinants into the S^2 subspace

--- a/forte2/sci/sci_helper_select_hbci.cc
+++ b/forte2/sci/sci_helper_select_hbci.cc
@@ -392,7 +392,7 @@ void SelectedCIHelper::select_hbci(double var_threshold, double pt2_threshold) {
             total_time += time;
         }
 
-        LOG_INFO1 << "Thread " << t << " processed " << total_batches << " batches, found "
+        LOG(log_level_) << "Thread " << t << " processed " << total_batches << " batches, found "
                   << total_dets << " new determinants in " << total_time << " seconds (avg "
                   << total_time / total_batches << " s/batch, "
                   << (total_time > 0.0 ? std::to_string(total_dets / total_time) : "N/A")

--- a/forte2/sparse/sparse_rdms.h
+++ b/forte2/sparse/sparse_rdms.h
@@ -1,0 +1,290 @@
+#pragma once
+
+#include "sparse/sparse_state.h"
+
+namespace forte2 {
+
+enum class Spin1 { a, b };
+enum class Spin2 { aa, ab, bb };
+enum class Spin3 { aaa, aab, abb, bbb };
+enum class Spin4 { aaaa, aaab, aabb, abbb, bbbb };
+
+template <Spin1 S>
+np_matrix compute_1rdm(SparseState state_left, SparseState state_right, std::size_t norb) {
+    auto g1_ref = make_zeros<nb::numpy, double, 2>({norb, norb});
+
+    Determinant J;
+
+    for (std::size_t p{0}; p < norb; p++) {
+        for (std::size_t q{0}; q < norb; ++q) {
+            double rdm = 0.0;
+            for (const auto& [I, c_I] : state_right) {
+                J = I;
+                double sign = 1.0;
+                if constexpr (S == Spin1::a) {
+                    sign *= J.destroy_a(q);
+                    sign *= J.create_a(p);
+                } else {
+                    sign *= J.destroy_b(q);
+                    sign *= J.create_b(p);
+                }
+                if (sign != 0) {
+                    if (state_left.count(J) != 0) {
+                        rdm += sign * to_double(state_left[J] * c_I);
+                    }
+                }
+            }
+            g1_ref(p, q) = rdm;
+        }
+    }
+    return g1_ref;
+}
+
+template <Spin2 S>
+np_tensor4 compute_2rdm(SparseState state_left, SparseState state_right, std::size_t norb) {
+    auto g2_ref = make_zeros<nb::numpy, double, 4>({norb, norb, norb, norb});
+    auto g2_view = g2_ref.view();
+
+    Determinant J;
+
+    for (std::size_t p{0}; p < norb; ++p) {
+        for (std::size_t q{0}; q < norb; ++q) {
+            for (std::size_t r{0}; r < norb; ++r) {
+                for (std::size_t s{0}; s < norb; ++s) {
+                    double rdm = 0.0;
+                    for (const auto& [I, c_I] : state_right) {
+                        J = I;
+                        double sign = 1.0;
+                        if constexpr (S == Spin2::aa) {
+                            sign *= J.destroy_a(r);
+                            sign *= J.destroy_a(s);
+                            sign *= J.create_a(q);
+                            sign *= J.create_a(p);
+                        } else if constexpr (S == Spin2::bb) {
+                            sign *= J.destroy_b(r);
+                            sign *= J.destroy_b(s);
+                            sign *= J.create_b(q);
+                            sign *= J.create_b(p);
+                        } else {
+                            sign *= J.destroy_a(r);
+                            sign *= J.destroy_b(s);
+                            sign *= J.create_b(q);
+                            sign *= J.create_a(p);
+                        }
+                        if (sign != 0) {
+                            if (state_left.count(J) != 0) {
+                                rdm += sign * to_double(state_left[J] * c_I);
+                            }
+                        }
+                        g2_view(p, q, r, s) = rdm;
+                    }
+                }
+            }
+        }
+    }
+    return g2_ref;
+}
+
+template <Spin3 S>
+np_tensor6 compute_3rdm(SparseState state_left, SparseState state_right, std::size_t norb) {
+    auto g3_ref = make_zeros<nb::numpy, double, 6>({norb, norb, norb, norb, norb, norb});
+    auto g3_view = g3_ref.view();
+
+    Determinant J;
+
+    for (std::size_t p{0}; p < norb; ++p) {
+        for (std::size_t q{0}; q < norb; ++q) {
+            for (std::size_t r{0}; r < norb; ++r) {
+                for (std::size_t s{0}; s < norb; ++s) {
+                    for (std::size_t t{0}; t < norb; ++t) {
+                        for (std::size_t u{0}; u < norb; ++u) {
+                            double rdm = 0.0;
+                            for (const auto& [I, c_I] : state_right) {
+                                J = I;
+                                double sign = 1.0;
+                                if constexpr (S == Spin3::aaa) {
+                                    sign *= J.destroy_a(s);
+                                    sign *= J.destroy_a(t);
+                                    sign *= J.destroy_a(u);
+                                    sign *= J.create_a(r);
+                                    sign *= J.create_a(q);
+                                    sign *= J.create_a(p);
+                                } else if constexpr (S == Spin3::bbb) {
+                                    sign *= J.destroy_b(s);
+                                    sign *= J.destroy_b(t);
+                                    sign *= J.destroy_b(u);
+                                    sign *= J.create_b(r);
+                                    sign *= J.create_b(q);
+                                    sign *= J.create_b(p);
+                                } else if constexpr (S == Spin3::aab) {
+                                    sign *= J.destroy_a(s);
+                                    sign *= J.destroy_a(t);
+                                    sign *= J.destroy_b(u);
+                                    sign *= J.create_b(r);
+                                    sign *= J.create_a(q);
+                                    sign *= J.create_a(p);
+                                } else {
+                                    sign *= J.destroy_a(s);
+                                    sign *= J.destroy_b(t);
+                                    sign *= J.destroy_b(u);
+                                    sign *= J.create_b(r);
+                                    sign *= J.create_b(q);
+                                    sign *= J.create_a(p);
+                                }
+                                if (sign != 0) {
+                                    if (state_left.count(J) != 0) {
+                                        rdm += sign * to_double(state_left[J] * c_I);
+                                    }
+                                }
+                            }
+                            g3_view(p, q, r, s, t, u) = rdm;
+                        }
+                    }
+                }
+            }
+        }
+    }
+    return g3_ref;
+}
+
+template <Spin4 S>
+np_tensor8 compute_4rdm(SparseState state_left, SparseState state_right, std::size_t norb) {
+    auto g4_ref =
+        make_zeros<nb::numpy, double, 8>({norb, norb, norb, norb, norb, norb, norb, norb});
+    auto g4_view = g4_ref.view();
+
+    Determinant J;
+
+    for (size_t p{0}; p < norb; ++p) {
+        for (size_t q{0}; q < norb; ++q) {
+            for (size_t r{0}; r < norb; ++r) {
+                for (size_t s{0}; s < norb; ++s) {
+                    for (size_t t{0}; t < norb; ++t) {
+                        for (size_t u{0}; u < norb; ++u) {
+                            for (size_t v{0}; v < norb; ++v) {
+                                for (size_t w{0}; w < norb; ++w) {
+                                    double rdm = 0.0;
+                                    for (const auto& [I, c_I] : state_right) {
+                                        J = I;
+                                        double sign = 1.0;
+                                        if constexpr (S == Spin4::aaaa) {
+                                            sign *= J.destroy_a(t);
+                                            sign *= J.destroy_a(u);
+                                            sign *= J.destroy_a(v);
+                                            sign *= J.destroy_a(w);
+                                            sign *= J.create_a(s);
+                                            sign *= J.create_a(r);
+                                            sign *= J.create_a(q);
+                                            sign *= J.create_a(p);
+                                        } else if constexpr (S == Spin4::bbbb) {
+                                            sign *= J.destroy_b(t);
+                                            sign *= J.destroy_b(u);
+                                            sign *= J.destroy_b(v);
+                                            sign *= J.destroy_b(w);
+                                            sign *= J.create_b(s);
+                                            sign *= J.create_b(r);
+                                            sign *= J.create_b(q);
+                                            sign *= J.create_b(p);
+                                        } else if constexpr (S == Spin4::aaab) {
+                                            sign *= J.destroy_a(t);
+                                            sign *= J.destroy_a(u);
+                                            sign *= J.destroy_a(v);
+                                            sign *= J.destroy_b(w);
+                                            sign *= J.create_b(s);
+                                            sign *= J.create_a(r);
+                                            sign *= J.create_a(q);
+                                            sign *= J.create_a(p);
+                                        } else if constexpr (S == Spin4::aabb) {
+                                            sign *= J.destroy_a(t);
+                                            sign *= J.destroy_a(u);
+                                            sign *= J.destroy_b(v);
+                                            sign *= J.destroy_b(w);
+                                            sign *= J.create_b(s);
+                                            sign *= J.create_b(r);
+                                            sign *= J.create_a(q);
+                                            sign *= J.create_a(p);
+                                        } else {
+                                            sign *= J.destroy_a(t);
+                                            sign *= J.destroy_b(u);
+                                            sign *= J.destroy_b(v);
+                                            sign *= J.destroy_b(w);
+                                            sign *= J.create_b(s);
+                                            sign *= J.create_b(r);
+                                            sign *= J.create_b(q);
+                                            sign *= J.create_a(p);
+                                        }
+                                        if (sign != 0) {
+                                            if (state_left.count(J) != 0) {
+                                                rdm += sign * to_double(state_left[J] * c_I);
+                                            }
+                                        }
+                                    }
+                                    g4_view(p, q, r, s, t, u, v, w) = rdm;
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        }
+    }
+    return g4_ref;
+}
+
+auto compute_a_1rdm(SparseState state_left, SparseState state_right, std::size_t norb) {
+    return compute_1rdm<Spin1::a>(state_left, state_right, norb);
+}
+
+auto compute_b_1rdm(SparseState state_left, SparseState state_right, std::size_t norb) {
+    return compute_1rdm<Spin1::b>(state_left, state_right, norb);
+}
+
+auto compute_aa_2rdm(SparseState state_left, SparseState state_right, std::size_t norb) {
+    return compute_2rdm<Spin2::aa>(state_left, state_right, norb);
+}
+
+auto compute_ab_2rdm(SparseState state_left, SparseState state_right, std::size_t norb) {
+    return compute_2rdm<Spin2::ab>(state_left, state_right, norb);
+}
+
+auto compute_bb_2rdm(SparseState state_left, SparseState state_right, std::size_t norb) {
+    return compute_2rdm<Spin2::bb>(state_left, state_right, norb);
+}
+
+auto compute_aaa_3rdm(SparseState state_left, SparseState state_right, std::size_t norb) {
+    return compute_3rdm<Spin3::aaa>(state_left, state_right, norb);
+}
+
+auto compute_aab_3rdm(SparseState state_left, SparseState state_right, std::size_t norb) {
+    return compute_3rdm<Spin3::aab>(state_left, state_right, norb);
+}
+
+auto compute_abb_3rdm(SparseState state_left, SparseState state_right, std::size_t norb) {
+    return compute_3rdm<Spin3::abb>(state_left, state_right, norb);
+}
+
+auto compute_bbb_3rdm(SparseState state_left, SparseState state_right, std::size_t norb) {
+    return compute_3rdm<Spin3::bbb>(state_left, state_right, norb);
+}
+
+auto compute_aaaa_4rdm(SparseState state_left, SparseState state_right, std::size_t norb) {
+    return compute_4rdm<Spin4::aaaa>(state_left, state_right, norb);
+}
+
+auto compute_aaab_4rdm(SparseState state_left, SparseState state_right, std::size_t norb) {
+    return compute_4rdm<Spin4::aaab>(state_left, state_right, norb);
+}
+
+auto compute_aabb_4rdm(SparseState state_left, SparseState state_right, std::size_t norb) {
+    return compute_4rdm<Spin4::aabb>(state_left, state_right, norb);
+}
+
+auto compute_abbb_4rdm(SparseState state_left, SparseState state_right, std::size_t norb) {
+    return compute_4rdm<Spin4::abbb>(state_left, state_right, norb);
+}
+
+auto compute_bbbb_4rdm(SparseState state_left, SparseState state_right, std::size_t norb) {
+    return compute_4rdm<Spin4::bbbb>(state_left, state_right, norb);
+}
+
+} // namespace forte2

--- a/forte2/sparse/sparse_rdms.h
+++ b/forte2/sparse/sparse_rdms.h
@@ -10,7 +10,8 @@ enum class Spin3 { aaa, aab, abb, bbb };
 enum class Spin4 { aaaa, aaab, aabb, abbb, bbbb };
 
 template <Spin1 S>
-np_matrix compute_1rdm(SparseState state_left, SparseState state_right, std::size_t norb) {
+np_matrix compute_1rdm(const SparseState& state_left, const SparseState& state_right,
+                       std::size_t norb) {
     auto g1_ref = make_zeros<nb::numpy, double, 2>({norb, norb});
 
     Determinant J;
@@ -41,7 +42,8 @@ np_matrix compute_1rdm(SparseState state_left, SparseState state_right, std::siz
 }
 
 template <Spin2 S>
-np_tensor4 compute_2rdm(SparseState state_left, SparseState state_right, std::size_t norb) {
+np_tensor4 compute_2rdm(const SparseState& state_left, const SparseState& state_right,
+                        std::size_t norb) {
     auto g2_ref = make_zeros<nb::numpy, double, 4>({norb, norb, norb, norb});
     auto g2_view = g2_ref.view();
 
@@ -76,8 +78,8 @@ np_tensor4 compute_2rdm(SparseState state_left, SparseState state_right, std::si
                                 rdm += sign * to_double(state_left[J] * c_I);
                             }
                         }
-                        g2_view(p, q, r, s) = rdm;
                     }
+                    g2_view(p, q, r, s) = rdm;
                 }
             }
         }
@@ -86,7 +88,8 @@ np_tensor4 compute_2rdm(SparseState state_left, SparseState state_right, std::si
 }
 
 template <Spin3 S>
-np_tensor6 compute_3rdm(SparseState state_left, SparseState state_right, std::size_t norb) {
+np_tensor6 compute_3rdm(const SparseState& state_left, const SparseState& state_right,
+                        std::size_t norb) {
     auto g3_ref = make_zeros<nb::numpy, double, 6>({norb, norb, norb, norb, norb, norb});
     auto g3_view = g3_ref.view();
 
@@ -148,21 +151,22 @@ np_tensor6 compute_3rdm(SparseState state_left, SparseState state_right, std::si
 }
 
 template <Spin4 S>
-np_tensor8 compute_4rdm(SparseState state_left, SparseState state_right, std::size_t norb) {
+np_tensor8 compute_4rdm(const SparseState& state_left, const SparseState& state_right,
+                        std::size_t norb) {
     auto g4_ref =
         make_zeros<nb::numpy, double, 8>({norb, norb, norb, norb, norb, norb, norb, norb});
     auto g4_view = g4_ref.view();
 
     Determinant J;
 
-    for (size_t p{0}; p < norb; ++p) {
-        for (size_t q{0}; q < norb; ++q) {
-            for (size_t r{0}; r < norb; ++r) {
-                for (size_t s{0}; s < norb; ++s) {
-                    for (size_t t{0}; t < norb; ++t) {
-                        for (size_t u{0}; u < norb; ++u) {
-                            for (size_t v{0}; v < norb; ++v) {
-                                for (size_t w{0}; w < norb; ++w) {
+    for (std::size_t p{0}; p < norb; ++p) {
+        for (std::size_t q{0}; q < norb; ++q) {
+            for (std::size_t r{0}; r < norb; ++r) {
+                for (std::size_t s{0}; s < norb; ++s) {
+                    for (std::size_t t{0}; t < norb; ++t) {
+                        for (std::size_t u{0}; u < norb; ++u) {
+                            for (std::size_t v{0}; v < norb; ++v) {
+                                for (std::size_t w{0}; w < norb; ++w) {
                                     double rdm = 0.0;
                                     for (const auto& [I, c_I] : state_right) {
                                         J = I;
@@ -231,59 +235,73 @@ np_tensor8 compute_4rdm(SparseState state_left, SparseState state_right, std::si
     return g4_ref;
 }
 
-auto compute_a_1rdm(SparseState state_left, SparseState state_right, std::size_t norb) {
+auto compute_a_1rdm(const SparseState& state_left, const SparseState& state_right,
+                    std::size_t norb) {
     return compute_1rdm<Spin1::a>(state_left, state_right, norb);
 }
 
-auto compute_b_1rdm(SparseState state_left, SparseState state_right, std::size_t norb) {
+auto compute_b_1rdm(const SparseState& state_left, const SparseState& state_right,
+                    std::size_t norb) {
     return compute_1rdm<Spin1::b>(state_left, state_right, norb);
 }
 
-auto compute_aa_2rdm(SparseState state_left, SparseState state_right, std::size_t norb) {
+auto compute_aa_2rdm(const SparseState& state_left, const SparseState& state_right,
+                     std::size_t norb) {
     return compute_2rdm<Spin2::aa>(state_left, state_right, norb);
 }
 
-auto compute_ab_2rdm(SparseState state_left, SparseState state_right, std::size_t norb) {
+auto compute_ab_2rdm(const SparseState& state_left, const SparseState& state_right,
+                     std::size_t norb) {
     return compute_2rdm<Spin2::ab>(state_left, state_right, norb);
 }
 
-auto compute_bb_2rdm(SparseState state_left, SparseState state_right, std::size_t norb) {
+auto compute_bb_2rdm(const SparseState& state_left, const SparseState& state_right,
+                     std::size_t norb) {
     return compute_2rdm<Spin2::bb>(state_left, state_right, norb);
 }
 
-auto compute_aaa_3rdm(SparseState state_left, SparseState state_right, std::size_t norb) {
+auto compute_aaa_3rdm(const SparseState& state_left, const SparseState& state_right,
+                      std::size_t norb) {
     return compute_3rdm<Spin3::aaa>(state_left, state_right, norb);
 }
 
-auto compute_aab_3rdm(SparseState state_left, SparseState state_right, std::size_t norb) {
+auto compute_aab_3rdm(const SparseState& state_left, const SparseState& state_right,
+                      std::size_t norb) {
     return compute_3rdm<Spin3::aab>(state_left, state_right, norb);
 }
 
-auto compute_abb_3rdm(SparseState state_left, SparseState state_right, std::size_t norb) {
+auto compute_abb_3rdm(const SparseState& state_left, const SparseState& state_right,
+                      std::size_t norb) {
     return compute_3rdm<Spin3::abb>(state_left, state_right, norb);
 }
 
-auto compute_bbb_3rdm(SparseState state_left, SparseState state_right, std::size_t norb) {
+auto compute_bbb_3rdm(const SparseState& state_left, const SparseState& state_right,
+                      std::size_t norb) {
     return compute_3rdm<Spin3::bbb>(state_left, state_right, norb);
 }
 
-auto compute_aaaa_4rdm(SparseState state_left, SparseState state_right, std::size_t norb) {
+auto compute_aaaa_4rdm(const SparseState& state_left, const SparseState& state_right,
+                       std::size_t norb) {
     return compute_4rdm<Spin4::aaaa>(state_left, state_right, norb);
 }
 
-auto compute_aaab_4rdm(SparseState state_left, SparseState state_right, std::size_t norb) {
+auto compute_aaab_4rdm(const SparseState& state_left, const SparseState& state_right,
+                       std::size_t norb) {
     return compute_4rdm<Spin4::aaab>(state_left, state_right, norb);
 }
 
-auto compute_aabb_4rdm(SparseState state_left, SparseState state_right, std::size_t norb) {
+auto compute_aabb_4rdm(const SparseState& state_left, const SparseState& state_right,
+                       std::size_t norb) {
     return compute_4rdm<Spin4::aabb>(state_left, state_right, norb);
 }
 
-auto compute_abbb_4rdm(SparseState state_left, SparseState state_right, std::size_t norb) {
+auto compute_abbb_4rdm(const SparseState& state_left, const SparseState& state_right,
+                       std::size_t norb) {
     return compute_4rdm<Spin4::abbb>(state_left, state_right, norb);
 }
 
-auto compute_bbbb_4rdm(SparseState state_left, SparseState state_right, std::size_t norb) {
+auto compute_bbbb_4rdm(const SparseState& state_left, const SparseState& state_right,
+                       std::size_t norb) {
     return compute_4rdm<Spin4::bbbb>(state_left, state_right, norb);
 }
 

--- a/forte2/sparse/sparse_rdms.h
+++ b/forte2/sparse/sparse_rdms.h
@@ -30,8 +30,9 @@ np_matrix compute_1rdm(const SparseState& state_left, const SparseState& state_r
                     sign *= J.create_b(p);
                 }
                 if (sign != 0) {
-                    if (state_left.count(J) != 0) {
-                        rdm += sign * to_double(state_left[J] * c_I);
+                    auto it = state_left.find(J);
+                    if (it != state_left.end()) {
+                        rdm += sign * to_double(it->second * c_I);
                     }
                 }
             }
@@ -74,8 +75,9 @@ np_tensor4 compute_2rdm(const SparseState& state_left, const SparseState& state_
                             sign *= J.create_a(p);
                         }
                         if (sign != 0) {
-                            if (state_left.count(J) != 0) {
-                                rdm += sign * to_double(state_left[J] * c_I);
+                            auto it = state_left.find(J);
+                            if (it != state_left.end()) {
+                                rdm += sign * to_double(it->second * c_I);
                             }
                         }
                     }
@@ -135,8 +137,9 @@ np_tensor6 compute_3rdm(const SparseState& state_left, const SparseState& state_
                                     sign *= J.create_a(p);
                                 }
                                 if (sign != 0) {
-                                    if (state_left.count(J) != 0) {
-                                        rdm += sign * to_double(state_left[J] * c_I);
+                                    auto it = state_left.find(J);
+                                    if (it != state_left.end()) {
+                                        rdm += sign * to_double(it->second * c_I);
                                     }
                                 }
                             }
@@ -218,8 +221,9 @@ np_tensor8 compute_4rdm(const SparseState& state_left, const SparseState& state_
                                             sign *= J.create_a(p);
                                         }
                                         if (sign != 0) {
-                                            if (state_left.count(J) != 0) {
-                                                rdm += sign * to_double(state_left[J] * c_I);
+                                            auto it = state_left.find(J);
+                                            if (it != state_left.end()) {
+                                                rdm += sign * to_double(it->second * c_I);
                                             }
                                         }
                                     }

--- a/forte2/utils/mutual_correlation_plot.py
+++ b/forte2/utils/mutual_correlation_plot.py
@@ -306,7 +306,7 @@ if __name__ == "__main__":
 
     system = System(xyz=xyz, basis_set="cc-pVDZ", auxiliary_basis_set="cc-pVTZ-JKFIT")
 
-    rhf = RHF(charge=0, econv=1e-12)(system)
+    rhf = RHF(charge=0, e_tol=1e-12)(system)
     ci = CI(
         State(system=system, multiplicity=1, ms=0.0), active_orbitals=list(range(10))
     )(rhf)

--- a/forte2/x2c/x2c.py
+++ b/forte2/x2c/x2c.py
@@ -1,5 +1,3 @@
-from functools import cached_property
-
 import numpy as np
 import scipy
 

--- a/tests/ci/test_ci_exact_diagonalization.py
+++ b/tests/ci/test_ci_exact_diagonalization.py
@@ -13,7 +13,7 @@ def test_ci_1():
 
     system = System(xyz=xyz, basis_set="sto-6g", auxiliary_basis_set="cc-pVTZ-JKFIT")
 
-    rhf = RHF(charge=0, econv=1e-12)(system)
+    rhf = RHF(charge=0, e_tol=1e-12)(system)
     ci = CI(
         State(system=system, multiplicity=1, ms=0.0),
         active_orbitals=[0, 1],
@@ -34,7 +34,7 @@ def test_ci_2():
     system = System(
         xyz=xyz, basis_set="cc-pVDZ", auxiliary_basis_set="cc-pVTZ-JKFIT", unit="bohr"
     )
-    rhf = RHF(charge=0, econv=1e-12)(system)
+    rhf = RHF(charge=0, e_tol=1e-12)(system)
     ci = CI(
         states=State(nel=10, multiplicity=1, ms=0.0),
         core_orbitals=[0],
@@ -54,7 +54,7 @@ def test_sa_ci_n2():
 
     system = System(xyz=xyz, basis_set="cc-pvdz", auxiliary_basis_set="cc-pVTZ-JKFIT")
 
-    rhf = RHF(charge=0, econv=1e-12)(system)
+    rhf = RHF(charge=0, e_tol=1e-12)(system)
     singlet = State(nel=14, multiplicity=1, ms=0.0)
     triplet = State(nel=14, multiplicity=3, ms=0.0)
     ci = CI(
@@ -90,7 +90,7 @@ def test_sa_ci_with_avas():
 
     system = System(xyz=xyz, basis_set="cc-pvdz", auxiliary_basis_set="cc-pVTZ-JKFIT")
 
-    rhf = RHF(charge=0, econv=1e-12)(system)
+    rhf = RHF(charge=0, e_tol=1e-12)(system)
     avas = AVAS(
         selection_method="separate",
         num_active_docc=3,
@@ -127,7 +127,7 @@ def test_ci_tdm():
     system = System(
         xyz=xyz, basis_set="cc-pVDZ", auxiliary_basis_set="cc-pVTZ-JKFIT", unit="bohr"
     )
-    rhf = RHF(charge=0, econv=1e-12)(system)
+    rhf = RHF(charge=0, e_tol=1e-12)(system)
     ci = CI(
         State(nel=14, multiplicity=1, ms=0.0),
         core_orbitals=[0, 1, 2, 3],
@@ -158,7 +158,7 @@ def test_ci_no_active():
         xyz=xyz, basis_set="cc-pVDZ", auxiliary_basis_set="cc-pVTZ-JKFIT", unit="bohr"
     )
     state = State(nel=10, multiplicity=1, ms=0.0)
-    rhf = RHF(charge=0, econv=1e-12)(system)
+    rhf = RHF(charge=0, e_tol=1e-12)(system)
     ci = CI(
         states=state,
         core_orbitals=[0, 1, 2, 3, 4],
@@ -187,7 +187,7 @@ def test_ci_single_determinant1():
         xyz=xyz, basis_set="cc-pVDZ", auxiliary_basis_set="cc-pVTZ-JKFIT", unit="bohr"
     )
     state = State(nel=10, multiplicity=1, ms=0.0)
-    rhf = RHF(charge=0, econv=1e-12)(system)
+    rhf = RHF(charge=0, e_tol=1e-12)(system)
     ci = CI(
         states=state,
         core_orbitals=[0, 1, 2, 3],
@@ -216,7 +216,7 @@ def test_ci_single_determinant2():
         xyz=xyz, basis_set="cc-pVDZ", auxiliary_basis_set="cc-pVTZ-JKFIT", unit="bohr"
     )
     state = State(nel=10, multiplicity=1, ms=0.0)
-    rhf = RHF(charge=0, econv=1e-12)(system)
+    rhf = RHF(charge=0, e_tol=1e-12)(system)
     ci = CI(
         states=state,
         core_orbitals=[],
@@ -243,7 +243,7 @@ def test_ci_single_determinant3():
 
     system = System(xyz=xyz, basis_set="cc-pVDZ", auxiliary_basis_set="cc-pVTZ-JKFIT")
 
-    rhf = ROHF(charge=0, ms=1.0, econv=1e-12)(system)
+    rhf = ROHF(charge=0, ms=1.0, e_tol=1e-12)(system)
     ci = CI(
         State(nel=2, multiplicity=3, ms=1.0),
         active_orbitals=[0, 1],
@@ -269,7 +269,7 @@ def test_ci_single_csf1():
 
     system = System(xyz=xyz, basis_set="cc-pVDZ", auxiliary_basis_set="cc-pVTZ-JKFIT")
 
-    rhf = ROHF(charge=0, ms=1.0, econv=1e-12)(system)
+    rhf = ROHF(charge=0, ms=1.0, e_tol=1e-12)(system)
     ci = CI(
         State(nel=2, multiplicity=3, ms=0.0),
         active_orbitals=[0, 1],

--- a/tests/ci/test_ci_exact_diagonalization.py
+++ b/tests/ci/test_ci_exact_diagonalization.py
@@ -137,8 +137,8 @@ def test_ci_tdm():
         ci_params=ci_params,
     )(rhf)
     ci.run()
-    assert abs(ci.tdm_per_solver[0][(0, 6)][2]) == approx(1.5435316739347478)
-    assert ci.fosc_per_solver[0][(0, 6)] == approx(1.1589808047738437)
+    assert abs(ci.transition_dipoles[(0, 6)][2]) == approx(1.5435316739347478)
+    assert ci.oscillator_strengths[(0, 6)] == approx(1.1589808047738437)
 
 
 def test_ci_no_active():

--- a/tests/ci/test_ci_rdms.py
+++ b/tests/ci/test_ci_rdms.py
@@ -318,7 +318,7 @@ def test_ci_rdms_1():
     system = System(
         xyz=xyz, basis_set="cc-pVDZ", auxiliary_basis_set="cc-pVTZ-JKFIT", unit="bohr"
     )
-    rhf = RHF(charge=0, econv=1e-12)(system)
+    rhf = RHF(charge=0, e_tol=1e-12)(system)
     ci = CI(
         states=State(nel=10, multiplicity=1, ms=0.0),
         core_orbitals=[0],
@@ -341,7 +341,7 @@ def test_ci_rdms_sa():
     system = System(
         xyz=xyz, basis_set="cc-pVDZ", auxiliary_basis_set="cc-pVTZ-JKFIT", unit="bohr"
     )
-    rhf = RHF(charge=0, econv=1e-12)(system)
+    rhf = RHF(charge=0, e_tol=1e-12)(system)
     ci = CI(
         states=[
             State(nel=10, multiplicity=1, ms=0.0),

--- a/tests/ci/test_ci_rhf.py
+++ b/tests/ci/test_ci_rhf.py
@@ -172,8 +172,8 @@ def test_ci_tdm():
         do_transition_dipole=True,
     )(rhf)
     ci.run()
-    assert abs(ci.tdm_per_solver[0][(0, 6)][2]) == approx(1.5435316739347478)
-    assert ci.fosc_per_solver[0][(0, 6)] == approx(1.1589808047738437)
+    assert abs(ci.transition_dipoles[(0, 6)][2]) == approx(1.5435316739347478)
+    assert ci.oscillator_strengths[(0, 6)] == approx(1.1589808047738437)
 
 
 def test_ci_no_active():

--- a/tests/ci/test_ci_rhf.py
+++ b/tests/ci/test_ci_rhf.py
@@ -10,7 +10,7 @@ def test_ci_1():
 
     system = System(xyz=xyz, basis_set="sto-6g", auxiliary_basis_set="cc-pVTZ-JKFIT")
 
-    rhf = RHF(charge=0, econv=1e-12)(system)
+    rhf = RHF(charge=0, e_tol=1e-12)(system)
     ci = CI(State(system=system, multiplicity=1, ms=0.0), active_orbitals=[0, 1])(rhf)
     ci.run()
 
@@ -27,7 +27,7 @@ def test_ci_2():
     system = System(
         xyz=xyz, basis_set="cc-pVDZ", auxiliary_basis_set="cc-pVTZ-JKFIT", unit="bohr"
     )
-    rhf = RHF(charge=0, econv=1e-12)(system)
+    rhf = RHF(charge=0, e_tol=1e-12)(system)
     ci = CI(
         states=State(nel=10, multiplicity=1, ms=0.0),
         core_orbitals=[0],
@@ -51,7 +51,7 @@ def test_ci_n2_with_symmetry():
         symmetry=True,
     )
 
-    rhf = RHF(charge=0, econv=1e-12)(system)
+    rhf = RHF(charge=0, e_tol=1e-12)(system)
     ci = CI(
         states=State(nel=14, multiplicity=1, ms=0.0),
         core_orbitals=4,
@@ -76,7 +76,7 @@ def test_ci_ch4_with_symmetry():
         auxiliary_basis_set="cc-pVTZ-JKFIT",
         symmetry=True,
     )
-    rhf = RHF(charge=0, econv=1e-12)(system)
+    rhf = RHF(charge=0, e_tol=1e-12)(system)
     ci = CI(
         states=State(nel=10, multiplicity=1, ms=0.0),
         core_orbitals=1,
@@ -96,7 +96,7 @@ def test_sa_ci_n2():
 
     system = System(xyz=xyz, basis_set="cc-pvdz", auxiliary_basis_set="cc-pVTZ-JKFIT")
 
-    rhf = RHF(charge=0, econv=1e-12)(system)
+    rhf = RHF(charge=0, e_tol=1e-12)(system)
     singlet = State(nel=14, multiplicity=1, ms=0.0)
     triplet = State(nel=14, multiplicity=3, ms=0.0)
     ci = CI(
@@ -131,7 +131,7 @@ def test_sa_ci_with_avas():
 
     system = System(xyz=xyz, basis_set="cc-pvdz", auxiliary_basis_set="cc-pVTZ-JKFIT")
 
-    rhf = RHF(charge=0, econv=1e-12)(system)
+    rhf = RHF(charge=0, e_tol=1e-12)(system)
     avas = AVAS(
         selection_method="separate",
         num_active_docc=3,
@@ -163,7 +163,7 @@ def test_ci_tdm():
     system = System(
         xyz=xyz, basis_set="cc-pVDZ", auxiliary_basis_set="cc-pVTZ-JKFIT", unit="bohr"
     )
-    rhf = RHF(charge=0, econv=1e-12)(system)
+    rhf = RHF(charge=0, e_tol=1e-12)(system)
     ci = CI(
         State(nel=14, multiplicity=1, ms=0.0),
         core_orbitals=[0, 1, 2, 3],
@@ -193,7 +193,7 @@ def test_ci_no_active():
         xyz=xyz, basis_set="cc-pVDZ", auxiliary_basis_set="cc-pVTZ-JKFIT", unit="bohr"
     )
     state = State(nel=10, multiplicity=1, ms=0.0)
-    rhf = RHF(charge=0, econv=1e-12)(system)
+    rhf = RHF(charge=0, e_tol=1e-12)(system)
     ci = CI(states=state, core_orbitals=[0, 1, 2, 3, 4], active_orbitals=[])(rhf)
     ci.run()
 
@@ -217,7 +217,7 @@ def test_ci_single_determinant1():
         xyz=xyz, basis_set="cc-pVDZ", auxiliary_basis_set="cc-pVTZ-JKFIT", unit="bohr"
     )
     state = State(nel=10, multiplicity=1, ms=0.0)
-    rhf = RHF(charge=0, econv=1e-12)(system)
+    rhf = RHF(charge=0, e_tol=1e-12)(system)
     ci = CI(states=state, core_orbitals=[0, 1, 2, 3], active_orbitals=[4])(rhf)
     ci.run()
 
@@ -241,7 +241,7 @@ def test_ci_single_determinant2():
         xyz=xyz, basis_set="cc-pVDZ", auxiliary_basis_set="cc-pVTZ-JKFIT", unit="bohr"
     )
     state = State(nel=10, multiplicity=1, ms=0.0)
-    rhf = RHF(charge=0, econv=1e-12)(system)
+    rhf = RHF(charge=0, e_tol=1e-12)(system)
     ci = CI(states=state, core_orbitals=[], active_orbitals=[0, 1, 2, 3, 4])(rhf)
     ci.run()
 
@@ -263,7 +263,7 @@ def test_ci_single_determinant3():
 
     system = System(xyz=xyz, basis_set="cc-pVDZ", auxiliary_basis_set="cc-pVTZ-JKFIT")
 
-    rhf = ROHF(charge=0, ms=1.0, econv=1e-12)(system)
+    rhf = ROHF(charge=0, ms=1.0, e_tol=1e-12)(system)
     ci = CI(State(nel=2, multiplicity=3, ms=1.0), active_orbitals=[0, 1])(rhf)
     ci.run()
 
@@ -285,7 +285,7 @@ def test_ci_single_csf1():
 
     system = System(xyz=xyz, basis_set="cc-pVDZ", auxiliary_basis_set="cc-pVTZ-JKFIT")
 
-    rhf = ROHF(charge=0, ms=1.0, econv=1e-12)(system)
+    rhf = ROHF(charge=0, ms=1.0, e_tol=1e-12)(system)
     ci = CI(State(nel=2, multiplicity=3, ms=0.0), active_orbitals=[0, 1])(rhf)
     ci.run()
 

--- a/tests/ci/test_ci_rohf.py
+++ b/tests/ci/test_ci_rohf.py
@@ -11,7 +11,7 @@ def test_rohf_ci_1():
     system = System(
         xyz=xyz, basis_set="cc-pVDZ", auxiliary_basis_set="cc-pVTZ-JKFIT", unit="bohr"
     )
-    rhf = ROHF(charge=1, ms=0.5, econv=1e-12)(system)
+    rhf = ROHF(charge=1, ms=0.5, e_tol=1e-12)(system)
     ci = CI(
         states=State(system=system, charge=1, multiplicity=2, ms=0.5),
         core_orbitals=[0],
@@ -33,7 +33,7 @@ def test_rohf_ci_2():
     system = System(
         xyz=xyz, basis_set="cc-pVDZ", auxiliary_basis_set="cc-pVTZ-JKFIT", unit="bohr"
     )
-    rhf = ROHF(charge=1, ms=-0.5, econv=1e-12)(system)
+    rhf = ROHF(charge=1, ms=-0.5, e_tol=1e-12)(system)
     ci = CI(
         active_orbitals=[1, 2, 3, 4, 5, 6],
         core_orbitals=[0],

--- a/tests/ci/test_fci_with_shift.py
+++ b/tests/ci/test_fci_with_shift.py
@@ -12,7 +12,7 @@ def test_fci_co_o_core_exc():
 
     system = System(xyz=xyz, basis_set="sto-6g", auxiliary_basis_set="cc-pVTZ-JKFIT")
 
-    rhf = RHF(charge=0, econv=1e-12)(system)
+    rhf = RHF(charge=0, e_tol=1e-12)(system)
     ci = CI(
         State(nel=14, multiplicity=1, ms=0.0),
         active_orbitals=list(range(system.nbf)),
@@ -31,7 +31,7 @@ def test_fci_co_c_core_exc():
 
     system = System(xyz=xyz, basis_set="sto-6g", auxiliary_basis_set="cc-pVTZ-JKFIT")
 
-    rhf = RHF(charge=0, econv=1e-12)(system)
+    rhf = RHF(charge=0, e_tol=1e-12)(system)
     ci = CI(
         State(nel=14, multiplicity=1, ms=0.0),
         active_orbitals=list(range(system.nbf)),

--- a/tests/ci/test_gasci_rhf.py
+++ b/tests/ci/test_gasci_rhf.py
@@ -14,7 +14,7 @@ def test_gasci_rhf_1():
 
     system = System(xyz=xyz, basis_set="sto-6g", auxiliary_basis_set="cc-pVTZ-JKFIT")
 
-    rhf = RHF(charge=0, econv=1e-12)(system)
+    rhf = RHF(charge=0, e_tol=1e-12)(system)
     ci = CI(
         active_orbitals=[[0], [1]],
         states=State(nel=2, multiplicity=1, ms=0.0, gas_min=[0], gas_max=[2]),
@@ -34,7 +34,7 @@ def test_gasci_rhf_2():
 
     system = System(xyz=xyz, basis_set="cc-pVDZ", auxiliary_basis_set="cc-pVTZ-JKFIT")
 
-    rhf = RHF(charge=0, econv=1e-12)(system)
+    rhf = RHF(charge=0, e_tol=1e-12)(system)
     ci = CI(
         active_orbitals=[[0], [1]],
         states=State(nel=2, multiplicity=1, ms=0.0, gas_min=[1, 0], gas_max=[2, 1]),
@@ -62,7 +62,7 @@ def test_gasci_rhf_3():
         auxiliary_basis_set_corr="def2-svp-rifit",
     )
 
-    rhf = RHF(charge=0, econv=1e-12)(system)
+    rhf = RHF(charge=0, e_tol=1e-12)(system)
     ci = CI(
         active_orbitals=[[0], [1]],
         states=State(nel=2, multiplicity=1, ms=0.0, gas_min=[0, 0], gas_max=[2, 2]),
@@ -84,7 +84,7 @@ def test_gasci_rhf_4():
         xyz=xyz, basis_set="cc-pvdz", auxiliary_basis_set="def2-universal-jkfit"
     )
 
-    rhf = RHF(charge=0, econv=1e-12, dconv=1e-8)(system)
+    rhf = RHF(charge=0, e_tol=1e-12, d_tol=1e-8)(system)
     ci = CI(
         active_orbitals=[[0, 1, 2, 3, 4], [5, 6]],
         states=State(nel=10, multiplicity=1, ms=0.0, gas_min=[6, 0], gas_max=[10, 4]),
@@ -107,7 +107,7 @@ def test_gasci_rhf_5():
         xyz=xyz, basis_set="cc-pvdz", auxiliary_basis_set="def2-universal-jkfit"
     )
 
-    rhf = RHF(charge=0, econv=1e-14, dconv=1e-8)(system)
+    rhf = RHF(charge=0, e_tol=1e-14, d_tol=1e-8)(system)
     ci = CI(
         active_orbitals=[[0], [1, 2, 3, 4, 5, 6]],
         states=State(nel=10, multiplicity=1, ms=0.0, gas_min=[0], gas_max=[1]),
@@ -129,7 +129,7 @@ def test_gasci_rhf_6():
         xyz=xyz, basis_set="cc-pvdz", auxiliary_basis_set="def2-universal-jkfit"
     )
 
-    rhf = RHF(charge=0, econv=1e-12, dconv=1e-8)(system)
+    rhf = RHF(charge=0, e_tol=1e-12, d_tol=1e-8)(system)
     ci = CI(
         active_orbitals=(3, 4, 3),
         states=State(
@@ -153,7 +153,7 @@ def test_gasci_rhf_7():
         xyz=xyz, basis_set="cc-pvdz", auxiliary_basis_set="def2-universal-jkfit"
     )
 
-    rhf = RHF(charge=0, econv=1e-12, dconv=1e-8)(system)
+    rhf = RHF(charge=0, e_tol=1e-12, d_tol=1e-8)(system)
     ci = CI(
         active_orbitals=[[0], [1, 2, 3, 4, 5, 6]],
         states=State(nel=10, multiplicity=1, ms=0.0, gas_min=[1], gas_max=[1]),
@@ -178,7 +178,7 @@ def test_gasci_rhf_8():
         xyz=xyz, basis_set="sto-6g", auxiliary_basis_set="def2-universal-jkfit"
     )
 
-    rhf = RHF(charge=0, econv=1e-12, dconv=1e-8)(system)
+    rhf = RHF(charge=0, e_tol=1e-12, d_tol=1e-8)(system)
     ci = CI(
         active_orbitals=[[0], [1, 2, 3, 4, 5, 6]],
         states=State(nel=10, multiplicity=1, ms=0.0, gas_min=[1], gas_max=[1]),
@@ -206,7 +206,7 @@ def test_gasci_rhf_9():
         xyz=xyz, basis_set="cc-pVTZ", auxiliary_basis_set="def2-universal-jkfit"
     )
 
-    rhf = RHF(charge=0, econv=1e-12, dconv=1e-12)(system)
+    rhf = RHF(charge=0, e_tol=1e-12, d_tol=1e-12)(system)
 
     ci = CI(
         states=State(nel=10, multiplicity=1, ms=0.0, gas_min=[3], gas_max=[6]),
@@ -234,7 +234,7 @@ def test_gasci_rhf_10():
         xyz=xyz, basis_set="cc-pVTZ", auxiliary_basis_set="def2-universal-jkfit"
     )
 
-    rhf = RHF(charge=0, econv=1e-12, dconv=1e-6)(system)
+    rhf = RHF(charge=0, e_tol=1e-12, d_tol=1e-6)(system)
 
     ci = CI(
         states=State(nel=10, multiplicity=1, ms=0.0, gas_min=[4], gas_max=[8]),
@@ -262,7 +262,7 @@ def test_gasci_rhf_11():
         xyz=xyz, basis_set="cc-pVTZ", auxiliary_basis_set="def2-universal-jkfit"
     )
 
-    rhf = RHF(charge=0, econv=1e-12, dconv=1e-6)(system)
+    rhf = RHF(charge=0, e_tol=1e-12, d_tol=1e-6)(system)
 
     ci = CI(
         states=State(nel=10, multiplicity=1, ms=0.0, gas_min=[4], gas_max=[8]),

--- a/tests/ci/test_gasci_rohf.py
+++ b/tests/ci/test_gasci_rohf.py
@@ -19,7 +19,7 @@ def test_gasci_rohf_1():
         unit="bohr",
     )
 
-    rhf = ROHF(charge=1, ms=0.5, econv=1e-12, dconv=1e-8)(system)
+    rhf = ROHF(charge=1, ms=0.5, e_tol=1e-12, d_tol=1e-8)(system)
     ci = CI(
         active_orbitals=[[0], [1, 2, 3, 4, 5, 6, 7, 8]],
         states=State(nel=9, multiplicity=2, ms=0.5, gas_min=[1], gas_max=[1]),
@@ -47,7 +47,7 @@ def test_gasci_rohf_2():
         unit="bohr",
     )
 
-    rhf = ROHF(charge=1, ms=0.5, econv=1e-12, dconv=1e-8)(system)
+    rhf = ROHF(charge=1, ms=0.5, e_tol=1e-12, d_tol=1e-8)(system)
     ci = CI(
         active_orbitals=[[0], [1, 2, 3, 4, 5, 6, 7, 8]],
         states=State(nel=9, multiplicity=2, ms=0.5, gas_min=[1], gas_max=[1]),
@@ -70,7 +70,7 @@ def test_gasci_rohf_3():
         xyz=xyz, basis_set="cc-pvdz", auxiliary_basis_set="def2-universal-jkfit"
     )
 
-    rhf = ROHF(charge=0, econv=1e-12, dconv=1e-8, ms=1.0)(system)
+    rhf = ROHF(charge=0, e_tol=1e-12, d_tol=1e-8, ms=1.0)(system)
     ci = CI(
         active_orbitals=[[0], [1, 2, 3, 4, 5, 6]],
         states=State(nel=10, multiplicity=3, ms=1.0, gas_min=[0], gas_max=[1]),

--- a/tests/ci/test_rel_ci.py
+++ b/tests/ci/test_rel_ci.py
@@ -108,10 +108,10 @@ def test_rel_ci_hf_transition_dipole_equivalence_to_rhf():
         do_transition_dipole=True,
     )(scf)
     ci.run()
-    assert np.abs(ci.tdm_per_solver[0][(0, 0)]) == pytest.approx(
+    assert np.abs(ci.transition_dipoles[(0, 0)]) == pytest.approx(
         [0.0, 0.0, 0.756780349], abs=1e-6
     )
-    assert np.abs(ci.tdm_per_solver[0][(1, 1)]) == pytest.approx(
+    assert np.abs(ci.transition_dipoles[(1, 1)]) == pytest.approx(
         [0.0, 0.0, 0.721450697], abs=1e-6
     )
 
@@ -144,15 +144,15 @@ def test_rel_ci_hf_transition_dipole_ghf():
     assert ci.E[1] == approx(-99.7875319545)
     assert ci.E[3] == approx(-99.7866432345)
 
-    assert np.abs(ci.tdm_per_solver[0][(0, 0)]) == pytest.approx(
+    assert np.abs(ci.transition_dipoles[(0, 0)]) == pytest.approx(
         [0.0, 0.0, 7.54972929e-01], abs=1e-6
     )
-    assert np.abs(ci.tdm_per_solver[0][(1, 1)]) == pytest.approx(
+    assert np.abs(ci.transition_dipoles[(1, 1)]) == pytest.approx(
         [0.0, 0.0, 7.21280467e-01], abs=1e-6
     )
-    assert np.abs(ci.tdm_per_solver[0][(3, 3)]) == pytest.approx(
+    assert np.abs(ci.transition_dipoles[(3, 3)]) == pytest.approx(
         [0.0, 0.0, 7.21064890e-01], abs=1e-6
     )
-    assert np.abs(ci.fosc_per_solver[0][(0, 3)]) == pytest.approx(
+    assert np.abs(ci.oscillator_strengths[(0, 3)]) == pytest.approx(
         1.711178808962322e-05, abs=1e-6
     )

--- a/tests/ci/test_rel_ci.py
+++ b/tests/ci/test_rel_ci.py
@@ -17,7 +17,7 @@ def test_rel_ci_h2():
     system = System(
         xyz=xyz, basis_set="sto-6g", auxiliary_basis_set="cc-pVTZ-JKFIT", unit="bohr"
     )
-    scf = GHF(charge=0, econv=1e-12)(system)
+    scf = GHF(charge=0, e_tol=1e-12)(system)
     scf.run()
     C = scf.C[0]
     nmo = C.shape[1]
@@ -40,7 +40,7 @@ def test_rel_ci_hf():
     system = System(
         xyz=xyz, basis_set="cc-pvdz", auxiliary_basis_set="cc-pVTZ-JKFIT", unit="bohr"
     )
-    scf = RHF(charge=0, econv=1e-10)(system)
+    scf = RHF(charge=0, e_tol=1e-10)(system)
     scf.run()
     C = convert_coeff_spatial_to_spinor(scf.C)[0]
     nmo = C.shape[1]

--- a/tests/ci/test_rel_gasci.py
+++ b/tests/ci/test_rel_gasci.py
@@ -33,7 +33,7 @@ def test_rel_gasci_rhf_1():
 
     system = System(xyz=xyz, basis_set="sto-6g", auxiliary_basis_set="cc-pVTZ-JKFIT")
 
-    rhf = RHF(charge=0, econv=1e-12)(system)
+    rhf = RHF(charge=0, e_tol=1e-12)(system)
     rhf, system = prepare_rhf_coeff_for_relci(rhf, system)
     ci = RelCI(
         active_orbitals=[[0, 1], [2, 3]],
@@ -54,7 +54,7 @@ def test_rel_gasci_rhf_2():
 
     system = System(xyz=xyz, basis_set="cc-pVDZ", auxiliary_basis_set="cc-pVTZ-JKFIT")
 
-    rhf = RHF(charge=0, econv=1e-12)(system)
+    rhf = RHF(charge=0, e_tol=1e-12)(system)
     rhf, system = prepare_rhf_coeff_for_relci(rhf, system)
     system.two_component = True
     ci = RelCI(
@@ -84,7 +84,7 @@ def test_rel_gasci_rhf_3():
         auxiliary_basis_set_corr="def2-svp-rifit",
     )
 
-    rhf = RHF(charge=0, econv=1e-12)(system)
+    rhf = RHF(charge=0, e_tol=1e-12)(system)
     rhf, system = prepare_rhf_coeff_for_relci(rhf, system)
     system.two_component = True
     ci = RelCI(
@@ -108,7 +108,7 @@ def test_rel_gasci_rhf_4():
         xyz=xyz, basis_set="cc-pvdz", auxiliary_basis_set="def2-universal-jkfit"
     )
 
-    rhf = RHF(charge=0, econv=1e-12, dconv=1e-8)(system)
+    rhf = RHF(charge=0, e_tol=1e-12, d_tol=1e-8)(system)
     rhf, system = prepare_rhf_coeff_for_relci(rhf, system)
     system.two_component = True
     ci = RelCI(
@@ -133,7 +133,7 @@ def test_rel_gasci_rhf_5():
         xyz=xyz, basis_set="cc-pvdz", auxiliary_basis_set="def2-universal-jkfit"
     )
 
-    rhf = RHF(charge=0, econv=1e-14, dconv=1e-8)(system)
+    rhf = RHF(charge=0, e_tol=1e-14, d_tol=1e-8)(system)
     rhf, system = prepare_rhf_coeff_for_relci(rhf, system)
     system.two_component = True
     ci = RelCI(
@@ -162,7 +162,7 @@ def test_rel_gasci_rohf_3():
         xyz=xyz, basis_set="cc-pvdz", auxiliary_basis_set="def2-universal-jkfit"
     )
 
-    rhf = ROHF(charge=0, econv=1e-12, dconv=1e-8, ms=1.0)(system)
+    rhf = ROHF(charge=0, e_tol=1e-12, d_tol=1e-8, ms=1.0)(system)
     rhf, system = prepare_rhf_coeff_for_relci(rhf, system)
     ci = RelCI(
         active_orbitals=(2, 12),

--- a/tests/ci/test_slater_rules.py
+++ b/tests/ci/test_slater_rules.py
@@ -19,7 +19,7 @@ def test_slater_rules_1():
     system = System(
         xyz=xyz, basis_set="sto-6g", auxiliary_basis_set="cc-pVTZ-JKFIT", unit="bohr"
     )
-    scf = RHF(charge=0, econv=1e-12)(system)
+    scf = RHF(charge=0, e_tol=1e-12)(system)
     scf.run()
 
     orbitals = [0, 1]
@@ -51,7 +51,7 @@ def test_slater_rules_2():
     system = System(
         xyz=xyz, basis_set="cc-pvdz", auxiliary_basis_set="cc-pVTZ-JKFIT", unit="bohr"
     )
-    scf = RHF(charge=0, econv=1e-10)(system)
+    scf = RHF(charge=0, e_tol=1e-10)(system)
     scf.run()
 
     core_orbitals = [0]
@@ -89,7 +89,7 @@ def test_slater_rules_1_complex():
     system = System(
         xyz=xyz, basis_set="sto-6g", auxiliary_basis_set="cc-pVTZ-JKFIT", unit="bohr"
     )
-    scf = RHF(charge=0, econv=1e-12)(system)
+    scf = RHF(charge=0, e_tol=1e-12)(system)
     scf.run()
 
     C = convert_coeff_spatial_to_spinor(scf.C)
@@ -140,7 +140,7 @@ def test_slater_rules_2_complex():
     system = System(
         xyz=xyz, basis_set="cc-pvdz", auxiliary_basis_set="cc-pVTZ-JKFIT", unit="bohr"
     )
-    scf = RHF(charge=0, econv=1e-10)(system)
+    scf = RHF(charge=0, e_tol=1e-10)(system)
     scf.run()
 
     C = convert_coeff_spatial_to_spinor(scf.C)

--- a/tests/dsrg/test_dsrg_mrpt2.py
+++ b/tests/dsrg/test_dsrg_mrpt2.py
@@ -1,4 +1,4 @@
-from forte2 import System, RHF, MCOptimizer, State, ROHF
+from forte2 import System, RHF, MCOptimizer, State, ROHF, CISolver
 from forte2.dsrg import DSRG_MRPT2
 from forte2.helpers.comparisons import approx
 
@@ -21,11 +21,12 @@ def test_sf_mrpt2_n2():
     rhf = RHF(charge=0)(system)
     rhf.run()
 
-    mc = MCOptimizer(
+    ci_solver = CISolver(
         states=State(nel=14, multiplicity=1, ms=0.0),
         core_orbitals=4,
         active_orbitals=6,
-    )(rhf)
+    )
+    mc = MCOptimizer(ci_solver)(rhf)
     mc.run()
 
     assert rhf.E == approx(erhf)
@@ -59,11 +60,12 @@ def test_sf_mrpt2_o2_triplet():
         auxiliary_basis_set="cc-pVTZ-JKFIT",
     )
     mf = ROHF(charge=0, ms=1.0)(system)
-    mc = MCOptimizer(
+    ci_solver = CISolver(
         states=State(nel=16, multiplicity=3, ms=1.0),
         core_orbitals=4,
         active_orbitals=6,
-    )(mf)
+    )
+    mc = MCOptimizer(ci_solver)(mf)
     dsrg = DSRG_MRPT2(
         flow_param=1.0,
         relax_reference="twice",

--- a/tests/dsrg/test_rel_dsrg_mrpt2.py
+++ b/tests/dsrg/test_rel_dsrg_mrpt2.py
@@ -1,7 +1,7 @@
 import numpy as np
 import pytest
 
-from forte2 import System, GHF, RelMCOptimizer, AVAS
+from forte2 import System, GHF, MCOptimizer, RelCISolver, AVAS
 from forte2.dsrg import RelDSRG_MRPT2, RelDSRG_MRPT2_Slow
 from forte2.helpers.comparisons import approx
 from forte2.data.atom_data import EH_TO_WN
@@ -28,11 +28,12 @@ def test_mrpt2_n2_nonrel():
     random_phase = np.diag(np.exp(1j * rng.uniform(-np.pi, np.pi, size=rhf.nmo * 2)))
     rhf.C[0] = rhf.C[0] @ random_phase
 
-    mc = RelMCOptimizer(
+    ci_solver = RelCISolver(
         nel=14,
         core_orbitals=8,
         active_orbitals=12,
-    )(rhf)
+    )
+    mc = MCOptimizer(ci_solver)(rhf)
     mc.run()
 
     assert rhf.E == approx(erhf)
@@ -79,11 +80,12 @@ def test_mrpt2_n2_sa_nonrel():
         subspace=["N(2p)"],
         diagonalize=True,
     )(rhf)
-    mc = RelMCOptimizer(
+    ci_solver = RelCISolver(
         nel=14,
         nroots=4,
         weights=[3, 1, 1, 1],
-    )(avas)
+    )
+    mc = MCOptimizer(ci_solver)(avas)
 
     dsrg = RelDSRG_MRPT2(flow_param=0.5, relax_reference="once")(mc)
     dsrg.run()
@@ -113,11 +115,14 @@ def test_mrpt2_carbon_rel_sa():
         snso_type="row-dependent",
     )
     mf = GHF(charge=0, die_if_not_converged=False)(system)
-    mc = RelMCOptimizer(
+    ci_solver = RelCISolver(
         nel=6,
         nroots=9,
         active_orbitals=8,
         core_orbitals=2,
+    )
+    mc = MCOptimizer(
+        ci_solver,
         econv=1e-8,
         gconv=1e-6,
     )(mf)
@@ -140,6 +145,7 @@ def test_mrpt2_carbon_rel_sa():
         ]
     )
 
+
 @pytest.mark.slow
 def test_mrpt2_se_rel_sa_gauss_nuc():
     # Test the zero-field splitting of Se atom with Gaussian nuclear charges
@@ -161,12 +167,13 @@ def test_mrpt2_se_rel_sa_gauss_nuc():
         die_if_not_converged=False,
         maxiter=50,
     )(system)
-    mc = RelMCOptimizer(
+    ci_solver = RelCISolver(
         nel=34,
         nroots=9,
         core_orbitals=28,
         active_orbitals=8,
-    )(mf)
+    )
+    mc = MCOptimizer(ci_solver)(mf)
     dsrg = RelDSRG_MRPT2(
         flow_param=0.24,
         relax_reference="once",
@@ -196,19 +203,23 @@ def test_mrpt2_s_rel_sa_gauss_nuc():
         die_if_not_converged=False,
         maxiter=50,
     )(system)
-    mc = RelMCOptimizer(
+    ci_solver = RelCISolver(
         nel=16,
         nroots=9,
-        econv=1e-11,
-        gconv=1e-10,
         core_orbitals=10,
         active_orbitals=8,
+    )
+    mc = MCOptimizer(
+        ci_solver,
+        econv=1e-11,
+        gconv=1e-10,
     )(mf)
     dsrg = RelDSRG_MRPT2(flow_param=0.24, relax_reference="once")(mc)
     dsrg.run()
     assert (dsrg.relax_eigvals[5] - dsrg.relax_eigvals[4]) * EH_TO_WN == pytest.approx(
         387.5234521376601, rel=1e-4
     )
+
 
 @pytest.mark.slow
 def test_mrpt2_sh_with_slow():
@@ -230,22 +241,24 @@ def test_mrpt2_sh_with_slow():
         die_if_not_converged=False,
         maxiter=50,
     )(system)
-    mc = RelMCOptimizer(
+    ci_solver = RelCISolver(
         nel=17,
         nroots=4,
         core_orbitals=10,
         active_orbitals=10,
-    )(mf)
+    )
+    mc = MCOptimizer(ci_solver)(mf)
     dsrg = RelDSRG_MRPT2(flow_param=0.5, relax_reference="iterate")(mc)
     dsrg.run()
     assert np.abs(dsrg.E_dsrg.imag) < 1e-12
 
-    mc = RelMCOptimizer(
+    ci_solver = RelCISolver(
         nel=17,
         nroots=4,
         core_orbitals=10,
         active_orbitals=10,
-    )(mf)
+    )
+    mc = MCOptimizer(ci_solver)(mf)
     dsrg_slow = RelDSRG_MRPT2_Slow(flow_param=0.5, relax_reference="iterate")(mc)
     dsrg_slow.run()
     assert np.abs(dsrg_slow.E_dsrg.imag) < 1e-12

--- a/tests/dsrg/test_rel_dsrg_mrpt2.py
+++ b/tests/dsrg/test_rel_dsrg_mrpt2.py
@@ -123,8 +123,8 @@ def test_mrpt2_carbon_rel_sa():
     )
     mc = MCOptimizer(
         ci_solver,
-        econv=1e-8,
-        gconv=1e-6,
+        e_tol=1e-8,
+        g_tol=1e-6,
     )(mf)
     dsrg = RelDSRG_MRPT2(flow_param=0.24, relax_reference="once")(mc)
     dsrg.run()
@@ -211,8 +211,8 @@ def test_mrpt2_s_rel_sa_gauss_nuc():
     )
     mc = MCOptimizer(
         ci_solver,
-        econv=1e-11,
-        gconv=1e-10,
+        e_tol=1e-11,
+        g_tol=1e-10,
     )(mf)
     dsrg = RelDSRG_MRPT2(flow_param=0.24, relax_reference="once")(mc)
     dsrg.run()

--- a/tests/mcopt/test_casscf_avas_cyclopropene.py
+++ b/tests/mcopt/test_casscf_avas_cyclopropene.py
@@ -24,7 +24,7 @@ def test_casscf_cyclopropene():
         auxiliary_basis_set="def2-universal-JKFIT",
     )
 
-    rhf = RHF(charge=0, econv=1e-6)(system)
+    rhf = RHF(charge=0, e_tol=1e-6)(system)
     avas = AVAS(
         subspace=["C(2p)"],
         subspace_pi_planes=[["C1-3"]],

--- a/tests/mcopt/test_casscf_avas_cyclopropene.py
+++ b/tests/mcopt/test_casscf_avas_cyclopropene.py
@@ -1,4 +1,4 @@
-from forte2 import System, RHF, MCOptimizer, AVAS, State
+from forte2 import System, RHF, MCOptimizer, AVAS, State, CISolver
 from forte2.helpers.comparisons import approx
 
 
@@ -31,7 +31,8 @@ def test_casscf_cyclopropene():
         selection_method="total",
         num_active=3,
     )(rhf)
-    mc = MCOptimizer(State(nel=rhf.nel, multiplicity=1, ms=0.0))(avas)
+    ci_solver = CISolver(State(nel=rhf.nel, multiplicity=1, ms=0.0))
+    mc = MCOptimizer(ci_solver)(avas)
     mc.run()
 
     assert rhf.E == approx(erhf)

--- a/tests/mcopt/test_casscf_cholesky_n2.py
+++ b/tests/mcopt/test_casscf_cholesky_n2.py
@@ -1,4 +1,4 @@
-from forte2 import System, RHF, MCOptimizer, State
+from forte2 import System, RHF, MCOptimizer, State, CISolver
 from forte2.helpers.comparisons import approx
 
 
@@ -21,10 +21,13 @@ def test_casscf_n2_cholesky():
     )
     rhf = RHF(charge=0, econv=1e-12)(system)
 
-    mc = MCOptimizer(
+    ci_solver = CISolver(
         State(nel=14, multiplicity=1, ms=0.0),
         core_orbitals=[0, 1, 2, 3],
         active_orbitals=[4, 5, 6, 7, 8, 9],
+    )
+    mc = MCOptimizer(
+        ci_solver,
         econv=1e-9,
     )(rhf)
     mc.run()

--- a/tests/mcopt/test_casscf_cholesky_n2.py
+++ b/tests/mcopt/test_casscf_cholesky_n2.py
@@ -19,7 +19,7 @@ def test_casscf_n2_cholesky():
         cholesky_tol=1e-10,
         symmetry=True,
     )
-    rhf = RHF(charge=0, econv=1e-12)(system)
+    rhf = RHF(charge=0, e_tol=1e-12)(system)
 
     ci_solver = CISolver(
         State(nel=14, multiplicity=1, ms=0.0),
@@ -28,7 +28,7 @@ def test_casscf_n2_cholesky():
     )
     mc = MCOptimizer(
         ci_solver,
-        econv=1e-9,
+        e_tol=1e-9,
     )(rhf)
     mc.run()
     assert rhf.E == approx(erhf)

--- a/tests/mcopt/test_casscf_frozen_co.py
+++ b/tests/mcopt/test_casscf_frozen_co.py
@@ -1,4 +1,4 @@
-from forte2 import System, AVAS, MCOptimizer, State, RHF
+from forte2 import System, AVAS, MCOptimizer, State, RHF, CISolver
 from forte2.helpers.comparisons import approx
 from forte2.base_classes import CIParams
 
@@ -22,21 +22,23 @@ def test_casscf_frozen_co():
         num_active_uocc=3,
     )(rhf)
 
-    mc = MCOptimizer(
+    ci_solver = CISolver(
         states=State(system=system, multiplicity=1, ms=0.0),
         core_orbitals=4,
         active_orbitals=6,
         ci_params=CIParams(ci_algorithm="exact"),
-    )(avas)
+    )
+    mc = MCOptimizer(ci_solver)(avas)
     mc.run()
     assert mc.E == approx(emcscf)
 
-    mc = MCOptimizer(
+    ci_solver = CISolver(
         states=State(system=system, multiplicity=1, ms=0.0),
         frozen_core_orbitals=1,
         core_orbitals=3,
         active_orbitals=6,
         frozen_virtual_orbitals=3,
     )(avas)
+    mc = MCOptimizer(ci_solver)(avas)
     mc.run()
     assert mc.E == approx(emcscf_frz)

--- a/tests/mcopt/test_casscf_frozen_co.py
+++ b/tests/mcopt/test_casscf_frozen_co.py
@@ -14,7 +14,7 @@ def test_casscf_frozen_co():
 
     system = System(xyz=xyz, basis_set="cc-pvdz", auxiliary_basis_set="cc-pVTZ-JKFIT")
 
-    rhf = RHF(charge=0, econv=1e-12)(system)
+    rhf = RHF(charge=0, e_tol=1e-12)(system)
     avas = AVAS(
         subspace=["C(2p)", "O(2p)"],
         selection_method="separate",

--- a/tests/mcopt/test_casscf_hf.py
+++ b/tests/mcopt/test_casscf_hf.py
@@ -14,7 +14,7 @@ def test_casscf_hf():
     system = System(
         xyz=xyz, basis_set="cc-pVDZ", auxiliary_basis_set="cc-pVTZ-JKFIT", unit="bohr"
     )
-    rhf = RHF(charge=0, econv=1e-12)(system)
+    rhf = RHF(charge=0, e_tol=1e-12)(system)
     ci_solver = CISolver(
         State(nel=10, multiplicity=1, ms=0.0),
         active_orbitals=6,
@@ -40,7 +40,7 @@ def test_casscf_hf_smaller_active():
         xyz=xyz, basis_set="cc-pvdz", auxiliary_basis_set="def2-universal-jkfit"
     )
 
-    rhf = RHF(charge=0, econv=1e-12)(system)
+    rhf = RHF(charge=0, e_tol=1e-12)(system)
     ci_solver = CISolver(
         State(nel=10, multiplicity=1, ms=0.0),
         active_orbitals=[4, 5],

--- a/tests/mcopt/test_casscf_hf.py
+++ b/tests/mcopt/test_casscf_hf.py
@@ -1,4 +1,4 @@
-from forte2 import System, RHF, MCOptimizer, State
+from forte2 import System, RHF, MCOptimizer, State, CISolver
 from forte2.helpers.comparisons import approx
 
 
@@ -15,11 +15,12 @@ def test_casscf_hf():
         xyz=xyz, basis_set="cc-pVDZ", auxiliary_basis_set="cc-pVTZ-JKFIT", unit="bohr"
     )
     rhf = RHF(charge=0, econv=1e-12)(system)
-    mc = MCOptimizer(
+    ci_solver = CISolver(
         State(nel=10, multiplicity=1, ms=0.0),
         active_orbitals=6,
         core_orbitals=1,
-    )(rhf)
+    )
+    mc = MCOptimizer(ci_solver)(rhf)
     mc.run()
 
     assert rhf.E == approx(erhf)
@@ -40,11 +41,12 @@ def test_casscf_hf_smaller_active():
     )
 
     rhf = RHF(charge=0, econv=1e-12)(system)
-    mc = MCOptimizer(
+    ci_solver = CISolver(
         State(nel=10, multiplicity=1, ms=0.0),
         active_orbitals=[4, 5],
         core_orbitals=[0, 1, 2, 3],
-    )(rhf)
+    )
+    mc = MCOptimizer(ci_solver)(rhf)
     mc.run()
 
     assert rhf.E == approx(erhf)

--- a/tests/mcopt/test_casscf_noncontiguous_spaces_n2.py
+++ b/tests/mcopt/test_casscf_noncontiguous_spaces_n2.py
@@ -1,4 +1,4 @@
-from forte2 import System, RHF, MCOptimizer, State
+from forte2 import System, RHF, MCOptimizer, State, CISolver
 from forte2.helpers.comparisons import approx
 
 
@@ -24,8 +24,9 @@ def test_mcscf_noncontiguous_spaces():
     virt = sorted(set(range(system.nbf)) - set(core + actv))
     rhf.C[0][:, core + actv + virt] = rhf.C[0]
 
-    mc = MCOptimizer(
+    ci_solver = CISolver(
         State(nel=14, multiplicity=1, ms=0.0), active_orbitals=actv, core_orbitals=core
-    )(rhf)
+    )
+    mc = MCOptimizer(ci_solver)(rhf)
     mc.run()
     assert mc.E == approx(ecasscf)

--- a/tests/mcopt/test_casscf_noncontiguous_spaces_n2.py
+++ b/tests/mcopt/test_casscf_noncontiguous_spaces_n2.py
@@ -14,7 +14,7 @@ def test_mcscf_noncontiguous_spaces():
     """
 
     system = System(xyz=xyz, basis_set="cc-pVDZ", auxiliary_basis_set="cc-pVTZ-JKFIT")
-    rhf = RHF(charge=0, econv=1e-12)(system)
+    rhf = RHF(charge=0, e_tol=1e-12)(system)
     rhf.run()
     assert rhf.E == approx(erhf)
 

--- a/tests/mcopt/test_casscf_simple.py
+++ b/tests/mcopt/test_casscf_simple.py
@@ -1,4 +1,4 @@
-from forte2 import System, RHF, MCOptimizer, State
+from forte2 import System, RHF, MCOptimizer, State, CISolver
 from forte2.helpers.comparisons import approx
 
 
@@ -14,7 +14,8 @@ def test_casscf_h2():
     system = System(xyz=xyz, basis_set="cc-pvdz", auxiliary_basis_set="cc-pVTZ-JKFIT")
 
     rhf = RHF(charge=0, econv=1e-12)(system)
-    mc = MCOptimizer(State(nel=2, multiplicity=1, ms=0.0), active_orbitals=[0, 1])(rhf)
+    ci_solver = CISolver(State(nel=2, multiplicity=1, ms=0.0), active_orbitals=[0, 1])
+    mc = MCOptimizer(ci_solver)(rhf)
     mc.run()
 
     assert rhf.E == approx(erhf)
@@ -32,10 +33,13 @@ def test_casscf_n2():
 
     system = System(xyz=xyz, basis_set="cc-pVDZ", auxiliary_basis_set="cc-pVTZ-JKFIT")
     rhf = RHF(charge=0, econv=1e-12)(system)
-    mc = MCOptimizer(
+    ci_solver = CISolver(
         State(nel=14, multiplicity=1, ms=0.0),
         active_orbitals=[4, 5, 6, 7, 8, 9],
         core_orbitals=[0, 1, 2, 3],
+    )
+    mc = MCOptimizer(
+        ci_solver,
         gconv=1e-7,
     )(rhf)
     mc.run()
@@ -61,10 +65,13 @@ def test_casscf_water():
     )
 
     rhf = RHF(charge=0, econv=1e-12, dconv=1e-12)(system)
-    mc = MCOptimizer(
+    ci_solver = CISolver(
         State(nel=10, multiplicity=1, ms=0.0),
         active_orbitals=[1, 2, 3, 4, 5, 6],
         core_orbitals=[0],
+    )
+    mc = MCOptimizer(
+        ci_solver,
         gconv=1e-6,
         econv=1e-10,
     )(rhf)

--- a/tests/mcopt/test_casscf_simple.py
+++ b/tests/mcopt/test_casscf_simple.py
@@ -13,7 +13,7 @@ def test_casscf_h2():
 
     system = System(xyz=xyz, basis_set="cc-pvdz", auxiliary_basis_set="cc-pVTZ-JKFIT")
 
-    rhf = RHF(charge=0, econv=1e-12)(system)
+    rhf = RHF(charge=0, e_tol=1e-12)(system)
     ci_solver = CISolver(State(nel=2, multiplicity=1, ms=0.0), active_orbitals=[0, 1])
     mc = MCOptimizer(ci_solver)(rhf)
     mc.run()
@@ -32,7 +32,7 @@ def test_casscf_n2():
     """
 
     system = System(xyz=xyz, basis_set="cc-pVDZ", auxiliary_basis_set="cc-pVTZ-JKFIT")
-    rhf = RHF(charge=0, econv=1e-12)(system)
+    rhf = RHF(charge=0, e_tol=1e-12)(system)
     ci_solver = CISolver(
         State(nel=14, multiplicity=1, ms=0.0),
         active_orbitals=[4, 5, 6, 7, 8, 9],
@@ -40,7 +40,7 @@ def test_casscf_n2():
     )
     mc = MCOptimizer(
         ci_solver,
-        gconv=1e-7,
+        g_tol=1e-7,
     )(rhf)
     mc.run()
     assert rhf.E == approx(erhf)
@@ -64,7 +64,7 @@ def test_casscf_water():
         unit="angstrom",
     )
 
-    rhf = RHF(charge=0, econv=1e-12, dconv=1e-12)(system)
+    rhf = RHF(charge=0, e_tol=1e-12, d_tol=1e-12)(system)
     ci_solver = CISolver(
         State(nel=10, multiplicity=1, ms=0.0),
         active_orbitals=[1, 2, 3, 4, 5, 6],
@@ -72,8 +72,8 @@ def test_casscf_water():
     )
     mc = MCOptimizer(
         ci_solver,
-        gconv=1e-6,
-        econv=1e-10,
+        g_tol=1e-6,
+        e_tol=1e-10,
     )(rhf)
     mc.run()
 

--- a/tests/mcopt/test_casscf_singlet_benzyne.py
+++ b/tests/mcopt/test_casscf_singlet_benzyne.py
@@ -1,4 +1,4 @@
-from forte2 import System, RHF, MCOptimizer, State
+from forte2 import System, RHF, MCOptimizer, State, CISolver
 from forte2.helpers.comparisons import approx
 
 
@@ -27,11 +27,12 @@ def test_casscf_singlet_benzyne():
     )
 
     rhf = RHF(charge=0, econv=1e-12)(system)
-    mc = MCOptimizer(
+    ci_solver = CISolver(
         State(nel=40, multiplicity=1, ms=0.0),
         core_orbitals=list(range(19)),
         active_orbitals=[19, 20],
-    )(rhf)
+    )
+    mc = MCOptimizer(ci_solver)(rhf)
     mc.run()
 
     assert rhf.E == approx(erhf)

--- a/tests/mcopt/test_casscf_singlet_benzyne.py
+++ b/tests/mcopt/test_casscf_singlet_benzyne.py
@@ -26,7 +26,7 @@ def test_casscf_singlet_benzyne():
         unit="bohr",
     )
 
-    rhf = RHF(charge=0, econv=1e-12)(system)
+    rhf = RHF(charge=0, e_tol=1e-12)(system)
     ci_solver = CISolver(
         State(nel=40, multiplicity=1, ms=0.0),
         core_orbitals=list(range(19)),

--- a/tests/mcopt/test_casscf_so.py
+++ b/tests/mcopt/test_casscf_so.py
@@ -5,6 +5,7 @@ from forte2 import (
     ROHF,
     MCOptimizer,
     State,
+    CISolver,
     RelCI,
 )
 from forte2.scf.scf_utils import convert_coeff_spatial_to_spinor
@@ -30,10 +31,11 @@ def test_casscf_so():
         num_active_uocc=0,
         subspace=["Br(4s)", "Br(4p)"],
     )(rhf)
-    mc = MCOptimizer(
+    ci_solver = CISolver(
         states=State(nel=35, multiplicity=2, ms=0.5),
         nroots=3,
-    )(avas)
+    )
+    mc = MCOptimizer(ci_solver)(avas)
     mc.run()
 
     system.two_component = True

--- a/tests/mcopt/test_casscf_symmetry_breaking_beh2.py
+++ b/tests/mcopt/test_casscf_symmetry_breaking_beh2.py
@@ -24,7 +24,7 @@ def test_casscf_symmetry_breaking():
         unit="bohr",
     )
 
-    rhf = RHF(charge=0, econv=1e-10)(system)
+    rhf = RHF(charge=0, e_tol=1e-10)(system)
     ci_solver = CISolver(
         State(nel=6, multiplicity=1, ms=0.0),
         core_orbitals=[0, 1],
@@ -32,7 +32,7 @@ def test_casscf_symmetry_breaking():
     )
     mc = MCOptimizer(
         ci_solver,
-        econv=1e-9,
+        e_tol=1e-9,
         maxiter=500,
     )(rhf)
     mc.run()

--- a/tests/mcopt/test_casscf_symmetry_breaking_beh2.py
+++ b/tests/mcopt/test_casscf_symmetry_breaking_beh2.py
@@ -1,4 +1,4 @@
-from forte2 import System, RHF, MCOptimizer, State
+from forte2 import System, RHF, MCOptimizer, State, CISolver
 from forte2.helpers.comparisons import approx
 
 
@@ -25,10 +25,13 @@ def test_casscf_symmetry_breaking():
     )
 
     rhf = RHF(charge=0, econv=1e-10)(system)
-    mc = MCOptimizer(
+    ci_solver = CISolver(
         State(nel=6, multiplicity=1, ms=0.0),
         core_orbitals=[0, 1],
         active_orbitals=[2, 3],
+    )
+    mc = MCOptimizer(
+        ci_solver,
         econv=1e-9,
         maxiter=500,
     )(rhf)

--- a/tests/mcopt/test_casscf_with_sci.py
+++ b/tests/mcopt/test_casscf_with_sci.py
@@ -1,0 +1,43 @@
+from forte2 import System, State, MCOptimizer
+from forte2.scf import RHF
+from forte2.sci import SelectedCISolver
+from forte2.helpers.comparisons import approx
+from forte2.base_classes.params import SelectedCIParams, DavidsonLiuParams
+
+
+def test_sciscf_n2_multiple_roots():
+    """Test that multiple roots can be converged for N2."""
+    xyz = """
+    N 0.0 0.0 0.0
+    N 0.0 0.0 1.1
+    """
+
+    system = System(xyz=xyz, basis_set="cc-pvdz", auxiliary_basis_set="cc-pVTZ-JKFIT")
+    rhf = RHF(charge=0)(system)
+    ci_solver = SelectedCISolver(
+        states=State(nel=14, multiplicity=1, ms=0.0),
+        core_orbitals=4,
+        active_orbitals=6,
+        sci_params=SelectedCIParams(
+            selection_algorithm="hbci",
+            var_threshold=1e-8,
+            pt2_threshold=0.0,
+            do_spin_penalty=True,
+            screening_criterion="hbci",
+            guess_occ_window=2,
+            guess_vir_window=2,
+            num_threads=4,
+            num_batches_per_thread=16,
+        ),
+        die_if_not_converged=False,
+        nroots=2,
+        davidson_liu_params=DavidsonLiuParams(
+            e_tol=1e-10,
+            r_tol=1e-5,
+            ndets_per_guess=20,
+        ),
+    )
+    mc = MCOptimizer(ci_solver)(rhf)
+    mc.run()
+    assert ci_solver.E[0] == approx(-109.0799734286)
+    assert ci_solver.E[1] == approx(-108.6858467105)

--- a/tests/mcopt/test_gasscf.py
+++ b/tests/mcopt/test_gasscf.py
@@ -173,3 +173,80 @@ def test_gasscf_5():
 
     assert rhf.E == approx(erhf)
     assert mc.E == approx(emcscf)
+
+
+def test_gasscf_transition_dipole():
+    # Validated against the following forte v1 input:
+    # import forte
+    # molecule h2o{
+    #     O            0.000000000000     0.000000000000    -0.069592187400
+    #     H            0.000000000000    -0.783151105291     0.552239257834
+    #     H            0.000000000000     0.783151105291     0.552239257834
+    # symmetry c1
+    # }
+
+    # set global {
+    #   scf_type                                df
+    #   basis                                   cc-pvdz
+    #   reference                               rhf
+    #   df_basis_scf                            def2-universal-jkfit
+    #   df_basis_mp2                            def2-universal-jkfit
+    # }
+
+    # set forte {
+    #   active_space_solver                     genci
+    #   int_type                                df
+    #   avg_state                               [[0,1,1],[0,1,1]]
+    #   avg_weight                              [[0],[1]]
+    #   e_convergence                           12
+    #   r_convergence                           8
+    #   rotate_mos                              [1, 1,2]
+    #   restricted_docc                         [1]
+    #   gas1                                    [1]
+    #   gas2                                    [5]
+    #   gas1min                                 [2,1]
+    #   gas1max                                 [2,1]
+    #   transition_dipoles                      [[0,1,0]]
+    #   mcscf_maxiter                           400
+    #   mcscf_e_convergence                     1e-10
+    #   mcscf_g_convergence                     1e-8
+    # }
+
+    # energy('forte')
+
+    xyz = """
+    O            0.000000000000     0.000000000000    -0.069592187400
+    H            0.000000000000    -0.783151105291     0.552239257834
+    H            0.000000000000     0.783151105291     0.552239257834
+    """
+
+    system = System(
+        xyz=xyz, basis_set="cc-pVDZ", auxiliary_basis_set="def2-universal-jkfit"
+    )
+
+    rhf = RHF(charge=0, e_tol=1e-12, d_tol=1e-12)(system)
+
+    ci_solver = CISolver(
+        states=[
+            State(nel=10, multiplicity=1, ms=0.0, gas_min=[1], gas_max=[1]),
+            State(nel=10, multiplicity=1, ms=0.0, gas_min=[2], gas_max=[2]),
+        ],
+        core_orbitals=[1],
+        active_orbitals=[[0], [2, 3, 4, 5, 6]],
+        nroots=[1, 1],
+        weights=[[1.0], [0.0]],
+    )
+    mc = MCOptimizer(
+        ci_solver,
+        e_tol=1e-10,
+        g_tol=1e-8,
+        do_transition_dipole=True,
+    )(rhf)
+    mc.run()
+
+    assert ci_solver.E[0] == approx(-56.3204849516)
+    assert ci_solver.E[1] == approx(-75.8022869454)
+
+    assert ci_solver.oscillator_strengths[(1, 0)] == pytest.approx(
+        0.00014521738399236842, abs=1e-5
+    )

--- a/tests/mcopt/test_gasscf_active_frozen.py
+++ b/tests/mcopt/test_gasscf_active_frozen.py
@@ -24,7 +24,7 @@ def test_gasscf_ch4_active_frozen_1s():
         unit="bohr",
     )
 
-    rhf = RHF(charge=0, econv=1e-12, dconv=1e-12)(system)
+    rhf = RHF(charge=0, e_tol=1e-12, d_tol=1e-12)(system)
 
     ci_solver = CISolver(
         State(nel=10, multiplicity=1, ms=0.0, gas_min=[1], gas_max=[1]),
@@ -61,7 +61,7 @@ def test_gasscf_ch4_active_frozen_1s_highest_active():
         unit="bohr",
     )
 
-    rhf = RHF(charge=0, econv=1e-12, dconv=1e-12)(system)
+    rhf = RHF(charge=0, e_tol=1e-12, d_tol=1e-12)(system)
 
     ci_solver = CISolver(
         State(nel=10, multiplicity=1, ms=0.0, gas_min=[1], gas_max=[1]),
@@ -98,7 +98,7 @@ def test_gasscf_ch4_active_frozen_1s_highest_active_noncontiguous():
         unit="bohr",
     )
 
-    rhf = RHF(charge=0, econv=1e-12, dconv=1e-12)(system)
+    rhf = RHF(charge=0, e_tol=1e-12, d_tol=1e-12)(system)
 
     ci_solver = CISolver(
         State(nel=10, multiplicity=1, ms=0.0, gas_min=[1], gas_max=[1]),

--- a/tests/mcopt/test_gasscf_active_frozen.py
+++ b/tests/mcopt/test_gasscf_active_frozen.py
@@ -1,6 +1,6 @@
 import pytest
 
-from forte2 import System, RHF, MCOptimizer, State
+from forte2 import System, RHF, MCOptimizer, State, CISolver
 from forte2.helpers.comparisons import approx
 
 
@@ -26,9 +26,12 @@ def test_gasscf_ch4_active_frozen_1s():
 
     rhf = RHF(charge=0, econv=1e-12, dconv=1e-12)(system)
 
-    mc = MCOptimizer(
+    ci_solver = CISolver(
         State(nel=10, multiplicity=1, ms=0.0, gas_min=[1], gas_max=[1]),
         active_orbitals=[[0], [1, 2, 3, 4, 5, 6, 7, 8]],
+    )
+    mc = MCOptimizer(
+        ci_solver,
         active_frozen_orbitals=[0],
         maxiter=500,
     )(rhf)
@@ -60,9 +63,12 @@ def test_gasscf_ch4_active_frozen_1s_highest_active():
 
     rhf = RHF(charge=0, econv=1e-12, dconv=1e-12)(system)
 
-    mc = MCOptimizer(
+    ci_solver = CISolver(
         State(nel=10, multiplicity=1, ms=0.0, gas_min=[1], gas_max=[1]),
         active_orbitals=[[0], [1, 2, 3, 4, 5, 6, 7, 8]],
+    )
+    mc = MCOptimizer(
+        ci_solver,
         active_frozen_orbitals=[0, 8],
         maxiter=100,
     )(rhf)
@@ -94,9 +100,12 @@ def test_gasscf_ch4_active_frozen_1s_highest_active_noncontiguous():
 
     rhf = RHF(charge=0, econv=1e-12, dconv=1e-12)(system)
 
-    mc = MCOptimizer(
+    ci_solver = CISolver(
         State(nel=10, multiplicity=1, ms=0.0, gas_min=[1], gas_max=[1]),
         active_orbitals=[[0], [1, 2, 3, 4, 5, 6, 7, 9]],
+    )
+    mc = MCOptimizer(
+        ci_solver,
         active_frozen_orbitals=[0, 9],
         maxiter=500,
     )(rhf)

--- a/tests/mcopt/test_gasscf_equiv_to_casscf.py
+++ b/tests/mcopt/test_gasscf_equiv_to_casscf.py
@@ -1,4 +1,4 @@
-from forte2 import System, RHF, MCOptimizer, State
+from forte2 import System, RHF, MCOptimizer, State, CISolver
 from forte2.helpers.comparisons import approx
 
 
@@ -19,10 +19,13 @@ def test_gasscf_equiv_to_casscf():
 
     rhf = RHF(charge=0, econv=1e-12, dconv=1e-12)(system)
 
-    casscf = MCOptimizer(
+    ci_solver = CISolver(
         State(nel=10, multiplicity=1, ms=0.0),
         core_orbitals=[0, 1],
         active_orbitals=[[2, 3, 4, 5, 6, 7], []],
+    )
+    casscf = MCOptimizer(
+        ci_solver,
         econv=1e-8,
         gconv=1e-7,
         maxiter=500,

--- a/tests/mcopt/test_gasscf_equiv_to_casscf.py
+++ b/tests/mcopt/test_gasscf_equiv_to_casscf.py
@@ -17,7 +17,7 @@ def test_gasscf_equiv_to_casscf():
         xyz=xyz, basis_set="cc-pVTZ", auxiliary_basis_set="def2-universal-jkfit"
     )
 
-    rhf = RHF(charge=0, econv=1e-12, dconv=1e-12)(system)
+    rhf = RHF(charge=0, e_tol=1e-12, d_tol=1e-12)(system)
 
     ci_solver = CISolver(
         State(nel=10, multiplicity=1, ms=0.0),
@@ -26,8 +26,8 @@ def test_gasscf_equiv_to_casscf():
     )
     casscf = MCOptimizer(
         ci_solver,
-        econv=1e-8,
-        gconv=1e-7,
+        e_tol=1e-8,
+        g_tol=1e-7,
         maxiter=500,
     )(rhf)
     casscf.run()

--- a/tests/mcopt/test_gasscf_simple.py
+++ b/tests/mcopt/test_gasscf_simple.py
@@ -85,7 +85,7 @@ def test_gasscf_2():
         xyz=xyz, basis_set="cc-pVTZ", auxiliary_basis_set="def2-universal-jkfit"
     )
 
-    rhf = RHF(charge=0, econv=1e-12, dconv=1e-12)(system)
+    rhf = RHF(charge=0, e_tol=1e-12, d_tol=1e-12)(system)
 
     ci_solver = CISolver(
         State(nel=10, multiplicity=1, ms=0.0, gas_min=[3], gas_max=[6]),
@@ -94,8 +94,8 @@ def test_gasscf_2():
     )
     mc = MCOptimizer(
         ci_solver,
-        econv=1e-8,
-        gconv=1e-7,
+        e_tol=1e-8,
+        g_tol=1e-7,
         maxiter=100,
     )(rhf)
     mc.run()
@@ -124,7 +124,7 @@ def test_gasscf_3():
         unit="bohr",
     )
 
-    rhf = RHF(charge=0, econv=1e-12, dconv=1e-12)(system)
+    rhf = RHF(charge=0, e_tol=1e-12, d_tol=1e-12)(system)
 
     ci_solver = CISolver(
         State(nel=10, multiplicity=1, ms=0.0, gas_min=[1], gas_max=[1]),
@@ -132,8 +132,8 @@ def test_gasscf_3():
     )
     mc = MCOptimizer(
         ci_solver,
-        econv=1e-8,
-        gconv=1e-7,
+        e_tol=1e-8,
+        g_tol=1e-7,
         maxiter=500,
     )(rhf)
     mc.run()
@@ -156,7 +156,7 @@ def test_gasscf_5():
         xyz=xyz, basis_set="cc-pVDZ", auxiliary_basis_set="def2-universal-jkfit"
     )
 
-    rhf = RHF(charge=0, econv=1e-12, dconv=1e-12)(system)
+    rhf = RHF(charge=0, e_tol=1e-12, d_tol=1e-12)(system)
 
     ci_solver = CISolver(
         states=State(nel=10, multiplicity=1, ms=0.0, gas_min=[6, 0], gas_max=[8, 2]),
@@ -166,8 +166,8 @@ def test_gasscf_5():
     mc = MCOptimizer(
         ci_solver,
         freeze_inter_gas_rots=True,
-        econv=1e-10,
-        gconv=1e-8,
+        e_tol=1e-10,
+        g_tol=1e-8,
     )(rhf)
     mc.run()
 

--- a/tests/mcopt/test_gasscf_simple.py
+++ b/tests/mcopt/test_gasscf_simple.py
@@ -1,6 +1,6 @@
 import pytest
 
-from forte2 import System, RHF, MCOptimizer, State
+from forte2 import System, RHF, MCOptimizer, State, CISolver
 from forte2.helpers.comparisons import approx
 
 
@@ -20,10 +20,13 @@ def test_gasscf_1():
 
     rhf = RHF(charge=0)(system)
 
-    mc = MCOptimizer(
+    ci_solver = CISolver(
         State(nel=10, multiplicity=1, ms=0.0, gas_min=[3], gas_max=[6]),
         core_orbitals=2,
         active_orbitals=(3, 3),
+    )
+    mc = MCOptimizer(
+        ci_solver,
         freeze_inter_gas_rots=True,
     )(rhf)
     mc.run()
@@ -47,7 +50,7 @@ def test_gasscf_h2o_core():
 
     rhf = RHF(charge=0)(system)
 
-    mc = MCOptimizer(
+    ci_solver = CISolver(
         states=[
             State(nel=10, multiplicity=1, ms=0.0, gas_min=[0], gas_max=[1]),
             State(nel=10, multiplicity=3, ms=1.0, gas_min=[0], gas_max=[1]),
@@ -56,6 +59,9 @@ def test_gasscf_h2o_core():
         weights=[[1.0], [3.0]],
         core_orbitals=[1],
         active_orbitals=[[0], [2, 3, 4, 5]],
+    )
+    mc = MCOptimizer(
+        ci_solver,
         freeze_inter_gas_rots=True,
     )(rhf)
     mc.run()
@@ -81,10 +87,13 @@ def test_gasscf_2():
 
     rhf = RHF(charge=0, econv=1e-12, dconv=1e-12)(system)
 
-    mc = MCOptimizer(
+    ci_solver = CISolver(
         State(nel=10, multiplicity=1, ms=0.0, gas_min=[3], gas_max=[6]),
         core_orbitals=[0, 1],
         active_orbitals=[[2, 3, 4], [5]],
+    )
+    mc = MCOptimizer(
+        ci_solver,
         econv=1e-8,
         gconv=1e-7,
         maxiter=100,
@@ -117,9 +126,12 @@ def test_gasscf_3():
 
     rhf = RHF(charge=0, econv=1e-12, dconv=1e-12)(system)
 
-    mc = MCOptimizer(
+    ci_solver = CISolver(
         State(nel=10, multiplicity=1, ms=0.0, gas_min=[1], gas_max=[1]),
         active_orbitals=[[0], [1, 2, 3, 4, 5, 6, 7, 8]],
+    )
+    mc = MCOptimizer(
+        ci_solver,
         econv=1e-8,
         gconv=1e-7,
         maxiter=500,
@@ -146,10 +158,13 @@ def test_gasscf_5():
 
     rhf = RHF(charge=0, econv=1e-12, dconv=1e-12)(system)
 
-    mc = MCOptimizer(
+    ci_solver = CISolver(
         states=State(nel=10, multiplicity=1, ms=0.0, gas_min=[6, 0], gas_max=[8, 2]),
         core_orbitals=[0],
         active_orbitals=[[1, 2, 3, 4], [5, 6]],
+    )
+    mc = MCOptimizer(
+        ci_solver,
         freeze_inter_gas_rots=True,
         econv=1e-10,
         gconv=1e-8,

--- a/tests/mcopt/test_mcopt_rdms.py
+++ b/tests/mcopt/test_mcopt_rdms.py
@@ -21,7 +21,7 @@ def test_mcoptimizer_rdm_accessors_single_solver():
         basis_set="cc-pvdz",
         auxiliary_basis_set="cc-pVTZ-JKFIT",
     )
-    rhf = RHF(charge=0, econv=1e-12)(system)
+    rhf = RHF(charge=0, e_tol=1e-12)(system)
 
     ci_solver = CISolver(
         State(nel=2, multiplicity=1, ms=0.0),
@@ -59,7 +59,7 @@ def test_mcoptimizer_rdm_accessors_multi_solver():
         auxiliary_basis_set="cc-pVTZ-JKFIT",
         unit="bohr",
     )
-    rhf = RHF(charge=0, econv=1e-8)(system)
+    rhf = RHF(charge=0, e_tol=1e-8)(system)
 
     singlet = State(nel=10, multiplicity=1, ms=0.0)
     triplet = State(nel=10, multiplicity=3, ms=1.0)

--- a/tests/mcopt/test_mcopt_rdms.py
+++ b/tests/mcopt/test_mcopt_rdms.py
@@ -1,7 +1,7 @@
 import numpy as np
 import pytest
 
-from forte2 import System, RHF, MCOptimizer, State
+from forte2 import System, RHF, MCOptimizer, State, CISolver
 from forte2.base_classes import DavidsonLiuParams
 
 
@@ -23,12 +23,13 @@ def test_mcoptimizer_rdm_accessors_single_solver():
     )
     rhf = RHF(charge=0, econv=1e-12)(system)
 
-    mc = MCOptimizer(
+    ci_solver = CISolver(
         State(nel=2, multiplicity=1, ms=0.0),
         active_orbitals=[0, 1],
         nroots=2,
         davidson_liu_params=DavidsonLiuParams(e_tol=1e-12, r_tol=1e-10),
-    )(rhf)
+    )
+    mc = MCOptimizer(ci_solver)(rhf)
     mc.run()
 
     solver = mc.ci_solver.sub_solvers[0]
@@ -62,13 +63,14 @@ def test_mcoptimizer_rdm_accessors_multi_solver():
 
     singlet = State(nel=10, multiplicity=1, ms=0.0)
     triplet = State(nel=10, multiplicity=3, ms=1.0)
-    mc = MCOptimizer(
+    ci_solver = CISolver(
         states=[singlet, triplet],
         nroots=[2, 1],
         core_orbitals=[0],
         active_orbitals=[1, 2, 3, 4, 5, 6, 7],
         davidson_liu_params=DavidsonLiuParams(e_tol=1e-8, r_tol=1e-4),
-    )(rhf)
+    )
+    mc = MCOptimizer(ci_solver)(rhf)
     mc.run()
 
     singlet_solver, triplet_solver = mc.ci_solver.sub_solvers
@@ -89,3 +91,4 @@ def test_mcoptimizer_rdm_accessors_multi_solver():
         mc.make_sd_2rdm(2),
         triplet_solver.make_sd_2rdm(0),
     )
+test_mcoptimizer_rdm_accessors_multi_solver()

--- a/tests/mcopt/test_mcopt_rdms.py
+++ b/tests/mcopt/test_mcopt_rdms.py
@@ -94,4 +94,3 @@ def test_mcoptimizer_rdm_accessors_multi_solver():
         mc.make_sd_2rdm(2),
         triplet_solver.make_sd_2rdm(0),
     )
-test_mcoptimizer_rdm_accessors_multi_solver()

--- a/tests/mcopt/test_mcopt_rdms.py
+++ b/tests/mcopt/test_mcopt_rdms.py
@@ -73,7 +73,10 @@ def test_mcoptimizer_rdm_accessors_multi_solver():
 
     singlet_solver, triplet_solver = mc.ci_solver.sub_solvers
 
-    with pytest.raises(ValueError, match="Cross-state RDMs are not supported"):
+    with pytest.raises(
+        ValueError,
+        match="Cross-state RDMs are only supported for states with the same number of alpha and beta electrons",
+    ):
         mc.make_sd_1rdm(1, 2)
 
     with pytest.raises(ValueError, match="absolute_root must be between 0"):

--- a/tests/mcopt/test_rel_casscf.py
+++ b/tests/mcopt/test_rel_casscf.py
@@ -1,9 +1,8 @@
 import numpy as np
 
-from forte2 import System, GHF, RHF
+from forte2 import System, GHF, RHF, RelCISolver, MCOptimizer
 from forte2.helpers.comparisons import approx
 from forte2.scf.scf_utils import convert_coeff_spatial_to_spinor
-from forte2.mcopt import RelMCOptimizer
 from forte2.orbitals import AVAS
 
 
@@ -31,12 +30,12 @@ def test_rel_casscf_hf_equivalence_to_nonrel():
     scf.run()
     scf = rhf_to_ghf_with_random_phase(scf)
     system.two_component = True
-    mc = RelMCOptimizer(
+    ci_solver = RelCISolver(
         nel=10,
         core_orbitals=2,
         active_orbitals=12,
-        maxiter=200,
-    )(scf)
+    )
+    mc = MCOptimizer(ci_solver)(scf)
     mc.run()
     assert scf.E == approx(erhf)
     assert mc.E == approx(emcscf)
@@ -59,13 +58,13 @@ def test_rel_casscf_hf_ghf():
         snso_type=None,
     )
     scf = GHF(charge=0)(system)
-    mc = RelMCOptimizer(
+    ci_solver = RelCISolver(
         nel=10,
         nroots=1,
         core_orbitals=2,
         active_orbitals=12,
-        maxiter=200,
-    )(scf)
+    )
+    mc = MCOptimizer(ci_solver)(scf)
     mc.run()
 
     assert scf.E == approx(escf)
@@ -91,21 +90,23 @@ def test_rel_casscf_frozen_co_equivalent_to_nonrel():
         num_active_uocc=6,
     )(rhf)
 
-    mc = RelMCOptimizer(
+    ci_solver = RelCISolver(
         nel=14,
         core_orbitals=8,
         active_orbitals=12,
-    )(avas)
+    )
+    mc = MCOptimizer(ci_solver)(avas)
     mc.run()
     assert mc.E == approx(emcscf)
 
-    mc = RelMCOptimizer(
+    ci_solver = RelCISolver(
         nel=14,
         frozen_core_orbitals=2,
         core_orbitals=6,
         active_orbitals=12,
         frozen_virtual_orbitals=6,
     )(avas)
+    mc = MCOptimizer(ci_solver)(avas)
     mc.run()
     assert mc.E == approx(emcscf_frz)
 
@@ -135,11 +136,12 @@ def test_rel_casscf_frozen_co_x2c():
         num_active_uocc=6,
     )(mf)
 
-    mc = RelMCOptimizer(
+    ci_solver = RelCISolver(
         nel=14,
         core_orbitals=8,
         active_orbitals=12,
-    )(avas)
+    )
+    mc = MCOptimizer(ci_solver)(avas)
     mc.run()
     assert mc.E == approx(emcscf)
 
@@ -159,13 +161,13 @@ def test_rel_casscf_na_ghf():
         snso_type=None,
     )
     scf = GHF(charge=0)(system)
-    mc = RelMCOptimizer(
+    ci_solver = RelCISolver(
         nel=11,
         nroots=8,
         core_orbitals=10,
         active_orbitals=8,
-        maxiter=500,
-    )(scf)
+    )
+    mc = MCOptimizer(ci_solver)(scf)
     mc.run()
 
     assert mc.E == approx(emcscf)
@@ -184,11 +186,12 @@ def test_rel_ci_br():
         snso_type="row-dependent",
     )
     scf = GHF(charge=-1)(system)
-    mc = RelMCOptimizer(
+    ci_solver = RelCISolver(
         nel=35,
         nroots=6,
         active_orbitals=8,
         core_orbitals=28,
-    )(scf)
+    )
+    mc = MCOptimizer(ci_solver)(scf)
     mc.run()
     assert mc.E == approx(-2597.0679040990)

--- a/tests/mcopt/test_rel_casscf.py
+++ b/tests/mcopt/test_rel_casscf.py
@@ -26,7 +26,7 @@ def test_rel_casscf_hf_equivalence_to_nonrel():
     system = System(
         xyz=xyz, basis_set="cc-pvdz", auxiliary_basis_set="cc-pVTZ-JKFIT", unit="bohr"
     )
-    scf = RHF(charge=0, econv=1e-10)(system)
+    scf = RHF(charge=0, e_tol=1e-10)(system)
     scf.run()
     scf = rhf_to_ghf_with_random_phase(scf)
     system.two_component = True
@@ -82,7 +82,7 @@ def test_rel_casscf_frozen_co_equivalent_to_nonrel():
 
     system = System(xyz=xyz, basis_set="cc-pvdz", auxiliary_basis_set="cc-pVTZ-JKFIT")
 
-    rhf = GHF(charge=0, econv=1e-12)(system)
+    rhf = GHF(charge=0, e_tol=1e-12)(system)
     avas = AVAS(
         subspace=["C(2p)", "O(2p)"],
         selection_method="separate",
@@ -128,7 +128,7 @@ def test_rel_casscf_frozen_co_x2c():
         snso_type="row-dependent",
     )
 
-    mf = GHF(charge=0, econv=1e-12)(system)
+    mf = GHF(charge=0, e_tol=1e-12)(system)
     avas = AVAS(
         subspace=["C(2p)", "O(2p)"],
         selection_method="separate",

--- a/tests/mcopt/test_rel_casscf.py
+++ b/tests/mcopt/test_rel_casscf.py
@@ -171,7 +171,7 @@ def test_rel_casscf_na_ghf():
     assert mc.E == approx(emcscf)
 
 
-def test_rel_ci_br():
+def test_rel_casscf_br():
     xyz = """
     Br 0 0 0
     """

--- a/tests/mcopt/test_rel_gasscf.py
+++ b/tests/mcopt/test_rel_gasscf.py
@@ -1,7 +1,6 @@
 import pytest
 
-from forte2 import System, GHF, RelState
-from forte2.mcopt import RelMCOptimizer
+from forte2 import System, GHF, RelState, MCOptimizer, RelCISolver
 from forte2.helpers.comparisons import approx
 
 
@@ -22,10 +21,13 @@ def test_rel_gasscf_equivalence_to_nonrel():
 
     hf = GHF(charge=0, econv=1e-12, dconv=1e-12)(system)
 
-    mc = RelMCOptimizer(
+    ci_solver = RelCISolver(
         RelState(nel=10, gas_min=[3], gas_max=[6]),
         core_orbitals=4,
         active_orbitals=(6, 6),
+    )
+    mc = MCOptimizer(
+        ci_solver,
         freeze_inter_gas_rots=True,
     )(hf)
     mc.run()
@@ -55,11 +57,14 @@ def test_rel_gasscf_h2o_core():
 
     scf = GHF(charge=0)(system)
 
-    mc = RelMCOptimizer(
+    ci_solver = RelCISolver(
         RelState(nel=10, gas_min=[0], gas_max=[1]),
         core_orbitals=[2, 3],
         nroots=4,
         active_orbitals=[[0, 1], [4, 5, 6, 7, 8, 9, 10, 11]],
+    )
+    mc = MCOptimizer(
+        ci_solver,
         active_frozen_orbitals=[0, 1],
     )(scf)
     mc.run()

--- a/tests/mcopt/test_rel_gasscf.py
+++ b/tests/mcopt/test_rel_gasscf.py
@@ -19,7 +19,7 @@ def test_rel_gasscf_equivalence_to_nonrel():
         xyz=xyz, basis_set="cc-pVTZ", auxiliary_basis_set="def2-universal-jkfit"
     )
 
-    hf = GHF(charge=0, econv=1e-12, dconv=1e-12)(system)
+    hf = GHF(charge=0, e_tol=1e-12, d_tol=1e-12)(system)
 
     ci_solver = RelCISolver(
         RelState(nel=10, gas_min=[3], gas_max=[6]),

--- a/tests/mcopt/test_sa_casscf_c2.py
+++ b/tests/mcopt/test_sa_casscf_c2.py
@@ -19,7 +19,7 @@ def test_sa_casscf_c2():
         auxiliary_basis_set="cc-pVTZ-JKFIT",
     )
 
-    rhf = RHF(charge=0, econv=1e-12)(system)
+    rhf = RHF(charge=0, e_tol=1e-12)(system)
     avas = AVAS(
         selection_method="separate",
         num_active_docc=4,

--- a/tests/mcopt/test_sa_casscf_c2.py
+++ b/tests/mcopt/test_sa_casscf_c2.py
@@ -1,4 +1,4 @@
-from forte2 import System, RHF, MCOptimizer, AVAS, State
+from forte2 import System, RHF, MCOptimizer, AVAS, State, CISolver
 from forte2.helpers.comparisons import approx
 
 
@@ -26,7 +26,8 @@ def test_sa_casscf_c2():
         num_active_uocc=4,
         subspace=["C(2s)", "C(2p)"],
     )(rhf)
-    mc = MCOptimizer(State(nel=rhf.nel, multiplicity=1, ms=0.0), nroots=3)(avas)
+    ci_solver = CISolver(State(nel=rhf.nel, multiplicity=1, ms=0.0), nroots=3)
+    mc = MCOptimizer(ci_solver)(avas)
     mc.run()
 
     assert rhf.E == approx(erhf)

--- a/tests/mcopt/test_sa_casscf_hf.py
+++ b/tests/mcopt/test_sa_casscf_hf.py
@@ -19,7 +19,7 @@ def test_sa_casscf_hf():
 
     system = System(xyz=xyz, basis_set="cc-pvdz", auxiliary_basis_set="cc-pvtz-jkfit")
 
-    rhf = RHF(charge=0, econv=1e-12)(system)
+    rhf = RHF(charge=0, e_tol=1e-12)(system)
     ci_solver = CISolver(
         State(nel=10, multiplicity=1, ms=0.0),
         core_orbitals=[0],

--- a/tests/mcopt/test_sa_casscf_hf.py
+++ b/tests/mcopt/test_sa_casscf_hf.py
@@ -41,17 +41,17 @@ def test_sa_casscf_hf():
 
     # if energy is converged to ~1e-8, properties are converged to ~1e-4
     # transition dipole moment of 0->3 transition
-    assert abs(mc.ci_solver.tdm_per_solver[0][(0, 3)][2]) == pytest.approx(
+    assert abs(mc.ci_solver.transition_dipoles[(0, 3)][2]) == pytest.approx(
         1.1357911621720147, abs=1e-4
     )
     # transition oscillator strength of 0->3 transition
-    assert mc.ci_solver.fosc_per_solver[0][(0, 3)] == pytest.approx(
+    assert mc.ci_solver.oscillator_strengths[(0, 3)] == pytest.approx(
         0.4525407586932925, abs=1e-4
     )
     # total dipole of state 0, 1
-    assert abs(mc.ci_solver.tdm_per_solver[0][(0, 0)][2]) == pytest.approx(
+    assert abs(mc.ci_solver.transition_dipoles[(0, 0)][2]) == pytest.approx(
         0.7244112903260456, abs=1e-4
     )
-    assert abs(mc.ci_solver.tdm_per_solver[0][(1, 1)][2]) == pytest.approx(
+    assert abs(mc.ci_solver.transition_dipoles[(1, 1)][2]) == pytest.approx(
         0.8239033452222257, abs=1e-4
     )

--- a/tests/mcopt/test_sa_casscf_hf.py
+++ b/tests/mcopt/test_sa_casscf_hf.py
@@ -1,6 +1,6 @@
 import pytest
 
-from forte2 import System, RHF, MCOptimizer, State
+from forte2 import System, RHF, MCOptimizer, State, CISolver
 from forte2.helpers.comparisons import approx
 
 
@@ -20,11 +20,14 @@ def test_sa_casscf_hf():
     system = System(xyz=xyz, basis_set="cc-pvdz", auxiliary_basis_set="cc-pvtz-jkfit")
 
     rhf = RHF(charge=0, econv=1e-12)(system)
-    mc = MCOptimizer(
+    ci_solver = CISolver(
         State(nel=10, multiplicity=1, ms=0.0),
         core_orbitals=[0],
         active_orbitals=[1, 2, 3, 4, 5],
         nroots=4,
+    )
+    mc = MCOptimizer(
+        ci_solver,
         do_transition_dipole=True,
     )(rhf)
     mc.run()

--- a/tests/mcopt/test_sa_casscf_n2.py
+++ b/tests/mcopt/test_sa_casscf_n2.py
@@ -15,7 +15,7 @@ def test_sa_casscf_same_mult():
     """
 
     system = System(xyz=xyz, basis_set="cc-pVDZ", auxiliary_basis_set="cc-pVTZ-JKFIT")
-    rhf = RHF(charge=0, econv=1e-12)(system)
+    rhf = RHF(charge=0, e_tol=1e-12)(system)
     ci_solver = CISolver(
         State(nel=14, multiplicity=1, ms=0.0),
         active_orbitals=[4, 5, 6, 7, 8, 9],
@@ -24,7 +24,7 @@ def test_sa_casscf_same_mult():
     )
     mc = MCOptimizer(
         ci_solver,
-        gconv=1e-7,
+        g_tol=1e-7,
     )(rhf)
     mc.run()
     assert rhf.E == approx(erhf)
@@ -40,7 +40,7 @@ def test_sa_mcscf_diff_mult_with_avas():
 
     system = System(xyz=xyz, basis_set="cc-pvdz", auxiliary_basis_set="cc-pVTZ-JKFIT")
 
-    rhf = RHF(charge=0, econv=1e-12)(system)
+    rhf = RHF(charge=0, e_tol=1e-12)(system)
     avas = AVAS(
         selection_method="separate",
         num_active_docc=3,
@@ -88,7 +88,7 @@ def test_sa_casscf_diff_mult():
 
     system = System(xyz=xyz, basis_set="cc-pvdz", auxiliary_basis_set="cc-pVTZ-JKFIT")
 
-    rhf = RHF(charge=0, econv=1e-12)(system)
+    rhf = RHF(charge=0, e_tol=1e-12)(system)
     singlet = State(nel=rhf.nel, multiplicity=1, ms=0.0)
     triplet = State(nel=rhf.nel, multiplicity=3, ms=0.0)
     ci_solver = CISolver(

--- a/tests/mcopt/test_sa_casscf_n2.py
+++ b/tests/mcopt/test_sa_casscf_n2.py
@@ -1,7 +1,7 @@
 import pytest
 import numpy as np
 
-from forte2 import System, RHF, MCOptimizer, AVAS, State
+from forte2 import System, RHF, MCOptimizer, AVAS, State, CISolver
 from forte2.helpers.comparisons import approx
 
 
@@ -16,11 +16,14 @@ def test_sa_casscf_same_mult():
 
     system = System(xyz=xyz, basis_set="cc-pVDZ", auxiliary_basis_set="cc-pVTZ-JKFIT")
     rhf = RHF(charge=0, econv=1e-12)(system)
-    mc = MCOptimizer(
+    ci_solver = CISolver(
         State(nel=14, multiplicity=1, ms=0.0),
         active_orbitals=[4, 5, 6, 7, 8, 9],
         core_orbitals=[0, 1, 2, 3],
         nroots=2,
+    )
+    mc = MCOptimizer(
+        ci_solver,
         gconv=1e-7,
     )(rhf)
     mc.run()
@@ -47,9 +50,10 @@ def test_sa_mcscf_diff_mult_with_avas():
     )(rhf)
     singlet = State(nel=rhf.nel, multiplicity=1, ms=0.0)
     triplet = State(nel=rhf.nel, multiplicity=3, ms=0.0)
-    mc = MCOptimizer(
+    ci_solver = CISolver(
         [singlet, triplet], weights=[[0.25], [0.75 * 0.85, 0.75 * 0.15]], nroots=[1, 2]
-    )(avas)
+    )
+    mc = MCOptimizer(ci_solver)(avas)
     mc.run()
 
     eref_singlet = -109.0664322107
@@ -87,13 +91,14 @@ def test_sa_casscf_diff_mult():
     rhf = RHF(charge=0, econv=1e-12)(system)
     singlet = State(nel=rhf.nel, multiplicity=1, ms=0.0)
     triplet = State(nel=rhf.nel, multiplicity=3, ms=0.0)
-    mc = MCOptimizer(
+    ci_solver = CISolver(
         [singlet, triplet],
         active_orbitals=[4, 5, 6, 7, 8, 9],
         core_orbitals=[0, 1, 2, 3],
         weights=[[0.25], [0.75 * 0.85, 0.75 * 0.15]],
         nroots=[1, 2],
-    )(rhf)
+    )
+    mc = MCOptimizer(ci_solver)(rhf)
     mc.run()
 
     eref_singlet = -109.0664322107

--- a/tests/mcopt/test_sa_casscf_transition_dipole_c2.py
+++ b/tests/mcopt/test_sa_casscf_transition_dipole_c2.py
@@ -31,4 +31,4 @@ def test_sa_casscf_c2_transition_dipole():
     assert mc.ci_solver.evals_per_solver[0][1] == approx(-75.5314535451)
     assert mc.ci_solver.evals_per_solver[1][0] == approx(-75.5792187010)
     assert mc.ci_solver.evals_per_solver[1][1] == approx(-75.5789867708)
-    assert mc.ci_solver.fosc_per_solver[0][(0, 1)] == approx(0.006525243082121279)
+    assert mc.ci_solver.oscillator_strengths[(0, 1)] == approx(0.006525243082121279)

--- a/tests/mcopt/test_sa_casscf_transition_dipole_c2.py
+++ b/tests/mcopt/test_sa_casscf_transition_dipole_c2.py
@@ -1,4 +1,4 @@
-from forte2 import System, RHF, MCOptimizer, AVAS, State
+from forte2 import System, RHF, MCOptimizer, AVAS, State, CISolver
 from forte2.helpers.comparisons import approx
 
 
@@ -24,7 +24,8 @@ def test_sa_casscf_c2_transition_dipole():
         num_active_uocc=4,
         subspace=["C(2s)", "C(2p)"],
     )(rhf)
-    mc = MCOptimizer([singlet, triplet], nroots=[2, 2], do_transition_dipole=True)(avas)
+    ci_solver = CISolver([singlet, triplet], nroots=[2, 2])
+    mc = MCOptimizer(ci_solver, do_transition_dipole=True)(avas)
     mc.run()
     assert mc.ci_solver.evals_per_solver[0][0] == approx(-75.6107427252)
     assert mc.ci_solver.evals_per_solver[0][1] == approx(-75.5314535451)

--- a/tests/mcopt/test_sa_casscf_transition_dipole_c2.py
+++ b/tests/mcopt/test_sa_casscf_transition_dipole_c2.py
@@ -15,7 +15,7 @@ def test_sa_casscf_c2_transition_dipole():
         auxiliary_basis_set="cc-pVTZ-JKFIT",
     )
 
-    rhf = RHF(charge=0, econv=1e-12)(system)
+    rhf = RHF(charge=0, e_tol=1e-12)(system)
     singlet = State(nel=rhf.nel, multiplicity=1, ms=0.0)
     triplet = State(nel=rhf.nel, multiplicity=3, ms=0.0)
     avas = AVAS(

--- a/tests/orbitals/test_aset.py
+++ b/tests/orbitals/test_aset.py
@@ -1,7 +1,7 @@
 import numpy as np
 from pathlib import Path
 
-from forte2 import System, RHF, MCOptimizer, ASET, CI, State
+from forte2 import System, RHF, MCOptimizer, ASET, CI, State, CISolver
 from forte2.helpers.comparisons import approx
 
 # Directory containing *this* file
@@ -49,11 +49,12 @@ def test_aset_1():
     )
 
     rhf = RHF(charge=0, econv=1e-12)(system)
-    mc = MCOptimizer(
+    ci_solver = CISolver(
         State(nel=24, multiplicity=1, ms=0.0),
         core_orbitals=[0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10],
         active_orbitals=[11, 12],
-    )(rhf)
+    )
+    mc = MCOptimizer(ci_solver)(rhf)
     aset = ASET(
         fragment=["C1-2", "H1-3"],
         cutoff_method="threshold",
@@ -84,11 +85,12 @@ def test_aset_2():
     )
 
     rhf = RHF(charge=0, econv=1e-12)(system)
-    mc = MCOptimizer(
+    ci_solver = CISolver(
         State(nel=24, multiplicity=1, ms=0.0),
         core_orbitals=10,
         active_orbitals=4,
-    )(rhf)
+    )
+    mc = MCOptimizer(ci_solver)(rhf)
     aset = ASET(
         fragment=["N", "H"],
         frozen_core_orbitals=3,
@@ -128,11 +130,12 @@ def test_aset_3():
     )
 
     rhf = RHF(charge=0, econv=1e-12)(system)
-    mc = MCOptimizer(
+    ci_solver = CISolver(
         State(nel=24, multiplicity=1, ms=0.0),
         core_orbitals=11,
         active_orbitals=2,
-    )(rhf)
+    )
+    mc = MCOptimizer(ci_solver)(rhf)
     aset = ASET(
         fragment=["C1-2", "H1-3"],
         frozen_core_orbitals=3,
@@ -167,10 +170,13 @@ def test_aset_4():
     )
 
     rhf = RHF(charge=0, econv=1e-10)(system)
-    mc = MCOptimizer(
+    ci_solver = CISolver(
         State(nel=24, multiplicity=1, ms=0.0),
         core_orbitals=10,
         active_orbitals=4,
+    )
+    mc = MCOptimizer(
+        ci_solver,
         econv=1e-9,
     )(rhf)
     aset = ASET(
@@ -213,11 +219,12 @@ def test_aset_5():
     )
 
     rhf = RHF(charge=0, econv=1e-12)(system)
-    mc = MCOptimizer(
+    ci_solver = CISolver(
         State(system=system, multiplicity=1, ms=0.0),
         core_orbitals=[0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14],
         active_orbitals=[15, 16],
-    )(rhf)
+    )
+    mc = MCOptimizer(ci_solver)(rhf)
     aset = ASET(fragment=["C1-2", "H1-3"], cutoff_method="threshold")(mc)
     ci = CI(State(system=system, multiplicity=1, ms=0.0))(aset)
     ci.run()

--- a/tests/orbitals/test_aset.py
+++ b/tests/orbitals/test_aset.py
@@ -48,7 +48,7 @@ def test_aset_1():
         auxiliary_basis_set="def2-universal-JKFIT",
     )
 
-    rhf = RHF(charge=0, econv=1e-12)(system)
+    rhf = RHF(charge=0, e_tol=1e-12)(system)
     ci_solver = CISolver(
         State(nel=24, multiplicity=1, ms=0.0),
         core_orbitals=[0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10],
@@ -84,7 +84,7 @@ def test_aset_2():
         auxiliary_basis_set="def2-universal-JKFIT",
     )
 
-    rhf = RHF(charge=0, econv=1e-12)(system)
+    rhf = RHF(charge=0, e_tol=1e-12)(system)
     ci_solver = CISolver(
         State(nel=24, multiplicity=1, ms=0.0),
         core_orbitals=10,
@@ -129,7 +129,7 @@ def test_aset_3():
         auxiliary_basis_set="def2-universal-JKFIT",
     )
 
-    rhf = RHF(charge=0, econv=1e-12)(system)
+    rhf = RHF(charge=0, e_tol=1e-12)(system)
     ci_solver = CISolver(
         State(nel=24, multiplicity=1, ms=0.0),
         core_orbitals=11,
@@ -169,7 +169,7 @@ def test_aset_4():
         auxiliary_basis_set="def2-universal-JKFIT",
     )
 
-    rhf = RHF(charge=0, econv=1e-10)(system)
+    rhf = RHF(charge=0, e_tol=1e-10)(system)
     ci_solver = CISolver(
         State(nel=24, multiplicity=1, ms=0.0),
         core_orbitals=10,
@@ -177,7 +177,7 @@ def test_aset_4():
     )
     mc = MCOptimizer(
         ci_solver,
-        econv=1e-9,
+        e_tol=1e-9,
     )(rhf)
     aset = ASET(
         fragment=["N", "H"],
@@ -218,7 +218,7 @@ def test_aset_5():
         auxiliary_basis_set="def2-universal-JKFIT",
     )
 
-    rhf = RHF(charge=0, econv=1e-12)(system)
+    rhf = RHF(charge=0, e_tol=1e-12)(system)
     ci_solver = CISolver(
         State(system=system, multiplicity=1, ms=0.0),
         core_orbitals=[0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14],

--- a/tests/orbitals/test_avas.py
+++ b/tests/orbitals/test_avas.py
@@ -1,6 +1,6 @@
 import pytest
 
-from forte2 import System, AVAS, CI, RHF, ROHF, State, MCOptimizer, GHF, RelCI
+from forte2 import System, AVAS, CI, RHF, ROHF, State, MCOptimizer, GHF, RelCI, CISolver
 from forte2.helpers.comparisons import approx
 
 
@@ -406,7 +406,8 @@ def test_avas_subspace_planes_h2co_casscf():
         sigma=1.0,
         diagonalize=True,
     )(rhf)
-    mc = MCOptimizer(states=State(nel=rhf.nel, multiplicity=1, ms=0.0))(avas)
+    ci_solver = CISolver(states=State(nel=rhf.nel, multiplicity=1, ms=0.0))
+    mc = MCOptimizer(ci_solver)(avas)
     mc.run()
     assert mc.E_ci[0] == approx(eref_avas)
 
@@ -424,7 +425,8 @@ def test_avas_zero_uocc():
         num_active_docc=3,
         num_active_uocc=0,
     )(mf)
-    mc = MCOptimizer(states=State(nel=35, multiplicity=2, ms=0.5), nroots=3)(avas)
+    ci_solver = CISolver(states=State(nel=35, multiplicity=2, ms=0.5), nroots=3)
+    mc = MCOptimizer(ci_solver)(avas)
     mc.run()
     assert mc.E_avg == approx(-2572.3646258078)
 
@@ -442,6 +444,7 @@ def test_avas_zero_uocc2():
         num_active_docc=0,
         num_active_uocc=0,
     )(mf)
-    mc = MCOptimizer(states=State(nel=6, multiplicity=5, ms=2.0), nroots=1)(avas)
+    ci_solver = CISolver(states=State(nel=6, multiplicity=5, ms=2.0), nroots=1)
+    mc = MCOptimizer(ci_solver)(avas)
     mc.run()
     assert mc.E_avg == approx(-37.5906751187)

--- a/tests/orbitals/test_avas.py
+++ b/tests/orbitals/test_avas.py
@@ -12,7 +12,7 @@ def test_avas_inputs():
 
     system = System(xyz=xyz, basis_set="cc-pvdz", auxiliary_basis_set="cc-pVTZ-JKFIT")
 
-    rhf = RHF(charge=0, econv=1e-12)(system)
+    rhf = RHF(charge=0, e_tol=1e-12)(system)
 
     # raise if num_active_docc/vir <= 0
     with pytest.raises(Exception):
@@ -76,7 +76,7 @@ def test_avas_subspace():
         minao_basis_set="sto-3g",
     )
 
-    rhf = RHF(charge=0, econv=1e-12)(system)
+    rhf = RHF(charge=0, e_tol=1e-12)(system)
 
     # sto-3g does not have 3p orbitals
     with pytest.raises(Exception):
@@ -115,7 +115,7 @@ def test_avas_separate_n2():
 
     system = System(xyz=xyz, basis_set="cc-pvdz", auxiliary_basis_set="cc-pVTZ-JKFIT")
 
-    rhf = RHF(charge=0, econv=1e-12)(system)
+    rhf = RHF(charge=0, e_tol=1e-12)(system)
     casci = CI(
         active_orbitals=[4, 5, 6, 7, 8, 9],
         core_orbitals=[0, 1, 2, 3],
@@ -158,7 +158,7 @@ def test_avas_separate_n2_ghf_equivalent_to_rhf():
 
     system = System(xyz=xyz, basis_set="cc-pvdz", auxiliary_basis_set="cc-pVTZ-JKFIT")
 
-    mf = GHF(charge=0, econv=1e-12)(system)
+    mf = GHF(charge=0, e_tol=1e-12)(system)
     casci = RelCI(
         nel=14,
         active_orbitals=12,
@@ -200,7 +200,7 @@ def test_avas_rohf_n2plus():
 
     system = System(xyz=xyz, basis_set="cc-pvdz", auxiliary_basis_set="cc-pVTZ-JKFIT")
 
-    rhf = ROHF(charge=1, ms=0.5, econv=1e-12)(system)
+    rhf = ROHF(charge=1, ms=0.5, e_tol=1e-12)(system)
     avas = AVAS(
         selection_method="separate",
         subspace=["N(2p)"],
@@ -223,7 +223,7 @@ def test_avas_rohf_n2minus():
 
     system = System(xyz=xyz, basis_set="cc-pvdz", auxiliary_basis_set="cc-pVTZ-JKFIT")
 
-    rhf = ROHF(charge=-1, ms=0.5, econv=1e-12)(system)
+    rhf = ROHF(charge=-1, ms=0.5, e_tol=1e-12)(system)
     avas = AVAS(
         selection_method="separate",
         subspace=["N(2p)"],
@@ -248,7 +248,7 @@ def test_avas_cumulative_h2co_all():
 
     system = System(xyz=xyz, basis_set="cc-pvdz", auxiliary_basis_set="cc-pVTZ-JKFIT")
 
-    rhf = RHF(charge=0, econv=1e-12, dconv=1e-10)(system)
+    rhf = RHF(charge=0, e_tol=1e-12, d_tol=1e-10)(system)
     avas = AVAS(
         selection_method="cumulative",
         subspace=["C1(2px)", "O(2px)"],
@@ -273,7 +273,7 @@ def test_avas_cumulative_h2co_98pc():
 
     system = System(xyz=xyz, basis_set="cc-pvdz", auxiliary_basis_set="cc-pVTZ-JKFIT")
 
-    rhf = RHF(charge=0, econv=1e-12, dconv=1e-10)(system)
+    rhf = RHF(charge=0, e_tol=1e-12, d_tol=1e-10)(system)
     avas = AVAS(
         selection_method="cumulative",
         subspace=["C(2px)", "O1(2px)"],
@@ -297,7 +297,7 @@ def test_avas_total_h2co():
 
     system = System(xyz=xyz, basis_set="cc-pvdz", auxiliary_basis_set="cc-pVTZ-JKFIT")
 
-    rhf = RHF(charge=0, econv=1e-12, dconv=1e-10)(system)
+    rhf = RHF(charge=0, e_tol=1e-12, d_tol=1e-10)(system)
     avas = AVAS(
         selection_method="total",
         subspace=["C(2px)", "O1(2px)"],
@@ -321,7 +321,7 @@ def test_avas_total_h2co_ghf_equivalent_to_rhf():
 
     system = System(xyz=xyz, basis_set="cc-pvdz", auxiliary_basis_set="cc-pVTZ-JKFIT")
 
-    rhf = GHF(charge=0, econv=1e-12, dconv=1e-10)(system)
+    rhf = GHF(charge=0, e_tol=1e-12, d_tol=1e-10)(system)
     avas = AVAS(
         selection_method="total",
         subspace=["C(2px)", "O1(2px)"],
@@ -346,7 +346,7 @@ def test_avas_separate_h2co():
 
     system = System(xyz=xyz, basis_set="cc-pvdz", auxiliary_basis_set="cc-pVTZ-JKFIT")
 
-    rhf = RHF(charge=0, econv=1e-12, dconv=1e-10)(system)
+    rhf = RHF(charge=0, e_tol=1e-12, d_tol=1e-10)(system)
     avas = AVAS(
         selection_method="separate",
         subspace=["C(2px)", "O(2px)"],
@@ -373,7 +373,7 @@ def test_avas_subspace_planes_h2co():
 
     system = System(xyz=xyz, basis_set="cc-pvdz", auxiliary_basis_set="cc-pVTZ-JKFIT")
 
-    rhf = RHF(charge=0, econv=1e-12, dconv=1e-10)(system)
+    rhf = RHF(charge=0, e_tol=1e-12, d_tol=1e-10)(system)
     avas = AVAS(
         selection_method="cumulative",
         subspace=["C(2p)", "O(2p)"],
@@ -398,7 +398,7 @@ def test_avas_subspace_planes_h2co_casscf():
     """
 
     system = System(xyz=xyz, basis_set="cc-pvdz", auxiliary_basis_set="cc-pVTZ-JKFIT")
-    rhf = RHF(charge=0, econv=1e-12, dconv=1e-10)(system)
+    rhf = RHF(charge=0, e_tol=1e-12, d_tol=1e-10)(system)
     avas = AVAS(
         selection_method="cumulative",
         subspace=["C(2p)", "O(2p)"],

--- a/tests/orbitals/test_iao.py
+++ b/tests/orbitals/test_iao.py
@@ -13,7 +13,7 @@ def test_iao_hcn():
     """
 
     system = System(xyz=xyz, basis_set="cc-pVTZ", auxiliary_basis_set="cc-pVTZ-JKFIT")
-    rhf = RHF(charge=0, econv=1e-12)(system)
+    rhf = RHF(charge=0, e_tol=1e-12)(system)
     rhf.run()
     C_occ = rhf.C[0][:, :7]
     iao = IAO(system, C_occ)
@@ -36,7 +36,7 @@ def test_iao_ch4():
     """
 
     system = System(xyz=xyz, basis_set="cc-pVTZ", auxiliary_basis_set="cc-pVTZ-JKFIT")
-    rhf = RHF(charge=0, econv=1e-12)(system)
+    rhf = RHF(charge=0, e_tol=1e-12)(system)
     rhf.run()
     C_occ = rhf.C[0][:, : rhf.ndocc]
     iao = IAO(system, C_occ)

--- a/tests/orbitals/test_ibo.py
+++ b/tests/orbitals/test_ibo.py
@@ -13,7 +13,7 @@ def test_ibo_water():
     """
 
     system = System(xyz=xyz, basis_set="cc-pVTZ", auxiliary_basis_set="cc-pVTZ-JKFIT")
-    rhf = RHF(charge=0, econv=1e-12)(system)
+    rhf = RHF(charge=0, e_tol=1e-12)(system)
     rhf.run()
     C_occ = rhf.C[0][:, : rhf.ndocc]
     ibo = IBO(system, C_occ)

--- a/tests/orbitals/test_ibo_slow.py
+++ b/tests/orbitals/test_ibo_slow.py
@@ -22,7 +22,7 @@ def test_ibo_acrylic_acid():
     """
 
     system = System(xyz=xyz, basis_set="cc-pVTZ", auxiliary_basis_set="cc-pVTZ-JKFIT")
-    rhf = RHF(charge=0, econv=1e-12)(system)
+    rhf = RHF(charge=0, e_tol=1e-12)(system)
     rhf.run()
     C_occ = rhf.C[0][:, : rhf.ndocc]
     ibo = IBO(system, C_occ)

--- a/tests/orbitals/test_semican.py
+++ b/tests/orbitals/test_semican.py
@@ -1,6 +1,16 @@
 import numpy as np
 
-from forte2 import System, RHF, CI, MOSpace, orbitals, State, MCOptimizer, integrals
+from forte2 import (
+    System,
+    RHF,
+    CI,
+    MOSpace,
+    orbitals,
+    State,
+    MCOptimizer,
+    integrals,
+    CISolver,
+)
 from forte2.helpers.comparisons import approx
 from forte2.orbitals import Semicanonicalizer
 from forte2.base_classes import DavidsonLiuParams
@@ -71,10 +81,13 @@ def test_semican_casscf():
     )
     rhf = RHF(charge=0, econv=1e-12)(system)
     rhf.run()
-    mc = MCOptimizer(
+    ci_solver = CISolver(
         State(nel=rhf.nel, multiplicity=1, ms=0.0),
         core_orbitals=[0, 1, 2, 3],
         active_orbitals=[4, 5, 6, 7, 8, 9],
+    )
+    mc = MCOptimizer(
+        ci_solver,
         final_orbital="semicanonical",
     )(rhf)
     mc.run()
@@ -82,11 +95,12 @@ def test_semican_casscf():
     assert eci_orig == approx(-109.0811491968)
 
     rhf.C[0] = mc.C[0].copy()
-    mc = MCOptimizer(
+    ci_solver = CISolver(
         State(nel=rhf.nel, multiplicity=1, ms=0.0),
         core_orbitals=[0, 1, 2, 3],
         active_orbitals=[4, 5, 6, 7, 8, 9],
-    )(rhf)
+    )
+    mc = MCOptimizer(ci_solver)(rhf)
     mc.run()
     assert mc.ci_solver.evals_flat[0] == approx(eci_orig)
 
@@ -153,11 +167,14 @@ def test_semican_orbitals():
     )
 
     rhf = RHF(charge=0, econv=1e-12)(system)
-    mc = MCOptimizer(
+    ci_solver = CISolver(
         State(nel=24, multiplicity=1, ms=0.0),
         core_orbitals=10,
         active_orbitals=4,
         davidson_liu_params=DavidsonLiuParams(e_tol=1e-12, r_tol=1e-10),
+    )
+    mc = MCOptimizer(
+        ci_solver,
         final_orbital="semicanonical",
     )(rhf)
     mc.run()

--- a/tests/orbitals/test_semican.py
+++ b/tests/orbitals/test_semican.py
@@ -26,7 +26,7 @@ def test_semican_rhf():
     system = System(
         xyz=xyz, basis_set="cc-pVDZ", auxiliary_basis_set="cc-pVTZ-JKFIT", unit="bohr"
     )
-    rhf = RHF(charge=0, econv=1e-12)(system)
+    rhf = RHF(charge=0, e_tol=1e-12)(system)
     rhf.run()
     mo_space = MOSpace(
         core_orbitals=[0, 1, 2, 3], active_orbitals=[4, 5, 6, 7, 8, 9], nmo=system.nmo
@@ -47,7 +47,7 @@ def test_semican_ci():
     system = System(
         xyz=xyz, basis_set="cc-pVDZ", auxiliary_basis_set="cc-pVTZ-JKFIT", unit="bohr"
     )
-    rhf = RHF(charge=0, econv=1e-12)(system)
+    rhf = RHF(charge=0, e_tol=1e-12)(system)
     rhf.run()
     ci = CI(
         State(nel=rhf.nel, multiplicity=1, ms=0.0),
@@ -79,7 +79,7 @@ def test_semican_casscf():
     system = System(
         xyz=xyz, basis_set="cc-pVDZ", auxiliary_basis_set="cc-pVTZ-JKFIT", unit="bohr"
     )
-    rhf = RHF(charge=0, econv=1e-12)(system)
+    rhf = RHF(charge=0, e_tol=1e-12)(system)
     rhf.run()
     ci_solver = CISolver(
         State(nel=rhf.nel, multiplicity=1, ms=0.0),
@@ -115,7 +115,7 @@ def test_semican_fock_offdiag():
     system = System(
         xyz=xyz, basis_set="cc-pVDZ", auxiliary_basis_set="cc-pVTZ-JKFIT", unit="bohr"
     )
-    rhf = RHF(charge=0, econv=1e-12)(system)
+    rhf = RHF(charge=0, e_tol=1e-12)(system)
     rhf.run()
     ci = CI(
         State(nel=rhf.nel, multiplicity=1, ms=0.0),
@@ -166,7 +166,7 @@ def test_semican_orbitals():
         auxiliary_basis_set="def2-universal-JKFIT",
     )
 
-    rhf = RHF(charge=0, econv=1e-12)(system)
+    rhf = RHF(charge=0, e_tol=1e-12)(system)
     ci_solver = CISolver(
         State(nel=24, multiplicity=1, ms=0.0),
         core_orbitals=10,

--- a/tests/props/test_mutcorr.py
+++ b/tests/props/test_mutcorr.py
@@ -14,7 +14,7 @@ def test_mutual_correlation_h2_singlet():
 
     system = System(xyz=xyz, basis_set="sto-6g", auxiliary_basis_set="cc-pVTZ-JKFIT")
 
-    rhf = RHF(charge=0, econv=1e-12)(system)
+    rhf = RHF(charge=0, e_tol=1e-12)(system)
     ci = CI(
         State(system=system, multiplicity=1, ms=0.0),
         active_orbitals=[0, 1],
@@ -42,7 +42,7 @@ def test_mutual_correlation_h2_triplet_lowspin():
 
     system = System(xyz=xyz, basis_set="sto-6g", auxiliary_basis_set="cc-pVTZ-JKFIT")
 
-    rhf = RHF(charge=0, econv=1e-12)(system)
+    rhf = RHF(charge=0, e_tol=1e-12)(system)
     ci = CI(
         State(system=system, multiplicity=3, ms=0.0),
         active_orbitals=[0, 1],
@@ -70,7 +70,7 @@ def test_mutual_correlation_h2_triplet_highspin():
 
     system = System(xyz=xyz, basis_set="sto-6g", auxiliary_basis_set="cc-pVTZ-JKFIT")
 
-    rhf = RHF(charge=0, econv=1e-12)(system)
+    rhf = RHF(charge=0, e_tol=1e-12)(system)
     ci = CI(
         State(system=system, multiplicity=3, ms=1.0),
         active_orbitals=[0, 1],
@@ -98,7 +98,7 @@ def test_mutual_correlation_h2_orbopt():
 
     system = System(xyz=xyz, basis_set="cc-pVDZ", auxiliary_basis_set="cc-pVTZ-JKFIT")
 
-    rhf = RHF(charge=0, econv=1e-12)(system)
+    rhf = RHF(charge=0, e_tol=1e-12)(system)
     ci = CI(
         State(system=system, multiplicity=1, ms=0.0),
         active_orbitals=list(range(10)),
@@ -130,7 +130,7 @@ def test_mutual_correlation_h6():
 
     system = System(xyz=xyz, basis_set="sto-3g", auxiliary_basis_set="cc-pVTZ-JKFIT")
 
-    rhf = RHF(charge=0, econv=1e-12)(system)
+    rhf = RHF(charge=0, e_tol=1e-12)(system)
     ci = CI(
         State(system=system, multiplicity=1, ms=0.0),
         active_orbitals=list(range(6)),

--- a/tests/scf/test_lindep.py
+++ b/tests/scf/test_lindep.py
@@ -22,7 +22,7 @@ def test_lindep_rhf():
     assert np.linalg.cond(ovlp) > 1e14
 
     # test diis with linear dependency as well with tight convergence
-    scf = RHF(charge=0, econv=1e-10, dconv=1e-8)(system)
+    scf = RHF(charge=0, e_tol=1e-10, d_tol=1e-8)(system)
     scf.run()
     assert scf.nbf == 90
     assert scf.nmo == 79
@@ -98,7 +98,7 @@ def test_lindep_x2c_quick():
     assert np.linalg.cond(ovlp) > 1e14
 
     # test diis with linear dependency as well with tight convergence
-    scf = GHF(charge=0, econv=1e-10, dconv=1e-8)(system)
+    scf = GHF(charge=0, e_tol=1e-10, d_tol=1e-8)(system)
     scf.run()
     assert scf.nbf == 90
     assert scf.nmo == 79

--- a/tests/scf/test_x2c1e.py
+++ b/tests/scf/test_x2c1e.py
@@ -70,7 +70,7 @@ def test_lindep_sfx2c1e():
         ortho_thresh=2e-7,
     )
 
-    scf = RHF(charge=0, econv=1e-10, dconv=1e-8)(system)
+    scf = RHF(charge=0, e_tol=1e-10, d_tol=1e-8)(system)
     scf.run()
     assert scf.E == approx(erhf)
     assert scf.nbf == 90

--- a/tests/sci/test_sci.py
+++ b/tests/sci/test_sci.py
@@ -304,12 +304,12 @@ def test_sci_make_rdms():
     ci.run()
 
     # Test the 1-RDM
-    sf_1rdm = sci.make_average_sf_1rdm()
+    sf_1rdm = sci.make_average_1rdm()
     sf_1rdm_ci = ci.make_average_1rdm()
     assert np.allclose(sf_1rdm, sf_1rdm_ci, atol=1e-8)
 
     # Test the 2-RDM
-    sf_2rdm = sci.make_average_sf_2rdm()
+    sf_2rdm = sci.make_average_2rdm()
     sf_2rdm_ci = ci.make_average_2rdm()
     assert np.allclose(sf_2rdm, sf_2rdm_ci, atol=1e-8)
 

--- a/tests/sci/test_sci.py
+++ b/tests/sci/test_sci.py
@@ -17,7 +17,7 @@ def _h4_rhf():
     H 0.0 0.0 3.0
     """
     system = System(xyz=xyz, basis_set="sto-6g", auxiliary_basis_set="cc-pVTZ-JKFIT")
-    return RHF(charge=0, econv=1e-14)(system)
+    return RHF(charge=0, e_tol=1e-14)(system)
 
 
 def test_sci1():
@@ -57,7 +57,7 @@ def test_sci2():
 
     system = System(xyz=xyz, basis_set="cc-pVDZ", auxiliary_basis_set="cc-pVTZ-JKFIT")
 
-    rhf = RHF(charge=0, econv=1e-10)(system)
+    rhf = RHF(charge=0, e_tol=1e-10)(system)
 
     sci = SelectedCI(
         states=State(nel=6, multiplicity=1, ms=0.0),
@@ -98,7 +98,7 @@ def test_sci3():
 
     system = System(xyz=xyz, basis_set="cc-pVDZ", auxiliary_basis_set="cc-pVTZ-JKFIT")
 
-    rhf = RHF(charge=0, econv=1e-10)(system)
+    rhf = RHF(charge=0, e_tol=1e-10)(system)
 
     sci = SelectedCI(
         states=State(nel=6, multiplicity=1, ms=0.0),
@@ -136,7 +136,7 @@ def test_sci4():
 
     system = System(xyz=xyz, basis_set="cc-pVDZ", auxiliary_basis_set="cc-pVTZ-JKFIT")
 
-    rhf = RHF(charge=0, econv=1e-10)(system)
+    rhf = RHF(charge=0, e_tol=1e-10)(system)
 
     sci = SelectedCI(
         states=State(nel=6, multiplicity=1, ms=0.0),
@@ -170,7 +170,7 @@ def test_sci5():
 
     system = System(xyz=xyz, basis_set="cc-pVDZ", cholesky_tei=True, cholesky_tol=1e-16)
 
-    rhf = RHF(charge=0, econv=1e-10)(system)
+    rhf = RHF(charge=0, e_tol=1e-10)(system)
 
     sci0 = SelectedCI(
         states=State(nel=10, multiplicity=1, ms=0.0),
@@ -218,7 +218,7 @@ def test_sci6():
 
     system = System(xyz=xyz, basis_set="cc-pVDZ", cholesky_tei=True, cholesky_tol=1e-16)
 
-    rhf = RHF(charge=0, econv=1e-10)(system)
+    rhf = RHF(charge=0, e_tol=1e-10)(system)
 
     sci = SelectedCI(
         states=State(nel=10, multiplicity=1, ms=0.0),
@@ -386,6 +386,92 @@ def test_sci_water_core_excited():
     ci.run()
 
     assert ci.E[0] == pytest.approx(-56.34437851987155, abs=1e-6)
+
+
+@pytest.mark.slow
+def test_sci_water_core_excited_with_gasscf_orbs():
+    """Test SelectedCI on a water core-excited state."""
+    # This should be converged to the following GASCI input
+    # from forte2 import CISolver, MCOptimizer, CI
+    # xyz = """
+    # O   0.0000000000  -0.0000000000  -0.0662628033
+    # H   0.0000000000  -0.7540256101   0.5259060578
+    # H  -0.0000000000   0.7530256101   0.5260060578
+    # """
+
+    # system = System(xyz=xyz, basis_set="6-31g", auxiliary_basis_set="cc-pVTZ-JKFIT")
+    # rhf = RHF(charge=0)(system)
+
+    # ci = CISolver(
+    #     states=State(nel=10, multiplicity=1, ms=0.0, gas_max=[1, 2], gas_min=[1, 2]),
+    #     active_orbitals=[[0], [1], list(range(2, 7))],
+    #     davidson_liu_params=DavidsonLiuParams(
+    #         e_tol=1e-10,
+    #         r_tol=1e-5,
+    #     ),
+    # )
+    # mc = MCOptimizer(ci)(rhf)
+    # mc.run()
+
+    # ci = CI(
+    #     states=State(nel=10, multiplicity=1, ms=0.0, gas_max=[1], gas_min=[1]),
+    #     active_orbitals=[[0], list(range(1, 13))],
+    #     davidson_liu_params=DavidsonLiuParams(
+    #         e_tol=1e-10,
+    #         r_tol=1e-5,
+    #     ),
+    # )(mc)
+    # ci.run()
+
+    from forte2 import CISolver, MCOptimizer
+
+    xyz = """
+    O   0.0000000000  -0.0000000000  -0.0662628033
+    H   0.0000000000  -0.7540256101   0.5259060578
+    H  -0.0000000000   0.7530256101   0.5260060578
+    """
+
+    system = System(xyz=xyz, basis_set="6-31g", auxiliary_basis_set="cc-pVTZ-JKFIT")
+    rhf = RHF(charge=0)(system)
+
+    # Small active space GASSCF to get good initial orbitals for sCI
+    ci = CISolver(
+        states=State(nel=10, multiplicity=1, ms=0.0, gas_max=[1, 2], gas_min=[1, 2]),
+        active_orbitals=[[0], [1], list(range(2, 7))],
+        davidson_liu_params=DavidsonLiuParams(
+            e_tol=1e-10,
+            r_tol=1e-5,
+        ),
+    )
+    mc = MCOptimizer(ci)(rhf)
+    mc.run()
+
+    guess_dets = ci.sub_solvers[0].ci_strings.make_determinants()
+
+    ci = SelectedCI(
+        states=State(nel=10, multiplicity=1, ms=0.0),
+        active_orbitals=list(range(13)),
+        sci_params=SelectedCIParams(
+            selection_algorithm="hbci",
+            var_threshold=1e-5,
+            pt2_threshold=1e-10,
+            guess_dets=guess_dets,
+            do_spin_penalty=True,
+            screening_criterion="hbci",
+            # do not allow the core orbital occupation to change from the guess determinants
+            frozen_annihilation=[0],
+            frozen_creation=[0],
+            num_threads=4,
+            num_batches_per_thread=16,
+        ),
+        davidson_liu_params=DavidsonLiuParams(
+            e_tol=1e-10,
+            r_tol=1e-5,
+        ),
+    )(mc)
+    ci.run()
+
+    assert ci.E[0] == pytest.approx(-56.3574249874, abs=1e-6)
 
 
 def test_sci_n2_multiple_roots():

--- a/tests/sparse/test_sparse_operator.py
+++ b/tests/sparse/test_sparse_operator.py
@@ -467,8 +467,8 @@ def test_sparse_operator_hamiltonian():
     )
 
     scf = forte2.scf.RHF(charge=0)(system)
-    scf.econv = 1e-10
-    scf.dconv = 1e-8
+    scf.e_tol = 1e-10
+    scf.d_tol = 1e-8
     scf.run()
     assert np.isclose(
         scf.E, erhf, atol=1e-10

--- a/tests/sparse/test_sparse_rdms.py
+++ b/tests/sparse/test_sparse_rdms.py
@@ -13,9 +13,10 @@ from forte2 import (
     cpp_helpers,
 )
 from forte2.helpers.comparisons import approx
+from forte2.base_classes import DavidsonLiuParams
 
 
-def test_ci_tdm():
+def test_ci_tdm_same_solver():
     xyz = """
     N 0.0 0.0 -1.0
     N 0.0 0.0 1.0
@@ -64,3 +65,42 @@ def test_ci_tdm():
             assert np.allclose(tdm2_aa, tdm2_aa_ref)
             assert np.allclose(tdm2_ab, tdm2_ab_ref)
             assert np.allclose(tdm2_bb, tdm2_bb_ref)
+
+
+def test_gasci_tdm():
+    xyz = """
+    O  0.000000000000  0.000000000000 -0.069592187400
+    H  0.000000000000 -0.783151105291  0.552239257834
+    H  0.000000000000  0.783151105291  0.552239257834
+    """
+
+    system = System(
+        xyz=xyz, basis_set="cc-pvdz", auxiliary_basis_set="def2-universal-jkfit"
+    )
+
+    rhf = RHF(charge=0, econv=1e-12, dconv=1e-8)(system)
+    ci = CI(
+        active_orbitals=[[0], [2, 3, 4, 5, 6]],
+        states=[
+            State(nel=10, multiplicity=1, ms=0.0, gas_min=[1], gas_max=[1]),
+            State(nel=10, multiplicity=1, ms=0.0, gas_min=[2], gas_max=[2]),
+        ],
+        nroots=[1, 1],
+    )(rhf)
+    ci.run()
+
+    left_solver = ci.sub_solvers[0]
+    right_solver = ci.sub_solvers[1]
+    left_sb = left_solver.ci_sigma_builder
+    right_sb = right_solver.ci_sigma_builder
+
+    C_left = left_solver.csf_C_to_det_C(left_solver.evecs[:, 0])
+    C_right = right_solver.csf_C_to_det_C(right_solver.evecs[:, 0])
+
+    state_left = left_solver.ci_sigma_builder.make_sparse_state(C_left)
+    state_right = right_solver.ci_sigma_builder.make_sparse_state(C_right)
+
+    a_1trdm = left_sb.a_1trdm(right_sb, C_left, C_right)
+    a_1trdm_ref = compute_a_1rdm(state_left, state_right, 6)
+
+    assert np.allclose(a_1trdm, a_1trdm_ref)

--- a/tests/sparse/test_sparse_rdms.py
+++ b/tests/sparse/test_sparse_rdms.py
@@ -24,7 +24,7 @@ def test_ci_tdm_same_solver():
     system = System(
         xyz=xyz, basis_set="cc-pVDZ", auxiliary_basis_set="cc-pVTZ-JKFIT", unit="bohr"
     )
-    rhf = RHF(charge=0, econv=1e-12)(system)
+    rhf = RHF(charge=0, e_tol=1e-12)(system)
     ci = CI(
         State(nel=14, multiplicity=1, ms=0.0),
         core_orbitals=[0, 1, 2, 3],
@@ -78,7 +78,7 @@ def test_gasci_tdm_different_solvers():
         xyz=xyz, basis_set="cc-pvdz", auxiliary_basis_set="def2-universal-jkfit"
     )
 
-    rhf = RHF(charge=0, econv=1e-12, dconv=1e-8)(system)
+    rhf = RHF(charge=0, e_tol=1e-12, d_tol=1e-8)(system)
     ci = CI(
         active_orbitals=[[0], [2, 3, 4, 5, 6]],
         states=[

--- a/tests/sparse/test_sparse_rdms.py
+++ b/tests/sparse/test_sparse_rdms.py
@@ -102,5 +102,4 @@ def test_gasci_tdm():
 
     a_1trdm = left_sb.a_1trdm(right_sb, C_left, C_right)
     a_1trdm_ref = compute_a_1rdm(state_left, state_right, 6)
-
     assert np.allclose(a_1trdm, a_1trdm_ref)

--- a/tests/sparse/test_sparse_rdms.py
+++ b/tests/sparse/test_sparse_rdms.py
@@ -13,6 +13,7 @@ from forte2 import (
     cpp_helpers,
 )
 from forte2.base_classes import DavidsonLiuParams
+from forte2.helpers.comparisons import approx
 
 
 def test_ci_tdm_same_solver():
@@ -80,6 +81,7 @@ def test_gasci_tdm_different_solvers():
 
     rhf = RHF(charge=0, e_tol=1e-12, d_tol=1e-8)(system)
     ci = CI(
+        core_orbitals=[1],
         active_orbitals=[[0], [2, 3, 4, 5, 6]],
         states=[
             State(nel=10, multiplicity=1, ms=0.0, gas_min=[1], gas_max=[1]),
@@ -102,7 +104,7 @@ def test_gasci_tdm_different_solvers():
     state_right = right_sb.make_sparse_state(C_right)
 
     a_1trdm, b_1trdm = ci.make_sd_1rdm(0, 1)
-    sf_1trdm = ci.make_sf_1rdm(0, 1)
+    sf_1trdm = ci.make_1rdm(0, 1)
     a_1trdm_ref = compute_a_1rdm(state_left, state_right, 6)
     b_1trdm_ref = compute_b_1rdm(state_left, state_right, 6)
     assert np.allclose(a_1trdm, a_1trdm_ref)
@@ -110,6 +112,7 @@ def test_gasci_tdm_different_solvers():
     assert np.allclose(sf_1trdm, a_1trdm_ref + b_1trdm_ref)
 
     a_1trdm, b_1trdm = ci.make_sd_1rdm(1, 0)
+    # make_sf_1rdm and make_1rdm are synonymous
     sf_1trdm = ci.make_sf_1rdm(1, 0)
     a_1trdm_ref = compute_a_1rdm(state_right, state_left, 6)
     b_1trdm_ref = compute_b_1rdm(state_right, state_left, 6)

--- a/tests/sparse/test_sparse_rdms.py
+++ b/tests/sparse/test_sparse_rdms.py
@@ -1,0 +1,66 @@
+import numpy as np
+
+from forte2 import (
+    System,
+    RHF,
+    CI,
+    State,
+    compute_a_1rdm,
+    compute_b_1rdm,
+    compute_aa_2rdm,
+    compute_ab_2rdm,
+    compute_bb_2rdm,
+    cpp_helpers,
+)
+from forte2.helpers.comparisons import approx
+
+
+def test_ci_tdm():
+    xyz = """
+    N 0.0 0.0 -1.0
+    N 0.0 0.0 1.0
+    """
+
+    system = System(
+        xyz=xyz, basis_set="cc-pVDZ", auxiliary_basis_set="cc-pVTZ-JKFIT", unit="bohr"
+    )
+    rhf = RHF(charge=0, econv=1e-12)(system)
+    ci = CI(
+        State(nel=14, multiplicity=1, ms=0.0),
+        core_orbitals=[0, 1, 2, 3],
+        active_orbitals=[4, 5, 6, 7, 8, 9],
+        nroots=3,
+    )(rhf)
+    ci.run()
+
+    for root_left in range(3):
+        for root_right in range(3):
+            c_l = ci.sub_solvers[0].csf_C_to_det_C(
+                ci.sub_solvers[0].evecs[:, root_left]
+            )
+            state_left = ci.sub_solvers[0].ci_sigma_builder.make_sparse_state(c_l)
+
+            c_r = ci.sub_solvers[0].csf_C_to_det_C(
+                ci.sub_solvers[0].evecs[:, root_right]
+            )
+            state_right = ci.sub_solvers[0].ci_sigma_builder.make_sparse_state(c_r)
+
+            tdm1_a_ref = compute_a_1rdm(state_left, state_right, 6)
+            tdm1_b_ref = compute_b_1rdm(state_left, state_right, 6)
+
+            tdm1_a, tdm1_b = ci.sub_solvers[0].make_sd_1rdm(root_left, root_right)
+            assert np.allclose(tdm1_a, tdm1_a_ref)
+            assert np.allclose(tdm1_b, tdm1_b_ref)
+
+            tdm2_aa_ref = compute_aa_2rdm(state_left, state_right, 6)
+            tdm2_ab_ref = compute_ab_2rdm(state_left, state_right, 6)
+            tdm2_bb_ref = compute_bb_2rdm(state_left, state_right, 6)
+
+            tdm2_aa, tdm2_ab, tdm2_bb = ci.sub_solvers[0].make_sd_2rdm(
+                root_left, root_right
+            )
+            tdm2_aa = cpp_helpers.packed_tensor4_to_tensor4(tdm2_aa)
+            tdm2_bb = cpp_helpers.packed_tensor4_to_tensor4(tdm2_bb)
+            assert np.allclose(tdm2_aa, tdm2_aa_ref)
+            assert np.allclose(tdm2_ab, tdm2_ab_ref)
+            assert np.allclose(tdm2_bb, tdm2_bb_ref)

--- a/tests/sparse/test_sparse_rdms.py
+++ b/tests/sparse/test_sparse_rdms.py
@@ -12,7 +12,6 @@ from forte2 import (
     compute_bb_2rdm,
     cpp_helpers,
 )
-from forte2.helpers.comparisons import approx
 from forte2.base_classes import DavidsonLiuParams
 
 
@@ -68,7 +67,7 @@ def test_ci_tdm_same_solver():
             assert np.allclose(tdm2_bb, tdm2_bb_ref)
 
 
-def test_gasci_tdm():
+def test_gasci_tdm_different_solvers():
     xyz = """
     O  0.000000000000  0.000000000000 -0.069592187400
     H  0.000000000000 -0.783151105291  0.552239257834
@@ -103,13 +102,17 @@ def test_gasci_tdm():
     state_right = right_sb.make_sparse_state(C_right)
 
     a_1trdm, b_1trdm = ci.make_sd_1rdm(0, 1)
+    sf_1trdm = ci.make_sf_1rdm(0, 1)
     a_1trdm_ref = compute_a_1rdm(state_left, state_right, 6)
     b_1trdm_ref = compute_b_1rdm(state_left, state_right, 6)
     assert np.allclose(a_1trdm, a_1trdm_ref)
     assert np.allclose(b_1trdm, b_1trdm_ref)
+    assert np.allclose(sf_1trdm, a_1trdm_ref + b_1trdm_ref)
 
     a_1trdm, b_1trdm = ci.make_sd_1rdm(1, 0)
+    sf_1trdm = ci.make_sf_1rdm(1, 0)
     a_1trdm_ref = compute_a_1rdm(state_right, state_left, 6)
     b_1trdm_ref = compute_b_1rdm(state_right, state_left, 6)
     assert np.allclose(a_1trdm, a_1trdm_ref)
     assert np.allclose(b_1trdm, b_1trdm_ref)
+    assert np.allclose(sf_1trdm, a_1trdm_ref + b_1trdm_ref)

--- a/tests/sparse/test_sparse_rdms.py
+++ b/tests/sparse/test_sparse_rdms.py
@@ -31,6 +31,7 @@ def test_ci_tdm_same_solver():
         core_orbitals=[0, 1, 2, 3],
         active_orbitals=[4, 5, 6, 7, 8, 9],
         nroots=3,
+        davidson_liu_params=DavidsonLiuParams(e_tol=1e-10, r_tol=1e-5),
     )(rhf)
     ci.run()
 
@@ -86,6 +87,7 @@ def test_gasci_tdm():
             State(nel=10, multiplicity=1, ms=0.0, gas_min=[2], gas_max=[2]),
         ],
         nroots=[1, 1],
+        davidson_liu_params=DavidsonLiuParams(e_tol=1e-10, r_tol=1e-5),
     )(rhf)
     ci.run()
 
@@ -97,9 +99,17 @@ def test_gasci_tdm():
     C_left = left_solver.csf_C_to_det_C(left_solver.evecs[:, 0])
     C_right = right_solver.csf_C_to_det_C(right_solver.evecs[:, 0])
 
-    state_left = left_solver.ci_sigma_builder.make_sparse_state(C_left)
-    state_right = right_solver.ci_sigma_builder.make_sparse_state(C_right)
+    state_left = left_sb.make_sparse_state(C_left)
+    state_right = right_sb.make_sparse_state(C_right)
 
-    a_1trdm = left_sb.a_1trdm(right_sb, C_left, C_right)
+    a_1trdm, b_1trdm = ci.make_sd_1rdm(0, 1)
     a_1trdm_ref = compute_a_1rdm(state_left, state_right, 6)
+    b_1trdm_ref = compute_b_1rdm(state_left, state_right, 6)
     assert np.allclose(a_1trdm, a_1trdm_ref)
+    assert np.allclose(b_1trdm, b_1trdm_ref)
+
+    a_1trdm, b_1trdm = ci.make_sd_1rdm(1, 0)
+    a_1trdm_ref = compute_a_1rdm(state_right, state_left, 6)
+    b_1trdm_ref = compute_b_1rdm(state_right, state_left, 6)
+    assert np.allclose(a_1trdm, a_1trdm_ref)
+    assert np.allclose(b_1trdm, b_1trdm_ref)


### PR DESCRIPTION
Adds 1-body transition reduced density matrices (RDMs). The main changes are grouped below:

### New sparse RDM computation API

* Added a new module `api/sparse_rdms_api.cc` that exposes functions to compute 1-, 2-, 3-, and 4-electron RDMs (and all spin cases) between two `SparseState` objects, and integrated it into the build and Python interface (`CMakeLists.txt`, `forte2_api.cc`, `__init__.pyi`).

### CI sigma builder API enhancements

* Added methods to `CISigmaBuilder` for constructing a sparse state from a CI vector and for computing alpha, beta, and spin-free one-electron transition RDMs between CI vectors, with corresponding Python bindings and type hints.

### CI code refactoring and simplification

* Introduced a helper method `csf_C_to_det_C` to convert CI vectors from the CSF basis to the determinant basis, and refactored all relevant CI routines to use this helper instead of duplicating conversion logic. This affects all routines that build RDMs and cumulants from CI roots.

### Build system updates

* Registered new source files (`api/sparse_rdms_api.cc`, `ci/ci_sigma_builder_1trdm.cc`) in the build system to enable the new features.

These changes collectively expand the capabilities for RDM computations in the codebase and make the CI code more maintainable and easier to extend.