### PR TITLE
fix(MCOptimizer): Account for near-threshold errors when comparing updated energies.

### DIFF
--- a/forte2/mcopt/mc_optimizer.py
+++ b/forte2/mcopt/mc_optimizer.py
@@ -479,7 +479,7 @@ class MCOptimizerBase(ABC, SystemMixin, MOsMixin, MOSpaceMixin):
         avg_de = np.abs(self.E_avg - new_E_avg)
         de = np.abs(self.E - new_E_avg)
         max_de = max(max_ci_de, avg_de, de)
-        if max_de > self.e_tol:
+        if max_de > self.e_tol * 10.0:  # account for near-threshold numerical noise
             logger.log_warning(
                 f"After producing the final orbitals, the CI solver converged to different solutions: "
                 f"Final energies: E_CI = {new_E_ci}, E_avg = {new_E_avg:.10f}, E = {self.E:.10f}. "


### PR DESCRIPTION
At the end of a MCOptimizer run, if the orbitals are changed, we run a new CI to update the CI coefficient based on the new orbitals.

This is a tiny fix to relax this test, allowing for errors up to 10 times the energy tolerance threshold (e_tol).