### PR TITLE
Fix MO ordering bugs for noncontiguous orbital spaces

### DIFF
--- a/forte2/mcopt/mc_optimizer.py
+++ b/forte2/mcopt/mc_optimizer.py
@@ -509,13 +509,9 @@ class MCOptimizerBase(ABC, SystemMixin, MOsMixin, MOSpaceMixin):
     def _print_ao_composition(self):
         basis_info = BasisInfo(self.system, self.system.basis)
         logger.log_info1("\nAO Composition of core MOs:")
-        basis_info.print_ao_composition(
-            self.C[0], list(range(self.core.start, self.core.stop))
-        )
+        basis_info.print_ao_composition(self.C[0], self.mo_space.docc_indices)
         logger.log_info1("\nAO Composition of active MOs:")
-        basis_info.print_ao_composition(
-            self.C[0], list(range(self.actv.start, self.actv.stop))
-        )
+        basis_info.print_ao_composition(self.C[0], self.mo_space.active_indices)
 
     def _get_nonredundant_rotations(self):
         """Lower triangular matrix of nonredundant rotations"""
@@ -545,7 +541,7 @@ class MCOptimizerBase(ABC, SystemMixin, MOsMixin, MOSpaceMixin):
 
         # zero out rotations between orbitals of different irreps
         if self.system.point_group.upper() != "C1":
-            _irrid = np.array(self.irrep_indices[0])
+            _irrid = self._final_orbital_irrep_indices()
             # equivalent to:
             # for i, j in range(nmo):
             #   if i^j != 0:

--- a/forte2/state/mo_space.py
+++ b/forte2/state/mo_space.py
@@ -102,6 +102,18 @@ class _MOSpaceBase:
             == self.nactv + self.ncore + self.nfrozen_core + self.nfrozen_virtual
         ), "All orbital indices must be unique across active, core, frozen core, and frozen virtual spaces."
 
+        all_indices = (
+            self.frozen_core_indices
+            + self.core_indices
+            + self.active_indices
+            + self.virtual_indices
+            + self.frozen_virtual_indices
+        )
+        if sorted(all_indices) != list(range(self.nmo)):
+            raise ValueError(
+                "Orbital spaces must contain each index from 0 to nmo - 1 exactly once."
+            )
+
         # permutation array that makes spaces contiguous:
         # [frozen_core, core, gas1, gas2, ..., virt, frozen_virtual]
         # such that C_contig = C_orig[:, self.orig_to_contig]
@@ -277,10 +289,6 @@ class MOSpace:
                 - set(self.frozen_virtual_orbitals),
             )
         )
-        if len(virtual_indices) < 0:
-            raise ValueError(
-                f"The sum of frozen_core, core, active, and frozen_virtual dimensions ({len(self.frozen_core_orbitals) + len(self.core_orbitals) + len(_active_flat) + len(self.frozen_virtual_orbitals)}) exceeds the total number of orbitals ({self.nmo})."
-            )
         return virtual_indices
 
     def _parse_lists(self):
@@ -296,6 +304,11 @@ class MOSpace:
             virtual_orbitals=[self.virtual_indices],
             frozen_virtual_orbitals=self.frozen_virtual_orbitals,
         )
+
+        if _mo_space.nmo != self.nmo:
+            raise ValueError(
+                "Orbital spaces must contain each index from 0 to nmo - 1 exactly once."
+            )
 
         self.ngas = _mo_space.ngas
 
@@ -381,10 +394,24 @@ class MOSpace:
 
         # convert integers to lists
         if isinstance(frozen_core_orbitals, int):
-            frozen_core_orbitals = list(range(frozen_core_orbitals))
+            core_orbitals = sorted(self.core_orbitals + self.frozen_core_orbitals)
+            if not 0 <= frozen_core_orbitals <= len(core_orbitals):
+                raise ValueError(
+                    "The number of frozen core orbitals exceeds the number of core orbitals."
+                )
+            frozen_core_orbitals = core_orbitals[:frozen_core_orbitals]
         if isinstance(frozen_virtual_orbitals, int):
