### PR TITLE
fix: Lack of nonredundant MCSCF parameters

### DIFF
--- a/forte2/dsrg/dsrg_base.py
+++ b/forte2/dsrg/dsrg_base.py
@@ -192,10 +192,12 @@ class DSRGBase(SystemMixin, MOsMixin, MOSpaceMixin, ABC):
                 )
             self.E = self.E_dsrg
         else:
-            logger.log_warning(
-                f"DSRG reference relaxation did not converge in {self.nrelax} iterations."
-            )
-        logger.log_info1("=" * width)
+            if self.nrelax > 0:
+                logger.log_warning(
+                    f"DSRG reference relaxation did not converge in {self.nrelax} iterations."
+                )
+        if self.nrelax > 0:
+            logger.log_info1("=" * width)
         logger.log_info1("\nFinal DSRG energies (a.u.):")
         logger.log_info1(f"  E0       : {self.ints['E'].real:.12f}")
         logger.log_info1(f"  Edsrg    : {self.E_dsrg.real:.12f}")

--- a/forte2/mcopt/mc_optimizer.py
+++ b/forte2/mcopt/mc_optimizer.py
@@ -227,16 +227,16 @@ class MCOptimizerBase(ABC, SystemMixin, MOsMixin, MOSpaceMixin):
         )
         logger.log_info1("-" * width)
 
-        # E_ci: list[float], CI eigenvalues
-        # E_avg: float, ensemble average energy
-        # E_orb: float, energy after orbital optimization
+        # CI eigenvalues
         self.E_ci = np.array(self.ci_solver.E)
-        self.E_avg = self.ci_solver.compute_average_energy()
-        self.E = self.E_avg
         self.E_ci_old = self.E_ci.copy()
+        # Ensemble average energy
+        self.E_avg = self.ci_solver.compute_average_energy()
+        self.E_avg_old = self.E_avg        
+        self.E = self.E_avg
+        # Energy after orbital optimization
         self.E_orb = self.E_avg
         self.E_orb_old = self.E_orb
-        self.E_avg_old = self.E_avg
 
         self.g1_act = self.make_average_1rdm()
         g2_act = self.make_average_2rdm()

--- a/forte2/mcopt/mc_optimizer.py
+++ b/forte2/mcopt/mc_optimizer.py
@@ -248,13 +248,15 @@ class MCOptimizerBase(ABC, SystemMixin, MOsMixin, MOSpaceMixin):
         self.E_orb = self.E_avg
         self.E_orb_old = self.E_orb
 
+        skip_macro_iter = (self.orb_opt.nrot == 0)
+
         self.g_old = np.zeros(self.orb_opt.nrot, dtype=self.dtype)
 
         # This holds the *overall* orbital rotation, C_current = C_0 @ exp(R)
         # It's used as the initial guess at the start of each orbital optimization
         R = np.zeros(self.orb_opt.nrot, dtype=self.dtype)
 
-        while self.iter < self.maxiter:
+        while self.iter < self.maxiter and not skip_macro_iter:
             # 1. Optimize orbitals at fixed CI expansion
             self.E_orb = self.lbfgs_solver.minimize(self.orb_opt, R)
             self._C = self.orb_opt.C.copy()
@@ -292,7 +294,7 @@ class MCOptimizerBase(ABC, SystemMixin, MOsMixin, MOSpaceMixin):
             g2_act = self.make_average_2rdm()
             self.orb_opt.set_rdms(self.g1_act, g2_act)
             self.iter += 1
-        else:
+        if self.iter >= self.maxiter and not conv:
             logger.log_info1("=" * width)
             if self.die_if_not_converged:
                 raise RuntimeError(

--- a/forte2/mcopt/mc_optimizer.py
+++ b/forte2/mcopt/mc_optimizer.py
@@ -227,12 +227,14 @@ class MCOptimizerBase(ABC, SystemMixin, MOsMixin, MOSpaceMixin):
         )
         logger.log_info1("-" * width)
 
-        # E_ci: list[float],CI eigenvalues,
-        # E_avg: float, ensemble average energy,
+        # E_ci: list[float], CI eigenvalues
+        # E_avg: float, ensemble average energy
         # E_orb: float, energy after orbital optimization
         self.E_ci = np.array(self.ci_solver.E)
