### PR TITLE
opt: refactor shared code into `CIBase`

### DIFF
--- a/forte2/base_classes/ci_base.py
+++ b/forte2/base_classes/ci_base.py
@@ -1,11 +1,29 @@
 from abc import abstractmethod
 from dataclasses import dataclass, field
 
+import numpy as np
+
 from .active_space_solver import ActiveSpaceSolver, RelActiveSpaceSolver
 
 
 @dataclass
 class CIBase(ActiveSpaceSolver):
+    """
+    Base class for (state-averaged) CI-type active-space solvers.
+
+    Provides the representation-agnostic orchestration shared by all concrete
+    solvers: root/state bookkeeping, state-averaged RDMs, and cumulants. These
+    methods assume the subclass populates the following in its ``_startup``/``run``:
+
+    - ``self.norb`` : number of active orbitals
+    - ``self.evals_flat`` : flat array of eigenvalues over all roots
+    - ``self.sub_solvers`` : list of per-state worker objects, each exposing
+      ``nroot`` and ``make_{1,2,3}rdm(root)`` returning the spin-free RDMs.
+
+    Subclasses implement the eigensolve and RDM primitives (``run``,
+    ``reset_eigensolver``, ``get_convergence_status``, ``make_sf_*``/``make_sd_*``).
+    """
+
     ### Non-init attributes
     first_run: bool = field(default=True, init=False)
     executed: bool = field(default=False, init=False)
@@ -53,6 +71,106 @@ class CIBase(ActiveSpaceSolver):
 
         return left_state, right_state, left_root_in_state, right_root_in_state
 
+    def compute_average_energy(self):
+        """
+        Compute the average energy from the CI roots using the weights.
+
+        Returns
+        -------
+        float
+            Average energy of the CI roots.
+        """
+        return np.dot(self.weights_flat, self.evals_flat)
+
+    def make_average_1rdm(self):
+        """
+        Make the average spin-free one-particle RDM from the CI vectors.
+
+        Returns
+        -------
+        NDArray
+            Average spin-free one-particle RDM.
+        """
+        rdm1 = np.zeros((self.norb,) * 2, dtype=self.dtype)
+        for i, ci_solver in enumerate(self.sub_solvers):
+            for j in range(ci_solver.nroot):
+                rdm1 += ci_solver.make_1rdm(j) * self.weights[i][j]
+        return rdm1
+
+    def make_average_2rdm(self):
+        """
+        Make the average spin-free two-particle RDM from the CI vectors.
+
+        Returns
+        -------
+        NDArray
+            Average spin-free two-particle RDM.
+        """
+        rdm2 = np.zeros((self.norb,) * 4, dtype=self.dtype)
+        for i, ci_solver in enumerate(self.sub_solvers):
+            for j in range(ci_solver.nroot):
+                rdm2 += ci_solver.make_2rdm(j) * self.weights[i][j]
+
+        return rdm2
+
+    def make_average_3rdm(self):
+        """
+        Make the average spin-free three-particle RDM from the CI vectors.
+
+        Returns
+        -------
+        NDArray
+            Average spin-free three-particle RDM.
+        """
+        rdm3 = np.zeros((self.norb,) * 6, dtype=self.dtype)
+        for i, ci_solver in enumerate(self.sub_solvers):
+            for j in range(ci_solver.nroot):
+                rdm3 += ci_solver.make_3rdm(j) * self.weights[i][j]
+
+        return rdm3
+
+    def make_average_2cumulant(self):
+        # Defer import to avoid a circular import at module load
+        from forte2.ci.ci_utils import make_2cumulant_sf, make_2cumulant_so
+
+        dm1 = self.make_average_1rdm()
+        dm2 = self.make_average_2rdm()
+        if self.two_component:
+            return make_2cumulant_so(dm1, dm2)
+        else:
+            return make_2cumulant_sf(dm1, dm2)
+
+    def make_average_3cumulant(self):
+        # Defer import to avoid a circular import at module load
+        from forte2.ci.ci_utils import make_3cumulant_sf, make_3cumulant_so
+
+        dm1 = self.make_average_1rdm()
+        dm2 = self.make_average_2rdm()
+        dm3 = self.make_average_3rdm()
+        if self.two_component:
+            return make_3cumulant_so(dm1, dm2, dm3)
+        else:
+            return make_3cumulant_sf(dm1, dm2, dm3)
+
+    def make_average_cumulants(self):
+        # Defer import to avoid a circular import at module load
+        from forte2.ci.ci_utils import (
+            make_2cumulant_sf,
+            make_2cumulant_so,
+            make_3cumulant_sf,
+            make_3cumulant_so,
+        )
+
+        dm1 = self.make_average_1rdm()
+        dm2 = self.make_average_2rdm()
+        dm3 = self.make_average_3rdm()
+        if self.two_component:
+            lambda2 = make_2cumulant_so(dm1, dm2)
+            lambda3 = make_3cumulant_so(dm1, dm2, dm3)
+        else:
+            lambda2 = make_2cumulant_sf(dm1, dm2)
+            lambda3 = make_3cumulant_sf(dm1, dm2, dm3)
+        return dm1, dm2, lambda2, lambda3
 
     @abstractmethod
     def run(self): ...
