### PR TITLE
fix: more informative error for linearly dependent (P|Q)

### DIFF
--- a/forte2/jkbuilder/jkbuilder.py
+++ b/forte2/jkbuilder/jkbuilder.py
@@ -139,10 +139,8 @@ class FockBuilder:
             try:
                 L = sp.linalg.cholesky(M, lower=True)
             except sp.linalg.LinAlgError:
-                cond = np.linalg.cond(M)
                 raise ValueError(
-                    f"Density fitting Coulomb metric (P|Q) is not positive definite.\n"
-                    f"Condition number of (P|Q): {cond}\n"
+                    "Density fitting Coulomb metric (P|Q) is not positive definite.\n"
                     "Please set df_ortho_rtol to a small positive value to orthogonalize the metric."
                 )
             # M^{-1/2} = L^{-T} L^{-1}, so L^{-1} can be considered as M^{-1/2}
@@ -669,7 +667,13 @@ class FockBuilderOTF:
             self.sevecs = sevecs[:, ndiscard:]
         else:
             # M = L L.T
-            self.L = sp.linalg.cholesky(M, lower=True)
+            try:
+                self.L = sp.linalg.cholesky(M, lower=True)
+            except sp.linalg.LinAlgError:
+                raise ValueError(
+                    "Density fitting Coulomb metric (P|Q) is not positive definite.\n"
+                    "Please set df_ortho_rtol to a small positive value to orthogonalize the metric."
+                )
             I = np.eye(M.shape[0])
             self.Mm12 = sp.linalg.solve_triangular(self.L, I, lower=True)
 

--- a/forte2/jkbuilder/jkbuilder.py
+++ b/forte2/jkbuilder/jkbuilder.py
@@ -136,7 +136,15 @@ class FockBuilder:
             print_metric_info(info, "Density fitting Coulomb metric (P|Q)")
         else:
             # M = L L^T
-            L = sp.linalg.cholesky(M, lower=True)
+            try:
+                L = sp.linalg.cholesky(M, lower=True)
+            except sp.linalg.LinAlgError:
+                cond = np.linalg.cond(M)
+                raise ValueError(
+                    f"Density fitting Coulomb metric (P|Q) is not positive definite.\n"
+                    f"Condition number of (P|Q): {cond}\n"
+                    "Please set df_ortho_rtol to a small positive value to orthogonalize the metric."
+                )
             # M^{-1/2} = L^{-T} L^{-1}, so L^{-1} can be considered as M^{-1/2}
             X = sp.linalg.solve_triangular(L, np.eye(naux), lower=True)
 
@@ -592,7 +600,10 @@ class FockBuilderOTF:
             math.ceil(self.jk_mem_thres_mb * 1024**2 / total_bytes_per_iblk),
         )
         maxpblksize = math.floor(
-            (self.jk_mem_thres_mb * 1024**2 - nbuf_vt * nbytes * self.nbf * self.naux * self.iblksize)
+            (
+                self.jk_mem_thres_mb * 1024**2
+                - nbuf_vt * nbytes * self.nbf * self.naux * self.iblksize
+            )
             / (8 * self.nbf**2)
         )
         self.pblksize = min(self.naux, maxpblksize)

--- a/tests/jkbuilder/test_jkbuilder.py
+++ b/tests/jkbuilder/test_jkbuilder.py
@@ -292,3 +292,26 @@ def test_jkbuilder_on_the_fly_large():
     J_otf, K_otf = fb_otf.build_JK([Cocc])
     assert np.linalg.norm(J_otf[0] - J_ref[0]) < 1e-8
     assert np.linalg.norm(K_otf[0] - K_ref[0]) < 1e-8
+
+
+def test_jkbuilder_lindep_metric():
+    xyz = """
+    H 0.0 0.0 0.0
+    H 0.0 0.0 1.0
+    """
+
+    system = System(
+        xyz=xyz,
+        basis_set="cc-pvdz",
+        auxiliary_basis_set="cc-pvtz-jkfit",
+        unit="bohr",
+    )
+    import forte2
+
+    fakeaux = forte2.ints.Basis()
+    # center 1: 1 + 3 = 4 basis functions, range (0, 4)
+    fakeaux.add(forte2.ints.Shell(0, [1.0], [1.0], [0.0, 0.0, 0.0]))
+    fakeaux.add(forte2.ints.Shell(0, [1.0], [1.0], [0.0, 0.0, 0.0]))
+    system.auxiliary_basis = fakeaux
+    with pytest.raises(ValueError, match="positive definite"):
+        system.fock_builder.B_Pmn

--- a/tests/jkbuilder/test_jkbuilder.py
+++ b/tests/jkbuilder/test_jkbuilder.py
@@ -309,9 +309,14 @@ def test_jkbuilder_lindep_metric():
     import forte2
 
     fakeaux = forte2.ints.Basis()
-    # center 1: 1 + 3 = 4 basis functions, range (0, 4)
+    # two identical auxiliary functions, this forces the Coulomb metric to be linearly dependent
     fakeaux.add(forte2.ints.Shell(0, [1.0], [1.0], [0.0, 0.0, 0.0]))
     fakeaux.add(forte2.ints.Shell(0, [1.0], [1.0], [0.0, 0.0, 0.0]))
     system.auxiliary_basis = fakeaux
     with pytest.raises(ValueError, match="positive definite"):
         system.fock_builder.B_Pmn
+
+    with pytest.raises(ValueError, match="positive definite"):
+        system.fock_builder = jkbuilder.FockBuilderOTF(
+            system, jk_mem_thres_mb=10, backend="libcint"
+        )


### PR DESCRIPTION
This PR adds a more informative error for when the density-fitting metric is extremely linearly dependent. Previously a cryptic message from numpy would appear, such as 
```
File "/home/agpavli/miniconda3/envs/forte2/lib/python3.12/site-packages/scipy/linalg/_decomp_cholesky.py", line 39, in _cholesky
    raise LinAlgError(
numpy.linalg.LinAlgError: 6417-th leading minor of the array is not positive definite
```
Now a hopefully more informative exception is thrown:
```
ValueError: Density fitting Coulomb metric (P|Q) is not positive definite.
Please set df_ortho_rtol to a small positive value to orthogonalize the metric.
```
A test has been added to this effect.
Thanks to @pavliceka for raising this issue.