### PR TITLE
fix: pin libblas to openblas

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -10,6 +10,7 @@ dependencies:
     - nanobind>=1.3.2
     - cxx-compiler
     - openblas
+    - libblas=*=*openblas
     - cmake=3.26
     - numpy
     - scipy


### PR DESCRIPTION
CIs started failing two days ago due to libblas drifting