@@ -63,6 +181,12 @@ class CIBase(ActiveSpaceSolver):
     @abstractmethod
     def get_convergence_status(self): ...
 
+    @abstractmethod
+    def make_1rdm(self, left_root: int, right_root: int | None = None): ...
+
+    @abstractmethod
+    def make_2rdm(self, left_root: int, right_root: int | None = None): ...
+
 
 @dataclass
 class RelCIBase(RelActiveSpaceSolver):
@@ -72,6 +196,15 @@ class RelCIBase(RelActiveSpaceSolver):
 
     __call__ = CIBase.__call__
     _collect_child_kwargs = CIBase._collect_child_kwargs
+    _get_state_root = CIBase._get_state_root
+    _validate_rdm_inputs = CIBase._validate_rdm_inputs
+    compute_average_energy = CIBase.compute_average_energy
+    make_average_1rdm = CIBase.make_average_1rdm
+    make_average_2rdm = CIBase.make_average_2rdm
+    make_average_3rdm = CIBase.make_average_3rdm
+    make_average_2cumulant = CIBase.make_average_2cumulant
+    make_average_3cumulant = CIBase.make_average_3cumulant
+    make_average_cumulants = CIBase.make_average_cumulants
 
     def _startup(self):
         super()._startup(two_component=True)
@@ -88,3 +221,9 @@ class RelCIBase(RelActiveSpaceSolver):
 
     @abstractmethod
     def get_convergence_status(self): ...
+
+    @abstractmethod
+    def make_1rdm(self, left_root: int, right_root: int | None = None): ...
+
+    @abstractmethod
+    def make_2rdm(self, left_root: int, right_root: int | None = None): ...

--- a/forte2/ci/ci.py
+++ b/forte2/ci/ci.py
@@ -29,10 +29,6 @@ from .ci_utils import (
     pretty_print_ci_nat_occ_numbers,
     pretty_print_ci_dets,
     pretty_print_ci_transition_props,
-    make_2cumulant_sf,
-    make_2cumulant_so,
-    make_3cumulant_sf,
-    make_3cumulant_so,
 )
 
 
@@ -1314,17 +1310,6 @@ class CISolver(CIBase):
         self.executed = True
         return self
 
-    def compute_average_energy(self):
-        """
-        Compute the average energy from the CI roots using the weights.
-
-        Returns
-        -------
-        float
-            Average energy of the CI roots.
-        """
-        return np.dot(self.weights_flat, self.evals_flat)
-
     def reset_eigensolver(self):
         """
         Reset the eigensolver for each sub-solver.
@@ -1334,82 +1319,6 @@ class CISolver(CIBase):
         """
         for ci_solver in self.sub_solvers:
             ci_solver.reset_eigensolver()
