### PR TITLE
fix(cpp): various bounds checking

### DIFF
--- a/forte2/api/integrals_api.cc
+++ b/forte2/api/integrals_api.cc
@@ -213,7 +213,8 @@ void export_basis_api(nb::module_& sub_m) {
         .def_prop_ro("max_nprim", &Basis::max_nprim,
                      "Returns the maximum number of primitive Gaussians in shells of the basis set")
         .def_prop_ro("nprim", &Basis::max_nprim,
-                     "Returns the number of primitive Gaussians in shells of the basis set")
+                     "Returns the maximum number of primitive Gaussians in any shell of the "
+                     "basis set (alias of max_nprim)")
         .def_prop_ro("max_nbasis", &Basis::max_nbasis,
                      "Returns the maximum number of basis functions in shells of the basis set")
         .def_prop_ro("nshells", &Basis::nshells, "Returns the number of shells in the basis set")

--- a/forte2/ci/ci_string_class.cc
+++ b/forte2/ci/ci_string_class.cc
@@ -1,3 +1,5 @@
+#include <cassert>
+
 #include "determinant/determinant.h"
 #include "ci_string_class.h"
 
@@ -20,12 +22,14 @@ StringClass::StringClass(size_t symmetry, const std::vector<std::vector<int>>& o
         beta_occupation_group_[beta_occupation[i]] = i;
     }
     int k = 0;
-    for (auto n{0}; const auto& sym : orbital_symmetry) {
+    for (size_t n = 0; const auto& sym : orbital_symmetry) {
+        assert(n < gas_masks_.size());
         gas_masks_[n].clear();
         for (int j = 0, maxj = sym.size(); j < maxj; j++) {
             gas_masks_[n].set_bit(k, true);
             k++;
         }
+        ++n;
     }
 
     occupations_ = occupations;

--- a/forte2/ci/ci_string_class.cc
+++ b/forte2/ci/ci_string_class.cc
@@ -22,7 +22,7 @@ StringClass::StringClass(size_t symmetry, const std::vector<std::vector<int>>& o
         beta_occupation_group_[beta_occupation[i]] = i;
     }
     int k = 0;
-    for (size_t n = 0; const auto& sym : orbital_symmetry) {
+    for (size_t n{0}; const auto& sym : orbital_symmetry) {
         assert(n < gas_masks_.size());
         gas_masks_[n].clear();
         for (int j = 0, maxj = sym.size(); j < maxj; j++) {

--- a/forte2/determinant/determinant.hpp
+++ b/forte2/determinant/determinant.hpp
@@ -274,7 +274,7 @@ template <size_t N> class DeterminantImpl : public BitArray<N> {
     /// @param n the orbital index
     /// @return the sign of the creation operator if the orbital was unoccupied, 0 otherwise
     double create_alpha(size_t n) {
-        if ((n >= N) or na(n))
+        if ((n >= norb_capacity) or na(n))
             return 0.0;
         set_na(n, true);
         return slater_sign_a(n);
@@ -286,7 +286,7 @@ template <size_t N> class DeterminantImpl : public BitArray<N> {
     /// @param n the orbital index
     /// @return the sign of the creation operator if the orbital was unoccupied, 0 otherwise
     double create_beta(size_t n) {
-        if ((n >= N) or nb(n))
+        if ((n >= norb_capacity) or nb(n))
             return 0.0;
         set_nb(n, true);
         return slater_sign_b(n);
@@ -298,7 +298,7 @@ template <size_t N> class DeterminantImpl : public BitArray<N> {
     /// @param n the orbital index
     /// @return the sign of the annihilation operator if the orbital was occupied, 0 otherwise
     double destroy_alpha(size_t n) {
-        if ((n >= N) or (not na(n)))
+        if ((n >= norb_capacity) or (not na(n)))
             return 0.0;
         set_na(n, false);
         return slater_sign_a(n);
@@ -310,7 +310,7 @@ template <size_t N> class DeterminantImpl : public BitArray<N> {
     /// @param n the orbital index
     /// @return the sign of the annihilation operator if the orbital was occupied, 0 otherwise
     double destroy_beta(size_t n) {
-        if ((n >= N) or (not nb(n)))
+        if ((n >= norb_capacity) or (not nb(n)))
             return 0.0;
         set_nb(n, false);
         return slater_sign_b(n);

--- a/forte2/integrals/basis.cc
+++ b/forte2/integrals/basis.cc
@@ -116,6 +116,12 @@ std::string shell_label(int l, int idx) {
     if (l < static_cast<int>(labels.size()) and idx < static_cast<int>(labels[l].size())) {
         return labels[l][idx];
     }
+    // general_labels only defines labels up to l = general_labels.size() - 1;
+    // guard the fallback so l beyond that raises instead of reading past the end.
+    if (l >= static_cast<int>(general_labels.size())) {
+        throw std::out_of_range("Angular momentum " + std::to_string(l) +
+                                " exceeds defined shell labels.");
+    }
     return general_labels[l] + "(" + std::to_string(idx) + ")";
 }
 

--- a/tests/integrals/test_basis.py
+++ b/tests/integrals/test_basis.py
@@ -17,3 +17,20 @@ def test_basis_properties():
     assert basis.max_l == 2
     assert basis.max_nprim == 2
     assert basis.max_nbasis == 5
+
+
+def test_shell_label_out_of_range_raises():
+    # Regression: shell_label validated l < 0 but not the upper bound, so
+    # general_labels[l] was an out-of-bounds vector read (UB) for l beyond the
+    # defined labels (l >= 12).
+    import pytest
+
+    # Defined labels: explicit s..f, general s..n (l = 0..11).
+    assert forte2.ints.shell_label(11, 0) == "n(0)"
+    assert forte2.ints.shell_label(4, 0) == "g(0)"
+    assert forte2.ints.shell_label(2, 0) == "dxy"
+
+    with pytest.raises(Exception):
+        forte2.ints.shell_label(12, 0)
+    with pytest.raises(Exception):
+        forte2.ints.shell_label(-1, 0)


### PR DESCRIPTION
shell_label bounds, determinant guard, GAS mask index; nprim doc

- basis.cc shell_label: guarded l < 0 but not the upper bound, so general_labels[l] was an out-of-bounds vector read for l >= 12 (reachable via the ints.shell_label Python binding). Raise std::out_of_range instead.
- determinant.hpp create/destroy_alpha/beta: bounds guard used n >= N (total spin-orbital slots) instead of n >= norb_capacity (= N/2), so spatial-orbital indices in [N/2, N) bypassed the guard and either corrupted the opposite spin's bits or wrote out of bounds. Use norb_capacity, matching check_index_bounds. (Latent: Python bindings pre-check, but fixes the internal contract.)
- ci_string_class.cc StringClass: the GAS-mask loop never incremented the space index n, so every GAS wrote into gas_masks_[0]. Increment n (and assert bounds). (Latent: the consuming methods have no callers.)
- integrals_api.cc: clarify that the 'nprim' property returns the *maximum* number of primitives per shell (alias of max_nprim).