-            frozen_virtual_orbitals = list(
-                range(self.nmo - frozen_virtual_orbitals, self.nmo)
+            virtual_orbitals = sorted(
+                self.virtual_indices + self.frozen_virtual_orbitals
+            )
+            if not 0 <= frozen_virtual_orbitals <= len(virtual_orbitals):
+                raise ValueError(
+                    "The number of frozen virtual orbitals exceeds the number of virtual orbitals."
+                )
+            frozen_virtual_orbitals = (
+                virtual_orbitals[-frozen_virtual_orbitals:]
+                if frozen_virtual_orbitals
+                else []
             )
 
         assert len(frozen_core_orbitals) == len(
@@ -478,6 +505,11 @@ class EmbeddingMOSpace:
             virtual_orbitals=[self.A_virtual_orbitals, self.B_virtual_orbitals],
             frozen_virtual_orbitals=self.frozen_virtual_orbitals,
         )
+
+        if _mo_space.nmo != self.nmo:
+            raise ValueError(
+                "Orbital spaces must contain each index from 0 to nmo - 1 exactly once."
+            )
 
         self.frozen_core = _mo_space.frozen_core
         self.B_core = _mo_space.core[0]

--- a/tests/ci/test_mo_space.py
+++ b/tests/ci/test_mo_space.py
@@ -56,6 +56,56 @@ def test_mo_space_invalid():
         mospace = MOSpace(nmo=nmo, core_orbitals=[0, 2], active_orbitals=[[4, 3], [1]])
 
 
+def test_mo_space_rejects_invalid_index_domains():
+    with pytest.raises(ValueError, match="exactly"):
+        MOSpace(nmo=3, core_orbitals=[0], active_orbitals=[3])
+
+    with pytest.raises(ValueError, match="exactly"):
+        MOSpace(nmo=3, core_orbitals=[0], active_orbitals=[-1])
+
+    with pytest.raises(ValueError, match="exactly"):
+        EmbeddingMOSpace(
+            nmo=5,
+            frozen_core_orbitals=[],
+            B_core_orbitals=[0],
+            A_core_orbitals=[1],
+            active_orbitals=[2],
+            A_virtual_orbitals=[],
+            B_virtual_orbitals=[],
+            frozen_virtual_orbitals=[],
+        )
+
+    with pytest.raises(ValueError, match="exactly"):
+        EmbeddingMOSpace(
+            nmo=4,
+            frozen_core_orbitals=[],
+            B_core_orbitals=[0],
+            A_core_orbitals=[],
+            active_orbitals=[1],
+            A_virtual_orbitals=[1],
+            B_virtual_orbitals=[2],
+            frozen_virtual_orbitals=[],
+        )
+
+
+def test_update_frozen_orbital_counts_with_noncontiguous_spaces():
+    core_space = MOSpace(
+        nmo=5,
+        core_orbitals=[1, 2],
+        active_orbitals=[0],
+    )
+    core_space = core_space.update_frozen_orbitals(frozen_core_orbitals=1)
+    assert core_space.frozen_core_indices == [1]
+
+    virtual_space = MOSpace(
+        nmo=5,
+        core_orbitals=[4],
+        active_orbitals=[3],
+    )
+    virtual_space = virtual_space.update_frozen_orbitals(frozen_virtual_orbitals=1)
+    assert virtual_space.frozen_virtual_indices == [2]
+
+
 def test_mo_space_simple_cas():
     mospace = MOSpace(nmo=10, core_orbitals=[0, 1, 2], active_orbitals=[3, 4])
     assert mospace.ngas == 1

--- a/tests/mcopt/test_mo_ordering.py
+++ b/tests/mcopt/test_mo_ordering.py
@@ -1,0 +1,74 @@
+from types import SimpleNamespace
+
+import numpy as np
+
+from forte2 import System, RHF, MCOptimizer, State, CISolver, MOSpace
+from forte2.helpers.comparisons import approx
+from forte2.mcopt import mc_optimizer as mc_optimizer_module
+from forte2.mcopt.mc_optimizer import MCOptimizerBase
+
+
+def test_gasscf_symmetry_invariant_to_noncontiguous_gas_order():
+    system = System(
+        xyz="H 0.0 0.0 0.0\nH 0.0 0.0 1.4",
+        basis_set="cc-pvdz",
+        auxiliary_basis_set="cc-pVTZ-JKFIT",
+        unit="bohr",
+        symmetry=True,
+    )
+    rhf = RHF(charge=0, e_tol=1e-12)(system)
+    state = State(
+        nel=2,
+        multiplicity=1,
+        ms=0.0,
+        gas_min=[0, 0],
+        gas_max=[2, 2],
+    )
+
+    def run(active_orbitals):
+        mc = MCOptimizer(
+            CISolver(state, active_orbitals=active_orbitals),
+            freeze_inter_gas_rots=True,
+            final_orbitals="original",
+            maxiter=100,
+        )(rhf)
+        mc.run()
+        return mc
+
+    mc_contiguous = run([[0], [1]])
+    mc_noncontiguous = run([[1], [0]])
+
+    assert mc_noncontiguous.E == approx(mc_contiguous.E)
+
+
+def test_mcoptimizer_ao_composition_uses_original_mo_indices(monkeypatch):
+    recorded_indices = []
+
+    class RecordingBasisInfo:
+        def __init__(self, system, basis):
+            pass
+
+        def print_ao_composition(self, C, indices):
+            recorded_indices.append(indices)
+
+    monkeypatch.setattr(mc_optimizer_module, "BasisInfo", RecordingBasisInfo)
+
+    mo_space = MOSpace(
+        nmo=5,
+        frozen_core_orbitals=[2],
+        core_orbitals=[0],
+        active_orbitals=[[4], [1]],
+    )
+    mc = object.__new__(MCOptimizerBase)
+    mc.system = SimpleNamespace(basis=None)
+    mc.C = [np.eye(mo_space.nmo)]
+    mc.mo_space = mo_space
+    mc.core = mo_space.docc
+    mc.actv = mo_space.actv
+
+    mc._print_ao_composition()
+
+    assert recorded_indices == [
+        mo_space.docc_indices,
+        mo_space.active_indices,
+    ]


### PR DESCRIPTION
## Summary

This PR fixes four independent bugs that appear when MO spaces do not follow the original column order.

### 1. Symmetry filtering used irrep labels in the wrong order

`MCOptimizerBase._get_nonredundant_rotations()` builds its rotation mask in contiguous MO-space order, but it filtered that mask with irrep labels in original MO order. For noncontiguous GAS definitions, valid same-irrep rotations could be removed and different-irrep rotations could be retained. The optimizer now reorders the irrep labels before applying the symmetry mask.

The numerical regression compares symmetry-enabled GASSCF calculations using `[[0], [1]]` and `[[1], [0]]`. Before the fix, their energies differed by about 0.0155 Eh.

### 2. MO-space permutations accepted invalid index domains

`_MOSpaceBase` checked uniqueness within several individual spaces, but did not require all spaces together to be an exact permutation of `0, ..., nmo - 1`. In particular, virtual-space overlaps, negative or out-of-range indices, and incomplete embedding spaces could produce malformed permutation arrays.

MO-space construction now requires every orbital index in the declared domain to occur exactly once. `MOSpace` and `EmbeddingMOSpace` also verify that the number of supplied or inferred indices agrees with their declared `nmo`.

### 3. Integer frozen-orbital counts assumed original spaces were contiguous

`update_frozen_orbitals()` interpreted an integer core count as `range(count)` and an integer virtual count as the highest labels below `nmo`. Those labels need not belong to the eligible core or virtual spaces when the spaces are noncontiguous.

Integer counts now select the lowest eligible core labels and highest eligible virtual labels, with bounds checks against the corresponding spaces.

### 4. AO composition reporting mixed contiguous slices with original MO columns

The optimizer passed contiguous core and active slices to `BasisInfo.print_ao_composition()`, while `self.C[0]` is stored in original MO order. Reports could therefore describe the wrong orbitals.

The report now uses `mo_space.docc_indices` and `mo_space.active_indices`, which are original-order column labels.

## Validation

- `pytest -q -m "not slow"`: 586 passed, 2 skipped, 28 deselected
- `pytest -q tests/mcopt -m "not slow"`: 43 passed, 5 deselected
- `pytest -q tests/ci -m "not slow"`: 77 passed
- `pytest -q tests/orbitals -m "not slow"`: 43 passed, 1 deselected