-
-    def make_average_1rdm(self):
-        """
-        Make the average spin-free one-particle RDM from the CI vectors.
-
-        Returns
-        -------
-        NDArray
-            Average spin-free one-particle RDM.
-        """
-        rdm1 = np.zeros((self.norb,) * 2, dtype=self.dtype)
-        for i, ci_solver in enumerate(self.sub_solvers):
-            for j in range(ci_solver.nroot):
-                rdm1 += ci_solver.make_1rdm(j) * self.weights[i][j]
-        return rdm1
-
-    def make_average_2rdm(self):
-        """
-        Make the average spin-free two-particle RDM from the CI vectors.
-
-        Returns
-        -------
-        NDArray
-            Average spin-free two-particle RDM.
-        """
-        rdm2 = np.zeros((self.norb,) * 4, dtype=self.dtype)
-        for i, ci_solver in enumerate(self.sub_solvers):
-            for j in range(ci_solver.nroot):
-                rdm2 += ci_solver.make_2rdm(j) * self.weights[i][j]
-
-        return rdm2
-
-    def make_average_3rdm(self):
-        """
-        Make the average spin-free three-particle RDM from the CI vectors.
-
-        Returns
-        -------
-        NDArray
-            Average spin-free three-particle RDM.
-        """
-        rdm3 = np.zeros((self.norb,) * 6, dtype=self.dtype)
-        for i, ci_solver in enumerate(self.sub_solvers):
-            for j in range(ci_solver.nroot):
-                rdm3 += ci_solver.make_3rdm(j) * self.weights[i][j]
-
-        return rdm3
-
-    def make_average_2cumulant(self):
-        dm1 = self.make_average_1rdm()
-        dm2 = self.make_average_2rdm()
-        if self.two_component:
-            return make_2cumulant_so(dm1, dm2)
-        else:
-            return make_2cumulant_sf(dm1, dm2)
-
-    def make_average_3cumulant(self):
-        dm1 = self.make_average_1rdm()
-        dm2 = self.make_average_2rdm()
-        dm3 = self.make_average_3rdm()
-        if self.two_component:
-            return make_3cumulant_so(dm1, dm2, dm3)
-        else:
-            return make_3cumulant_sf(dm1, dm2, dm3)
-
-    def make_average_cumulants(self):
-        dm1 = self.make_average_1rdm()
-        dm2 = self.make_average_2rdm()
-        dm3 = self.make_average_3rdm()
-        if self.two_component:
-            lambda2 = make_2cumulant_so(dm1, dm2)
-            lambda3 = make_3cumulant_so(dm1, dm2, dm3)
-        else:
-            lambda2 = make_2cumulant_sf(dm1, dm2)
-            lambda3 = make_3cumulant_sf(dm1, dm2, dm3)
-        return dm1, dm2, lambda2, lambda3
 
     def set_ints(self, scalar, oei, tei):
         """
@@ -1787,13 +1696,10 @@ class RelCISolver(RelCIBase):
     do_test_rdms: bool = False
     log_level: int = field(default=logger.get_verbosity_level() + 1)
 
-    compute_average_energy = CISolver.compute_average_energy
-    make_average_1rdm = CISolver.make_average_1rdm
-    make_average_2rdm = CISolver.make_average_2rdm
-    make_average_3rdm = CISolver.make_average_3rdm
-    make_average_2cumulant = CISolver.make_average_2cumulant
-    make_average_3cumulant = CISolver.make_average_3cumulant
-    make_average_cumulants = CISolver.make_average_cumulants
+    # State-averaging orchestration (compute_average_energy, make_average_*,
+    # cumulants) and root bookkeeping (_get_state_root, _validate_rdm_inputs)
+    # are inherited from RelCIBase/CIBase. The bindings below are the methods
+    # that live on CISolver itself.
     compute_natural_occupation_numbers = CISolver.compute_natural_occupation_numbers
     get_top_determinants = CISolver.get_top_determinants
     set_ints = CISolver.set_ints
@@ -1801,8 +1707,6 @@ class RelCISolver(RelCIBase):
     reset_eigensolver = CISolver.reset_eigensolver
     set_maxiter = CISolver.set_maxiter
     get_convergence_status = CISolver.get_convergence_status
-    _get_state_root = CISolver._get_state_root
-    _validate_rdm_inputs = CISolver._validate_rdm_inputs
 
     def _startup(self):
         super()._startup()

--- a/forte2/sci/sci.py
+++ b/forte2/sci/sci.py
@@ -903,6 +903,11 @@ class _SelectedCISingleStateSolver:
             right_root = left_root
         return self.sci_helper.sf_2rdm(left_root, right_root)
 
+    # The state-averaged RDM machinery in CIBase calls make_{1,2,3}rdm on the
+    # sub-solvers; sCI only supports spin-free 1- and 2-RDMs.
+    make_1rdm = make_sf_1rdm
+    make_2rdm = make_sf_2rdm
+
     def compute_natural_occupation_numbers(self):
         """
         Compute the natural occupation numbers from the spin-free 1-RDMs.
