### PR TITLE
gha: cache the build/ directory for incremental builds

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,7 +1,9 @@
 name: build
 
-on: 
+on:
   push:
+    branches: [main]
+    tags: ['**']
   pull_request:
     types: [opened, synchronize, reopened, ready_for_review, converted_to_draft]
   schedule:
@@ -9,12 +11,29 @@ on:
   merge_group:
     types: [checks_requested]
 
+# Cancel in-progress runs when a newer commit is pushed to the same PR/branch.
+# Never cancel on main or in merge queue, where every run must complete.
+concurrency:
+  group: build-${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
 jobs:
   build:
     runs-on: ${{ matrix.os }}
+    permissions:
+      actions: write      # needed to delete stale caches
+      contents: read
+    env:
+      # Content-addressed compiler cache — immune to the mtime resets that
+      # defeat Make's incremental logic after a git checkout.
+      CCACHE_DIR: ${{ github.workspace }}/.ccache
+      CCACHE_MAXSIZE: "1G"
+      # Hash the compiler's contents, not its mtime — survives conda reinstalls
+      # that rewrite the binary's timestamp without changing it.
+      CCACHE_COMPILERCHECK: content
     defaults:
       run:
-        shell: bash -el {0}   
+        shell: bash -el {0}
 
     strategy:
       fail-fast: false
@@ -38,13 +57,65 @@ jobs:
         auto-activate-base: false
         add-pip-as-python-dependency: true
 
+    - name: Restore C++ build tree
+      id: cache-restore
+      uses: actions/cache/restore@v4
+      with:
+        path: build
+        key: cxxbuild-${{ matrix.os }}-${{ hashFiles('environment.yml', '**/CMakeLists.txt', 'pyproject.toml') }}-${{ github.run_id }}
+        restore-keys: |
+          cxxbuild-${{ matrix.os }}-${{ hashFiles('environment.yml', '**/CMakeLists.txt', 'pyproject.toml') }}-
+          cxxbuild-${{ matrix.os }}-
+
+    - name: Restore ccache
+      id: ccache-restore
+      uses: actions/cache/restore@v4
+      with:
+        path: ${{ env.CCACHE_DIR }}
+        key: ccache-${{ matrix.os }}-${{ github.run_id }}
+        restore-keys: |
+          ccache-${{ matrix.os }}-
+
     - name: Compile Forte2
       id: compile-forte2
       run: |
         conda activate forte
         export CMAKE_GENERATOR="Unix Makefiles"
-        pip install --no-build-isolation -ve .
+        ccache --zero-stats
+        pip install --no-build-isolation -ve . \
+          --config-settings=cmake.define.CMAKE_C_COMPILER_LAUNCHER=ccache \
+          --config-settings=cmake.define.CMAKE_CXX_COMPILER_LAUNCHER=ccache
+        ccache --show-stats
         pip list
+
+    - name: Trim stale build caches for this ref
+      if: ${{ steps.compile-forte2.outcome == 'success' && !cancelled() }}
+      env:
+        GH_TOKEN: ${{ github.token }}
+      run: |
+        prefix="cxxbuild-${{ matrix.os }}-"
+        # Newest first; keep index 0 (the fallback we just restored), delete the rest.
+        ids=$(gh cache list --ref "$GITHUB_REF" --key "$prefix" \
+                --sort created_at --order desc --limit 100 \
+                --json id --jq '.[1:][].id' \
+                --repo "$GITHUB_REPOSITORY" 2>/dev/null) || ids=""
+        for id in $ids; do
+          gh cache delete "$id" --repo "$GITHUB_REPOSITORY" || true
+        done
+
+    - name: Save C++ build tree
+      if: ${{ steps.compile-forte2.outcome == 'success' && !cancelled() }}
+      uses: actions/cache/save@v4
+      with:
+        path: build
+        key: cxxbuild-${{ matrix.os }}-${{ hashFiles('environment.yml', '**/CMakeLists.txt', 'pyproject.toml') }}-${{ github.run_id }}
+
+    - name: Save ccache
+      if: ${{ steps.compile-forte2.outcome == 'success' && !cancelled() }}
+      uses: actions/cache/save@v4
+      with:
+        path: ${{ env.CCACHE_DIR }}
+        key: ccache-${{ matrix.os }}-${{ github.run_id }}
 
     - name: Run Forte2 pytest tests
       if: ${{ steps.compile-forte2.outcome == 'success' && !cancelled() }}

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -24,13 +24,14 @@ jobs:
       actions: write      # needed to delete stale caches
       contents: read
     env:
-      # Content-addressed compiler cache — immune to the mtime resets that
-      # defeat Make's incremental logic after a git checkout.
+      # Cache .o files
       CCACHE_DIR: ${{ github.workspace }}/.ccache
       CCACHE_MAXSIZE: "1G"
-      # Hash the compiler's contents, not its mtime — survives conda reinstalls
-      # that rewrite the binary's timestamp without changing it.
       CCACHE_COMPILERCHECK: content
+      # Rewrite absolute paths under the workspace to relative before hashing,
+      # so cache entries aren't tied to the checkout's absolute location.
+      CCACHE_BASEDIR: ${{ github.workspace }}
+      CCACHE_SLOPPINESS: include_file_ctime,include_file_mtime,time_macros,locale,pch_defines
     defaults:
       run:
         shell: bash -el {0}

--- a/.github/workflows/cleanup-caches.yml
+++ b/.github/workflows/cleanup-caches.yml
@@ -1,0 +1,31 @@
+name: cleanup-pr-caches
+
+# When a PR closes (merged or not), its refs/pull/<N>/merge caches can never be
+# read again, so delete them all to reclaim the repo's 10 GB cache budget.
+on:
+  pull_request:
+    types: [closed]
+
+jobs:
+  cleanup:
+    runs-on: ubuntu-latest
+    permissions:
+      actions: write      # needed to delete caches
+      contents: read
+    steps:
+      - name: Delete all caches for the closed PR
+        env:
+          GH_TOKEN: ${{ github.token }}
+          PR_REF: refs/pull/${{ github.event.pull_request.number }}/merge
+        run: |
+          ids=$(gh cache list --ref "$PR_REF" --limit 100 \
+                  --json id --jq '.[].id' \
+                  --repo "$GITHUB_REPOSITORY") || ids=""
+          if [ -z "$ids" ]; then
+            echo "No caches found for $PR_REF"
+            exit 0
+          fi
+          for id in $ids; do
+            echo "Deleting cache $id"
+            gh cache delete "$id" --repo "$GITHUB_REPOSITORY" || true
+          done

--- a/environment.yml
+++ b/environment.yml
@@ -9,6 +9,7 @@ dependencies:
     - pip
     - nanobind>=1.3.2
     - cxx-compiler
+    - ccache
     - openblas
     - libblas=*=*openblas
     - cmake=3.26


### PR DESCRIPTION
The fresh C++ build on every CI takes too long. This commit caches the build directory so every CI only needs to incrementally build the C++ part.