+        self.E_avg = self.ci_solver.compute_average_energy()
+        self.E = self.E_avg
         self.E_ci_old = self.E_ci.copy()
-        self.E_avg = self.E_orb = self.ci_solver.compute_average_energy()
+        self.E_orb = self.E_avg
         self.E_orb_old = self.E_orb
         self.E_avg_old = self.E_avg
 
@@ -248,62 +250,71 @@ class MCOptimizerBase(ABC, SystemMixin, MOsMixin, MOSpaceMixin):
         self.E_orb = self.E_avg
         self.E_orb_old = self.E_orb
 
-        skip_macro_iter = (self.orb_opt.nrot == 0)
-
         self.g_old = np.zeros(self.orb_opt.nrot, dtype=self.dtype)
 
         # This holds the *overall* orbital rotation, C_current = C_0 @ exp(R)
         # It's used as the initial guess at the start of each orbital optimization
         R = np.zeros(self.orb_opt.nrot, dtype=self.dtype)
 
-        while self.iter < self.maxiter and not skip_macro_iter:
-            # 1. Optimize orbitals at fixed CI expansion
-            self.E_orb = self.lbfgs_solver.minimize(self.orb_opt, R)
-            self._C = self.orb_opt.C.copy()
-            # 2. Convergence checks
-            _dg = self.lbfgs_solver.g - self.g_old
-            self.dg_rms = np.sqrt(np.mean((_dg.conj() * _dg).real))
-            self.g_rms = np.sqrt(
-                np.mean((self.lbfgs_solver.g.conj() * self.lbfgs_solver.g).real)
+        if self.orb_opt.nrot == 0:
+            logger.log_info1(
+                "No nonredundant orbital rotations; skipping macroiterations."
             )
-            self.g_old = self.lbfgs_solver.g.copy()
-            conv, conv_str = self._check_convergence()
-            lbfgs_str = f"{self.lbfgs_solver.iter}/{'Y' if self.lbfgs_solver.converged else 'N'}"
-            iter_info = (
-                f"{self.iter:>10d} {self.E_avg.real:>20.10f} {self.E_orb.real:>20.10f} "
-            )
-            iter_info += f"{self.delta_ci_avg.real:>12.4e} {self.max_ci_de:>12.4e} {self.g_rms.real:>12.4e} {lbfgs_str:>8} {conv_str:>8}"
-            if conv:
+            self.converged = True
+        else:
+            conv = False
+            while self.iter < self.maxiter:
+                # 1. Optimize orbitals at fixed CI expansion
+                self.E_orb = self.lbfgs_solver.minimize(self.orb_opt, R)
+                self._C = self.orb_opt.C.copy()
+                # 2. Convergence checks
+                _dg = self.lbfgs_solver.g - self.g_old
+                self.dg_rms = np.sqrt(np.mean((_dg.conj() * _dg).real))
+                self.g_rms = np.sqrt(
+                    np.mean((self.lbfgs_solver.g.conj() * self.lbfgs_solver.g).real)
+                )
+                self.g_old = self.lbfgs_solver.g.copy()
+                conv, conv_str = self._check_convergence()
+                lbfgs_str = (
+                    f"{self.lbfgs_solver.iter}/"
+                    f"{'Y' if self.lbfgs_solver.converged else 'N'}"
+                )
+                iter_info = (
+                    f"{self.iter:>10d} {self.E_avg.real:>20.10f} "
+                    f"{self.E_orb.real:>20.10f} "
+                )
+                iter_info += f"{self.delta_ci_avg.real:>12.4e} {self.max_ci_de:>12.4e} {self.g_rms.real:>12.4e} {lbfgs_str:>8} {conv_str:>8}"
+                if conv:
+                    logger.log_info1(iter_info)
+                    self.converged = True
+                    break
+
                 logger.log_info1(iter_info)
-                self.converged = True
-                break
 
-            logger.log_info1(iter_info)
-
-            # 3. Optimize CI expansion at fixed orbitals
-            self.ci_solver.set_ints(
-                self.orb_opt.Ecore + self.system.nuclear_repulsion,
-                self.orb_opt.Fcore[self.actv, self.actv],
-                self.orb_opt.get_active_space_ints(),
-            )
-            self.ci_solver.run()
-            self.E_avg = self.ci_solver.compute_average_energy()
-            self.E_ci = np.array(self.ci_solver.E)
-            self.E = self.E_avg
-            self.g1_act = self.make_average_1rdm()
-            g2_act = self.make_average_2rdm()
-            self.orb_opt.set_rdms(self.g1_act, g2_act)
-            self.iter += 1
-        if self.iter >= self.maxiter and not conv:
-            logger.log_info1("=" * width)
-            if self.die_if_not_converged:
-                raise RuntimeError(
-                    f"Orbital optimization did not converge in {self.maxiter} iterations."
+                # 3. Optimize CI expansion at fixed orbitals
+                self.ci_solver.set_ints(
+                    self.orb_opt.Ecore + self.system.nuclear_repulsion,
+                    self.orb_opt.Fcore[self.actv, self.actv],
+                    self.orb_opt.get_active_space_ints(),
                 )
-            else:
-                logger.log_warning(
-                    f"Orbital optimization did not converge in {self.maxiter} iterations."
-                )
+                self.ci_solver.run()
+                self.E_ci = np.array(self.ci_solver.E)
+                self.E_avg = self.ci_solver.compute_average_energy()
+                self.E = self.E_avg
+                self.g1_act = self.make_average_1rdm()
+                g2_act = self.make_average_2rdm()
+                self.orb_opt.set_rdms(self.g1_act, g2_act)
+                self.iter += 1
+            if self.iter >= self.maxiter and not conv:
+                logger.log_info1("=" * width)
+                if self.die_if_not_converged:
+                    raise RuntimeError(
+                        f"Orbital optimization did not converge in {self.maxiter} iterations."
+                    )
+                else:
+                    logger.log_warning(
+                        f"Orbital optimization did not converge in {self.maxiter} iterations."
+                    )
         # self.ci_solver.set_maxiter(ci_maxiter_save)
         self.ci_solver.set_ints(
             self.orb_opt.Ecore + self.system.nuclear_repulsion,
@@ -314,6 +325,7 @@ class MCOptimizerBase(ABC, SystemMixin, MOsMixin, MOSpaceMixin):
         self.ci_solver.run()
         self.E_ci = np.array(self.ci_solver.E)
         self.E_avg = self.ci_solver.compute_average_energy()
+        self.E = self.E_avg
         logger.log_info1(
             f"{'Final CI':>10} {self.E_avg:>20.10f} {self.E_orb:>20.10f} {'-':>12} {'-':>12} {'-':>12} {'-':>8} {'':>8}"
         )

--- a/forte2/mcopt/mc_optimizer.py
+++ b/forte2/mcopt/mc_optimizer.py
@@ -232,7 +232,7 @@ class MCOptimizerBase(ABC, SystemMixin, MOsMixin, MOSpaceMixin):
         self.E_ci_old = self.E_ci.copy()
         # Ensemble average energy
         self.E_avg = self.ci_solver.compute_average_energy()
-        self.E_avg_old = self.E_avg        
+        self.E_avg_old = self.E_avg
         self.E = self.E_avg
         # Energy after orbital optimization
         self.E_orb = self.E_avg

--- a/tests/dsrg/test_dsrg_mrpt2.py
+++ b/tests/dsrg/test_dsrg_mrpt2.py
@@ -79,3 +79,22 @@ def test_sf_mrpt2_o2_triplet():
     assert dsrg.relax_energies[1, 0] == approx(-149.96533377181)
     assert dsrg.relax_energies[1, 1] == approx(-149.965334494277)
     assert dsrg.relax_energies[1, 2] == approx(-149.70550603407)
+
+
+def test_mrpt2_all_active():
+    xyz = f"""
+    H 0.0 0.0 0.0
+    H 0.0 0.0 {0.529177210903 * 2}
+    """
+
+    system = System(xyz=xyz, basis_set="sto-6g", auxiliary_basis_set="cc-pVTZ-JKFIT")
+
+    rhf = RHF(charge=0, e_tol=1e-12)(system)
+    ci_solver = CISolver(State(nel=2, multiplicity=1, ms=0.0), active_orbitals=2)
+    mc = MCOptimizer(
+        ci_solver,
+        maxiter=5,
+    )(rhf)
+    pt = DSRG_MRPT2(flow_param=0.5)(mc)
+    pt.run()
+    assert pt.E_dsrg == approx(-1.096071975854)

--- a/tests/dsrg/test_rel_dsrg_mrpt2.py
+++ b/tests/dsrg/test_rel_dsrg_mrpt2.py
@@ -316,3 +316,22 @@ def test_mrpt2_sh_with_slow():
     assert dsrg.relax_eigvals == approx(dsrg_slow.relax_eigvals)
     assert dsrg.relax_eigvals_history == approx(dsrg_slow.relax_eigvals_history)
     assert dsrg.E_dsrg == approx(dsrg_slow.E_dsrg)
+
+
+def test_rel_mrpt2_all_active():
+    xyz = f"""
+    H 0.0 0.0 0.0
+    H 0.0 0.0 {0.529177210903 * 2}
+    """
+
+    system = System(xyz=xyz, basis_set="sto-6g", auxiliary_basis_set="cc-pVTZ-JKFIT")
+
+    rhf = GHF(charge=0, e_tol=1e-12)(system)
+    ci_solver = RelCISolver(nel=2, active_orbitals=4)
+    mc = MCOptimizer(
+        ci_solver,
+        maxiter=5,
+    )(rhf)
+    pt = RelDSRG_MRPT2(flow_param=0.5)(mc)
+    pt.run()
+    assert pt.E_dsrg == approx(-1.096071975854)

--- a/tests/mcopt/test_casscf_simple.py
+++ b/tests/mcopt/test_casscf_simple.py
@@ -22,6 +22,57 @@ def test_casscf_h2():
     assert mc.E == approx(emcscf)
 
 
+def test_casscf_h2_all_active_orbitals_frozen():
+    xyz = f"""
+    H 0.0 0.0 0.0
+    H 0.0 0.0 {0.529177210903 * 2}
+    """
+
+    system = System(xyz=xyz, basis_set="cc-pvdz", auxiliary_basis_set="cc-pVTZ-JKFIT")
+
+    rhf = RHF(charge=0, e_tol=1e-12)(system)
+    ci_solver = CISolver(State(nel=2, multiplicity=1, ms=0.0), active_orbitals=[0, 1])
+    mc = MCOptimizer(
+        ci_solver,
+        active_frozen_orbitals=[0, 1],
+        maxiter=0,
+        final_orbital="original",
+    )(rhf)
+    mc.run()
+
+    assert mc.orb_opt.nrot == 0
+    assert mc.iter == 0
+    assert mc.converged
+    assert mc.E == approx(mc.E_ci[0])
+
+
+def test_casscf_h2_all_orbitals_active_positive_maxiter():
+    xyz = f"""
+    H 0.0 0.0 0.0
+    H 0.0 0.0 {0.529177210903 * 2}
+    """
+
+    system = System(xyz=xyz, basis_set="sto-6g", auxiliary_basis_set="cc-pVTZ-JKFIT")
+
+    rhf = RHF(charge=0, e_tol=1e-12)(system)
+    ci_solver = CISolver(State(nel=2, multiplicity=1, ms=0.0), active_orbitals=2)
+    mc = MCOptimizer(
+        ci_solver,
+        maxiter=5,
+        final_orbital="original",
+    )(rhf)
+    mc.run()
+
+    assert mc.maxiter != 0
+    assert mc.mo_space.nactv == mc.mo_space.nmo
+    assert mc.mo_space.ncore == 0
+    assert mc.mo_space.nvirt == 0
+    assert mc.orb_opt.nrot == 0
+    assert mc.iter == 0
+    assert mc.converged
+    assert mc.E == approx(-1.096071975854)
+
+
 def test_casscf_n2():
     erhf = -108.761639873604
     ecasscf = -108.9800484156


### PR DESCRIPTION
Handles the cases where there are no orbital rotations to optimize. The main update ensures that the macro-iteration loop is skipped if `nrot == 0`, preventing unnecessary iterations when no orbital optimization is required. Additionally, the convergence check at the end of the loop is clarified.