@@ -1156,17 +1161,6 @@ class SelectedCISolver(CIBase):
         self.executed = True
         return self
 
-    def compute_average_energy(self):
-        """
-        Compute the average energy from the CI roots using the weights.
-
-        Returns
-        -------
-        float
-            Average energy of the CI roots.
-        """
-        return np.dot(self.weights_flat, self.evar_flat)
-
     def make_sd_1rdm(self, left_root: int, right_root: int | None = None):
         """
         Make the spin-dependent one-particle RDM for two absolute CI roots.
@@ -1207,41 +1201,32 @@ class SelectedCISolver(CIBase):
             right_solver.sci_helper, left_root_in_state, right_root_in_state
         )
 
+    def make_sf_2rdm(self, left_root: int, right_root: int | None = None):
+        """
+        Make the spin-free two-particle RDM for two absolute CI roots.
+        """
+        left_state, right_state, left_root_in_state, right_root_in_state = (
+            self._validate_rdm_inputs(left_root, right_root)
+        )
+        if left_state == right_state:
+            return self.sub_solvers[left_state].make_sf_2rdm(
+                left_root_in_state, right_root_in_state
+            )
+        raise ValueError(
+            f"Cross-state 2-RDMs are not supported. Got left_root in state {left_state} and right_root in state {right_state}."
+        )
+
     def make_1rdm(self, left_root: int, right_root: int | None = None):
         """
         Make the spin-free one-particle RDM for two absolute CI roots.
         """
         return self.make_sf_1rdm(left_root, right_root)
 
-    def make_average_1rdm(self):
+    def make_2rdm(self, left_root: int, right_root: int | None = None):
         """
-        Make the average spin-free one-particle RDM from the CI vectors.
-
-        Returns
-        -------
-        NDArray
-            Average spin-free one-particle RDM.
+        Make the spin-free two-particle RDM for two absolute CI roots.
         """
-        rdm1 = np.zeros((self.norb,) * 2)
-        for i, ci_solver in enumerate(self.sub_solvers):
-            for j in range(ci_solver.nroot):
-                rdm1 += ci_solver.make_sf_1rdm(j) * self.weights[i][j]
-        return rdm1
-
-    def make_average_2rdm(self):
-        """
-        Make the average spin-free two-particle RDM from the CI vectors.
-
-        Returns
-        -------
-        NDArray
-            Average spin-free two-particle RDM.
-        """
-        rdm2 = np.zeros((self.norb,) * 4)
-        for i, ci_solver in enumerate(self.sub_solvers):
-            for j in range(ci_solver.nroot):
-                rdm2 += ci_solver.make_sf_2rdm(j) * self.weights[i][j]
-        return rdm2
+        return self.make_sf_2rdm(left_root, right_root)
 
     def set_ints(self, scalar, oei, tei):
         """


### PR DESCRIPTION
Move some shared code into `CIBase`, put more `abstractmethod`'s that each CI solver needs to implement.