### PR TITLE
fix(avas): bare-element and all-SOMO edge cases

### DIFF
--- a/forte2/orbitals/avas.py
+++ b/forte2/orbitals/avas.py
@@ -153,7 +153,7 @@ class AVAS(MOsMixin, SystemMixin, MOSpaceMixin):
             ), "Number of active unoccupied orbitals cannot be negative."
             if isinstance(self.parent_method, ROHF):
                 nactv = (
-                    int(self.parent_method.ms) * 2
+                    round(2 * self.parent_method.ms)
                     + self.num_active_docc
                     + self.num_active_uocc
                 )
@@ -204,7 +204,8 @@ class AVAS(MOsMixin, SystemMixin, MOSpaceMixin):
             end = start + 1 if mgroups[2] is None else int(mgroups[2]) + 1
 
         # mgroups[3] contains the subset of AOs e.g. "2p", "2pz", "3dz2" etc.
-        if mgroups[3] is None:
+        # if empty, then treat as "all"
+        if not mgroups[3]:
             # no subset specified (e.g. "C")
             # select all AOs of the element, subject to subspace_planes
             for A in range(start, end):
@@ -446,6 +447,11 @@ class AVAS(MOsMixin, SystemMixin, MOSpaceMixin):
                     else:
                         inact_uocc.append(indices[imo])
         elif self.selection_method == "total":
+            if self.num_active > nsig:
+                raise ValueError(
+                    f"num_active ({self.num_active}) exceeds the number of "
+                    f"available AVAS orbitals ({nsig})."
+                )
             for imo in range(self.num_active):
                 if occupations[imo] == 1:
                     act_docc.append(indices[imo])

--- a/tests/orbitals/test_avas.py
+++ b/tests/orbitals/test_avas.py
@@ -103,6 +103,61 @@ def test_avas_subspace():
     )(rhf)
 
 
+def test_avas_bare_element_subspace():
+    xyz = """
+    N 0.0 0.0 0.0
+    N 0.0 0.0 1.2
+    """
+    system = System(
+        xyz=xyz,
+        basis_set="cc-pvdz",
+        auxiliary_basis_set="cc-pVTZ-JKFIT",
+        minao_basis_set="sto-3g",
+    )
+    rhf = RHF(charge=0, e_tol=1e-12)(system)
+
+    expected_minaos = [10, 5, 10]
+    for i, spec in enumerate(["N", "N1", "N1-2"]):
+        avas = AVAS(
+            selection_method="total",
+            num_active=4,
+            subspace=[spec],
+        )(rhf)
+        # A bare element selects at least one AO into the subspace.
+        assert len(avas.minao_subspace) == expected_minaos[i]
+
+
+def test_avas_total_num_active_too_large():
+    system = System(
+        xyz="N 0.0 0.0 0.0\nN 0.0 0.0 1.2",
+        basis_set="cc-pvdz",
+        auxiliary_basis_set="cc-pVTZ-JKFIT",
+        minao_basis_set="sto-3g",
+    )
+    rhf = RHF(charge=0, e_tol=1e-11)(system)
+    rhf.run()
+    with pytest.raises(ValueError, match="exceeds the number"):
+        AVAS(selection_method="total", num_active=999, subspace=["N(2p)"])(rhf).run()
+
+
+def test_avas_rohf_half_integer_ms_somo_count():
+    system = System(
+        xyz="N 0 0 0",
+        basis_set="cc-pvdz",
+        auxiliary_basis_set="cc-pVTZ-JKFIT",
+        minao_basis_set="sto-3g",
+    )
+    rohf = ROHF(charge=0, ms=0.5)(system)
+    # AVAS doesn't do anything here since the only
+    # active orbital is the SOMO, but it is a valid input
+    _ = AVAS(
+        selection_method="separate",
+        subspace=["N(2p)"],
+        num_active_docc=0,
+        num_active_uocc=0,
+    )(rohf)
+
+
 def test_avas_separate_n2():
     eref_casci = -109.00462206150347
     eref_casci_avas = -109.005019207444


### PR DESCRIPTION
Two edge cases are now supported:
1. if the orbital specifier isn't provided, e.g. 'N', 'N2', 'N1-2', an exception would be thrown, but these were documented as valid inputs.
2. an all-singly-occupied AVAS input (num_active_docc = num_active_uocc = 0) with ROHF was rejected if ms was half-integer. AVAS doesn't do any orbital rotations here since it's going to return the SOMOs (and other orbitals) unchanged, and the only convenience is that it sets the mo_space for downstream. there is no reason that this isn't valid input.