### PR TITLE
perf(rel-ci): optimize relativistic CI

### DIFF
--- a/forte2/ci/rel_ci_sigma_builder.cc
+++ b/forte2/ci/rel_ci_sigma_builder.cc
@@ -16,6 +16,13 @@ RelCISigmaBuilder::RelCISigmaBuilder(const CIStrings& lists, double E, np_matrix
                                      np_tensor4_complex& V, int log_level)
     : lists_(lists), E_(E), H_(H), V_(V), rel_slater_rules_(lists.norb(), E, H, V),
       log_level_(log_level) {
+    // Two-component (relativistic) CI treats every electron as an alpha spinor, so the beta space
+    // is the single vacuum string (nb == 0). The sigma/RDM builders rely on this: the opposite-spin
+    // spectator string count is always 1.
+    if (lists.nb() != 0)
+        throw std::runtime_error("RelCISigmaBuilder requires nb == 0 (two-component CI treats all "
+                                 "electrons as alpha spinors).");
+
     // Find the size of the largest symmetry block
     size_t max_size = 0;
     for (auto const& [nI, class_Ia, class_Ib] : lists.determinant_classes()) {
@@ -138,8 +145,8 @@ void RelCISigmaBuilder::Hamiltonian(np_vector_complex basis, np_vector_complex s
     H0(b_span, s_span);
     if (algorithm_ == CIAlgorithm::Knowles_Handy) {
     } else {
-        H1_hz(b_span, s_span, Spin::Alpha, h_hz);
-        H2_hz_same_spin(b_span, s_span, Spin::Alpha);
+        H1_hz(b_span, s_span, h_hz);
+        H2_hz_same_spin(b_span, s_span);
     }
 }
 

--- a/forte2/ci/rel_ci_sigma_builder.h
+++ b/forte2/ci/rel_ci_sigma_builder.h
@@ -159,21 +159,20 @@ class RelCISigmaBuilder {
     mutable std::vector<std::complex<double>> v_pr_qs;
 
     /// @brief  One-electron contribution to the sigma vector |sigma> = H |basis>
-    /// @param alpha If true, compute the alpha contribution, otherwise the beta
-    /// @param h The one-electron integrals
-    void H1_hz(std::span<std::complex<double>> basis, std::span<std::complex<double>> sigma,
-               Spin spin, std::span<std::complex<double>> h) const;
-
-    /// @brief  Two-electron same-spin contribution to the sigma vector |sigma> = H |basis>
-    /// @param alpha If true, compute the alpha contribution, otherwise the beta
-    void H2_hz_same_spin(std::span<std::complex<double>> basis,
-                         std::span<std::complex<double>> sigma, Spin spin) const;
-
-    /// @brief  Two-electron mixed-spin contribution to the sigma vector |sigma> = H |basis>
     /// @param basis The basis vector
     /// @param sigma The resulting sigma vector
-    void H2_hz_opposite_spin(std::span<std::complex<double>> basis,
-                             std::span<std::complex<double>> sigma) const;
+    /// @param h The one-electron integrals
+    /// @note Two-component CI acts only on alpha spinors (nb == 0), so this is the alpha
+    ///       contribution and the opposite-spin spectator string count is always 1.
+    void H1_hz(std::span<std::complex<double>> basis, std::span<std::complex<double>> sigma,
+               std::span<std::complex<double>> h) const;
+
+    /// @brief  Two-electron same-spin contribution to the sigma vector |sigma> = H |basis>
+    /// @param basis The basis vector
+    /// @param sigma The resulting sigma vector
+    /// @note Two-component CI acts only on alpha spinors (nb == 0); see H1_hz.
+    void H2_hz_same_spin(std::span<std::complex<double>> basis,
+                         std::span<std::complex<double>> sigma) const;
 
     // -- Knowles-Handy Algorithm Functions/Data --
 

--- a/forte2/ci/rel_ci_sigma_builder_harrison_zarrabian.cc
+++ b/forte2/ci/rel_ci_sigma_builder_harrison_zarrabian.cc
@@ -5,10 +5,23 @@
 #include "helpers/np_vector_functions.h"
 #include "helpers/indexing.hpp"
 #include "helpers/blas.h"
+#include "helpers/parallel.h"
 
 #include "rel_ci_sigma_builder.h"
 
 namespace forte2 {
+
+namespace {
+// Threading the gather/scatter loops helps only once there is enough work to amortize the overhead
+constexpr size_t kRelHzParallelThreshold = 16384;
+
+template <typename F> inline void gated_parallel_for_chunked(size_t count, F&& func) {
+    if (count < kRelHzParallelThreshold)
+        func(size_t{0}, count);
+    else
+        parallel_for_chunked(count, std::forward<F>(func));
+}
+} // namespace
 
 std::tuple<std::span<std::complex<double>>, std::span<std::complex<double>>, size_t>
 RelCISigmaBuilder::get_Kblock_spans(size_t nrows, size_t ncols) const {
@@ -43,25 +56,20 @@ RelCISigmaBuilder::get_Kblock_spans(size_t nrows, size_t ncols) const {
 }
 
 void RelCISigmaBuilder::H1_hz(std::span<std::complex<double>> basis,
-                              std::span<std::complex<double>> sigma, Spin spin,
+                              std::span<std::complex<double>> sigma,
                               std::span<std::complex<double>> h) const {
+    // Two-component CI acts only on alpha spinors (nb == 0), so the beta space is the single
+    // vacuum string and the opposite-spin spectator count maxL == 1. The [K, L] composite index
+    // therefore collapses to just K
     const size_t norb = lists_.norb();
-    const auto na = lists_.na();
-    const auto nb = lists_.nb();
-
-    // skip this block if there is no electron with equal spin to that on which this operator acts
-    if ((is_alpha(spin) and (na < 1)) or (is_beta(spin) and (nb < 1)))
+    if (lists_.na() < 1)
         return;
 
-    const auto& alpha_address = lists_.alpha_address();
-    const auto& beta_address = lists_.beta_address();
-    const int num_1h_classes = is_alpha(spin) ? lists_.alpha_address_1h()->nclasses()
-                                              : lists_.beta_address_1h()->nclasses();
+    const int num_1h_classes = lists_.alpha_address_1h()->nclasses();
 
-    // |K>|L> = ± a_p |I>|L>
+    // |K> = ± a_q |I>
     for (int class_K = 0; class_K < num_1h_classes; ++class_K) {
-        const size_t maxK = is_alpha(spin) ? lists_.alpha_address_1h()->strpcls(class_K)
-                                           : lists_.beta_address_1h()->strpcls(class_K);
+        const size_t maxK = lists_.alpha_address_1h()->strpcls(class_K);
 
         if (maxK == 0)
             continue;
@@ -72,76 +80,59 @@ void RelCISigmaBuilder::H1_hz(std::span<std::complex<double>> basis,
             if (lists_.block_size(nI) == 0)
                 continue;
 
-            // size of the strings with opposite spin to the one on which we act
-            const size_t maxL =
-                is_alpha(spin) ? beta_address->strpcls(class_Ib) : alpha_address->strpcls(class_Ia);
+            // Grab the temporary buffers that will hold intermediates D(i, K)
+            // and return the maximum size of a chunk of K indices
+            auto [Kblock1, Kblock2, K_chunk_size] = get_Kblock_spans(norb, maxK);
 
-            if (maxL > 0) {
-                // Grab the temporary buffers that will hold intermediates D(i,[K L])
-                // and return the maximum size of a chunk of K indices
-                auto [Kblock1, Kblock2, K_chunk_size] = get_Kblock_spans(norb * maxL, maxK);
+            // Grab a span with the C coefficients
+            auto tr = gather_block(basis, TR, Spin::Alpha, lists_, class_Ia, class_Ib);
 
-                // number of elements in the temporary buffer
-                const auto temp_dim = norb * K_chunk_size * maxL;
+            // Loop over ranges of K indices in chunks of size K_chunk_size
+            for (size_t K_start = 0; K_start < maxK; K_start += K_chunk_size) {
+                const size_t K_end = std::min(K_start + K_chunk_size, maxK);
+                // size of the K range, which may be smaller than K_chunk_size
+                const size_t K_size = K_end - K_start;
 
-                // Grab a span with the C coefficients
-                auto tr = gather_block(basis, TR, spin, lists_, class_Ia, class_Ib);
+                std::fill_n(Kblock2.begin(), norb * K_size, 0.0);
 
-                // Loop over ranges of K indices in chuncks of size K_chunk_size
-                for (size_t K_start = 0; K_start < maxK; K_start += K_chunk_size) {
-                    const size_t K_end = std::min(K_start + K_chunk_size, maxK);
-                    // size of the K range, which may be smaller than K_chunk_size
-                    const size_t K_size = K_end - K_start;
-                    // number of columns in the chunk we are processing
-                    const size_t dimKL = K_size * maxL;
-
-                    std::fill_n(Kblock2.begin(), temp_dim, 0.0);
-
-                    // Loop over the K indices in the chunk
-                    for (size_t K = 0; K < K_size; ++K) {
-                        const auto& Klist =
-                            is_alpha(spin)
-                                ? lists_.get_alpha_1h_list(class_K, K_start + K, class_Ia)
-                                : lists_.get_beta_1h_list(class_K, K_start + K, class_Ib);
-                        // D(q,[K L]) += <K|a_q|I> C(I,L)
-                        for (const auto& [sign_K, q, I] : Klist) {
-                            // Inline the length-maxL axpy (maxL == 1 for two-component CI) to
-                            // avoid a BLAS dispatch per substitution.
-                            const double s = static_cast<double>(sign_K);
-                            const auto* src = &tr[I * maxL];
-                            auto* dst = &Kblock2_[q * dimKL + K * maxL];
-                            for (size_t idx{0}; idx < maxL; ++idx)
-                                dst[idx] += s * src[idx];
-                        }
+                // D(q, K) = <K|a_q|I> C(I)
+                // Parallelize over K: each K writes its own column of Kblock2, so no write race.
+                gated_parallel_for_chunked(K_size, [&](size_t kb, size_t ke) {
+                    for (size_t K = kb; K < ke; ++K) {
+                        const auto& Klist = lists_.get_alpha_1h_list(class_K, K_start + K, class_Ia);
+                        for (const auto& [sign_K, q, I] : Klist)
+                            Kblock2[q * K_size + K] += static_cast<double>(sign_K) * tr[I];
                     }
+                });
 
-                    // E(p,[K L]) = sum_q h(p,q) D(q,[K L])
-                    matrix_product('N', 'N', norb, dimKL, norb, 1.0, h.data(), norb,
-                                   Kblock2_.data(), dimKL, 0.0, Kblock1_.data(), dimKL);
+                // E(p, K) = sum_q h(p,q) D(q, K)
+                matrix_product('N', 'N', norb, K_size, norb, 1.0, h.data(), norb, Kblock2.data(),
+                               K_size, 0.0, Kblock1.data(), K_size);
 
-                    // sigma(J L) += <J|a^+_p|K> E(p,[K L])
-                    for (const auto& [nJ, class_Ja, class_Jb] : lists_.determinant_classes()) {
-                        if ((is_alpha(spin) and (class_Ib != class_Jb)) or
-                            (is_beta(spin) and (class_Ia != class_Ja)))
-                            continue;
+                // sigma(J) += <J|a^+_p|K> E(p, K)
+                for (const auto& [nJ, class_Ja, class_Jb] : lists_.determinant_classes()) {
+                    if (class_Ib != class_Jb)
+                        continue;
 
-                        // zero the temporary buffer that will hold the result
-                        std::fill_n(TL.begin(), TL.size(), 0.0);
+                    const size_t maxJ = lists_.alpha_address()->strpcls(class_Ja);
+                    // zero the temporary buffer that will hold the result
+                    std::fill_n(TL.begin(), TL.size(), 0.0);
+                    // The scatter accumulates into TL(J) (a reduction over K), so parallelize over
+                    // the output string J, each thread owns a stripe of J and
+                    // scans all K, accumulating only into rows it owns.
+                    gated_parallel_for_chunked(maxJ, [&](size_t J_begin, size_t J_end) {
                         for (size_t K = 0; K < K_size; ++K) {
                             const auto& Klist =
-                                is_alpha(spin)
-                                    ? lists_.get_alpha_1h_list(class_K, K_start + K, class_Ja)
-                                    : lists_.get_beta_1h_list(class_K, K_start + K, class_Jb);
-                            for (const auto& [sign_K, p, I] : Klist) {
-                                const double s = static_cast<double>(sign_K);
-                                const auto* src = &Kblock1_[p * dimKL + K * maxL];
-                                auto* dst = &TL[I * maxL];
-                                for (size_t idx{0}; idx < maxL; ++idx)
-                                    dst[idx] += s * src[idx];
+                                lists_.get_alpha_1h_list(class_K, K_start + K, class_Ja);
+                            for (const auto& [sign_K, p, J] : Klist) {
+                                // this thread does not own this J
+                                if (J < J_begin || J >= J_end)
+                                    continue;
+                                TL[J] += static_cast<double>(sign_K) * Kblock1[p * K_size + K];
                             }
                         }
-                        scatter_block(TL, sigma, spin, lists_, class_Ja, class_Jb);
-                    }
+                    });
+                    scatter_block(TL, sigma, Spin::Alpha, lists_, class_Ja, class_Jb);
                 }
             }
         }
@@ -149,22 +140,17 @@ void RelCISigmaBuilder::H1_hz(std::span<std::complex<double>> basis,
 }
 
 void RelCISigmaBuilder::H2_hz_same_spin(std::span<std::complex<double>> basis,
-                                        std::span<std::complex<double>> sigma, Spin spin) const {
-    if ((is_alpha(spin) and (lists_.na() < 2)) or (is_beta(spin) and (lists_.nb() < 2)))
+                                        std::span<std::complex<double>> sigma) const {
+    if (lists_.na() < 2)
         return;
 
     const size_t norb = lists_.norb();
     const size_t npairs = norb * (norb - 1) / 2;
 
-    const auto& alpha_address = lists_.alpha_address();
-    const auto& beta_address = lists_.beta_address();
-
-    const int num_2h_classes = is_alpha(spin) ? lists_.alpha_address_2h()->nclasses()
-                                              : lists_.beta_address_2h()->nclasses();
+    const int num_2h_classes = lists_.alpha_address_2h()->nclasses();
 
     for (int class_K = 0; class_K < num_2h_classes; ++class_K) {
-        const size_t maxK = is_alpha(spin) ? lists_.alpha_address_2h()->strpcls(class_K)
-                                           : lists_.beta_address_2h()->strpcls(class_K);
+        const size_t maxK = lists_.alpha_address_2h()->strpcls(class_K);
 
         if (maxK == 0)
             continue;
@@ -174,168 +160,60 @@ void RelCISigmaBuilder::H2_hz_same_spin(std::span<std::complex<double>> basis,
             if (lists_.block_size(nI) == 0)
                 continue;
 
-            const size_t maxL =
-                is_alpha(spin) ? beta_address->strpcls(class_Ib) : alpha_address->strpcls(class_Ia);
+            // grab temporary buffers and the maximum size of a chunk of K indices
+            auto [Kblock1, Kblock2, K_chunk_size] = get_Kblock_spans(npairs, maxK);
 
-            if (maxL > 0) {
-                // grab temporary buffers and the maximum size of a chunk of K indices
-                auto [Kblock1, Kblock2, K_chunk_size] = get_Kblock_spans(npairs * maxL, maxK);
+            auto tr = gather_block(basis, TR, Spin::Alpha, lists_, class_Ia, class_Ib);
 
-                // number of elements in the temporary blocks
-                const auto temp_dim = npairs * K_chunk_size * maxL;
+            // Loop over ranges of K indices in chunks of size K_chunk_size
+            for (size_t K_start = 0; K_start < maxK; K_start += K_chunk_size) {
+                const size_t K_end = std::min(K_start + K_chunk_size, maxK);
+                // size of the K range, which may be smaller than K_chunk_size
+                const size_t K_size = K_end - K_start;
 
-                auto tr = gather_block(basis, TR, spin, lists_, class_Ia, class_Ib);
+                std::fill_n(Kblock2.begin(), npairs * K_size, 0.0);
 
-                // Loop over ranges of K indices in chuncks of size K_chunk_size
-                for (size_t K_start = 0; K_start < maxK; K_start += K_chunk_size) {
-                    const size_t K_end = std::min(K_start + K_chunk_size, maxK);
-                    // size of the K range, which may be smaller than K_chunk_size
-                    const size_t K_size = K_end - K_start;
-                    const size_t dimKL = K_size * maxL;
-
-                    std::fill_n(Kblock2.begin(), temp_dim, 0.0);
-
-                    for (size_t K = 0; K < K_size; ++K) {
-                        const auto& Krlist =
-                            is_alpha(spin)
-                                ? lists_.get_alpha_2h_list(class_K, K + K_start, class_Ia)
-                                : lists_.get_beta_2h_list(class_K, K + K_start, class_Ib);
+                // D([qs], K) = <K|a_q a_s|I> C(I)
+                // Parallelize over K: each K writes its own column of Kblock2, so no write race.
+                gated_parallel_for_chunked(K_size, [&](size_t kb, size_t ke) {
+                    for (size_t K = kb; K < ke; ++K) {
+                        const auto& Krlist = lists_.get_alpha_2h_list(class_K, K + K_start, class_Ia);
                         for (const auto& [sign_K, q, s, I] : Krlist) {
                             const size_t qs_index = pair_index_gt(q, s);
-                            const double sgn = static_cast<double>(sign_K);
-                            const auto* src = &tr[I * maxL];
-                            auto* dst = &Kblock2_[qs_index * dimKL + K * maxL];
-                            for (size_t idx{0}; idx < maxL; ++idx)
-                                dst[idx] += sgn * src[idx];
+                            Kblock2[qs_index * K_size + K] +=
+                                static_cast<double>(sign_K) * tr[I];
                         }
                     }
+                });
 
-                    matrix_product('N', 'N', npairs, dimKL, npairs, 1.0, v_pr_qs.data(), npairs,
-                                   Kblock2_.data(), dimKL, 0.0, Kblock1_.data(), dimKL);
+                // E([pr], K) = sum_{qs} v([pr],[qs]) D([qs], K)
+                matrix_product('N', 'N', npairs, K_size, npairs, 1.0, v_pr_qs.data(), npairs,
+                               Kblock2.data(), K_size, 0.0, Kblock1.data(), K_size);
 
-                    for (const auto& [nJ, class_Ja, class_Jb] : lists_.determinant_classes()) {
-                        if (((is_alpha(spin) and (class_Ib != class_Jb)) or
-                             (is_beta(spin) and (class_Ia != class_Ja))))
-                            continue;
+                for (const auto& [nJ, class_Ja, class_Jb] : lists_.determinant_classes()) {
+                    if (class_Ib != class_Jb)
+                        continue;
 
-                        std::fill_n(TL.begin(), TL.size(), 0.0);
+                    const size_t maxJ = lists_.alpha_address()->strpcls(class_Ja);
+                    std::fill_n(TL.begin(), TL.size(), 0.0);
+                    // sigma(J) += <J|a^+_p a^+_r|K> E([pr], K). The scatter accumulates into TL(J)
+                    // (a reduction over K), so parallelize over the output string J
+                    // (owner-computes): each thread owns a stripe of J and scans all K, writing
+                    // only rows it owns.
+                    gated_parallel_for_chunked(maxJ, [&](size_t J_begin, size_t J_end) {
                         for (size_t K = 0; K < K_size; ++K) {
                             const auto& Klist =
-                                is_alpha(spin)
-                                    ? lists_.get_alpha_2h_list(class_K, K + K_start, class_Ja)
-                                    : lists_.get_beta_2h_list(class_K, K + K_start, class_Jb);
-                            for (const auto& [sign_K, p, r, I] : Klist) {
+                                lists_.get_alpha_2h_list(class_K, K + K_start, class_Ja);
+                            for (const auto& [sign_K, p, r, J] : Klist) {
+                                // this thread does now own this J
+                                if (J < J_begin || J >= J_end)
+                                    continue;
                                 const size_t pr_index = pair_index_gt(p, r);
-                                const double sgn = static_cast<double>(sign_K);
-                                const auto* src = &Kblock1_[pr_index * dimKL + K * maxL];
-                                auto* dst = &TL[I * maxL];
-                                for (size_t idx{0}; idx < maxL; ++idx)
-                                    dst[idx] += sgn * src[idx];
+                                TL[J] += static_cast<double>(sign_K) * Kblock1[pr_index * K_size + K];
                             }
                         }
-                        scatter_block(TL, sigma, spin, lists_, class_Ja, class_Jb);
-                    }
-                }
-            }
-        }
-    }
-}
-
-void RelCISigmaBuilder::H2_hz_opposite_spin(std::span<std::complex<double>> basis,
-                                            std::span<std::complex<double>> sigma) const {
-    if ((lists_.na() < 1) or (lists_.nb() < 1))
-        return;
-
-    size_t norb = lists_.norb();
-    const auto norb2 = norb * norb;
-
-    const int num_1h_class_Ka = lists_.alpha_address_1h()->nclasses();
-    const int num_1h_class_Kb = lists_.beta_address_1h()->nclasses();
-
-    // loop over blocks of N-2 space
-    for (int class_Ka = 0; class_Ka < num_1h_class_Ka; ++class_Ka) {
-        for (int class_Kb = 0; class_Kb < num_1h_class_Kb; ++class_Kb) {
-            const auto maxKa = lists_.alpha_address_1h()->strpcls(class_Ka);
-            const auto maxKb = lists_.beta_address_1h()->strpcls(class_Kb);
-
-            if ((maxKa == 0) or (maxKb == 0))
-                continue;
-
-            // We gather the block of C into TR
-            const size_t Kb_block_start = 0;
-            const size_t Kb_block_end = maxKb;
-            const size_t Kb_block_size = maxKb;
-
-            auto [Kblock1, Kblock2, Ka_block_size] = get_Kblock_spans(norb2 * maxKb, maxKa);
-
-            for (size_t Ka_block_start = 0; Ka_block_start < maxKa;
-                 Ka_block_start += Ka_block_size) {
-                size_t Ka_block_end = std::min(Ka_block_start + Ka_block_size, maxKa);
-                size_t Ka_block_size = Ka_block_end - Ka_block_start;
-                const auto Kdim = Ka_block_size * Kb_block_size;
-                const auto temp_dim = norb2 * Kdim;
-
-                std::fill_n(Kblock1.begin(), temp_dim, 0.0);
-
-                // D([qs],[Ka Kb]) = \sum_{Ia,Ib} B^{Ka,Kb,Ia,Ib}_{pq} C_{Ia,Ib}
-                for (const auto& [nI, class_Ia, class_Ib] : lists_.determinant_classes()) {
-                    if (lists_.block_size(nI) == 0)
-                        continue;
-                    const auto maxIb = lists_.beta_address()->strpcls(class_Ib);
-                    const auto Cr_offset = lists_.block_offset(nI);
-                    const auto& Ka_right_list = lists_.get_alpha_1h_list2(class_Ka, class_Ia);
-                    const auto& Kb_right_list = lists_.get_beta_1h_list2(class_Kb, class_Ib);
-                    if (Ka_right_list.empty() || Kb_right_list.empty())
-                        continue;
-                    for (size_t Ka = 0; Ka < Ka_block_size; ++Ka) {
-                        const auto& KaL = Ka_right_list[Ka_block_start + Ka];
-                        for (size_t Kb = 0; Kb < Kb_block_size; ++Kb) {
-                            const auto& KbL = Kb_right_list[Kb_block_start + Kb];
-                            const auto Kidx = Ka * Kb_block_size + Kb;
-                            for (const auto& [sign_q, q, Ia] : KaL) {
-                                const size_t qnorb = q * norb;
-                                const size_t b_offset = Cr_offset + Ia * maxIb;
-                                for (const auto& [sign_s, s, Ib] : KbL) {
-                                    const size_t qs_index = qnorb + s;
-                                    Kblock1[qs_index * Kdim + Kidx] =
-                                        static_cast<std::complex<double>>(sign_q * sign_s) *
-                                        basis[b_offset + Ib];
-                                }
-                            }
-                        }
-                    }
-                }
-
-                matrix_product('N', 'N', norb2, Kdim, norb2, 1.0, v_pr_qs.data(), norb2,
-                               Kblock1.data(), Kdim, 0.0, Kblock2.data(), Kdim);
-
-                // D([qs],[Ka Kb]) = \sum_{Ia,Ib} B^{Ka,Kb,Ia,Ib}_{pq} C_{Ia,Ib}
-                for (const auto& [nI, class_Ia, class_Ib] : lists_.determinant_classes()) {
-                    if (lists_.block_size(nI) == 0)
-                        continue;
-                    const auto maxIb = lists_.beta_address()->strpcls(class_Ib);
-                    const auto Cr_offset = lists_.block_offset(nI);
-                    const auto& Ka_right_list = lists_.get_alpha_1h_list2(class_Ka, class_Ia);
-                    const auto& Kb_right_list = lists_.get_beta_1h_list2(class_Kb, class_Ib);
-                    if (Ka_right_list.empty() || Kb_right_list.empty())
-                        continue;
-                    for (size_t Ka = 0; Ka < Ka_block_size; ++Ka) {
-                        const auto& KaL = Ka_right_list[Ka_block_start + Ka];
-                        for (size_t Kb = 0; Kb < Kb_block_size; ++Kb) {
-                            const auto& KbL = Kb_right_list[Kb_block_start + Kb];
-                            const auto Kidx = Ka * Kb_block_size + Kb;
-                            for (const auto& [sign_p, p, Ia] : KaL) {
-                                const size_t pnorb = p * norb;
-                                const size_t s_offset = Cr_offset + Ia * maxIb;
-                                for (const auto& [sign_r, r, Ib] : KbL) {
-                                    const size_t pr_index = pnorb + r;
-                                    sigma[s_offset + Ib] +=
-                                        static_cast<std::complex<double>>(sign_p * sign_r) *
-                                        Kblock2[pr_index * Kdim + Kidx];
-                                }
-                            }
-                        }
-                    }
+                    });
+                    scatter_block(TL, sigma, Spin::Alpha, lists_, class_Ja, class_Jb);
                 }
             }
         }

--- a/forte2/ci/rel_ci_sigma_builder_harrison_zarrabian.cc
+++ b/forte2/ci/rel_ci_sigma_builder_harrison_zarrabian.cc
@@ -105,7 +105,13 @@ void RelCISigmaBuilder::H1_hz(std::span<std::complex<double>> basis,
                                 : lists_.get_beta_1h_list(class_K, K_start + K, class_Ib);
                         // D(q,[K L]) += <K|a_q|I> C(I,L)
                         for (const auto& [sign_K, q, I] : Klist) {
-                            add(maxL, sign_K, &tr[I * maxL], 1, &Kblock2_[q * dimKL + K * maxL], 1);
+                            // Inline the length-maxL axpy (maxL == 1 for two-component CI) to
+                            // avoid a BLAS dispatch per substitution.
+                            const double s = static_cast<double>(sign_K);
+                            const auto* src = &tr[I * maxL];
+                            auto* dst = &Kblock2_[q * dimKL + K * maxL];
+                            for (size_t idx{0}; idx < maxL; ++idx)
+                                dst[idx] += s * src[idx];
                         }
                     }
 
@@ -127,8 +133,11 @@ void RelCISigmaBuilder::H1_hz(std::span<std::complex<double>> basis,
                                     ? lists_.get_alpha_1h_list(class_K, K_start + K, class_Ja)
                                     : lists_.get_beta_1h_list(class_K, K_start + K, class_Jb);
                             for (const auto& [sign_K, p, I] : Klist) {
-                                add(maxL, sign_K, &Kblock1_[p * dimKL + K * maxL], 1, &TL[I * maxL],
-                                    1);
+                                const double s = static_cast<double>(sign_K);
+                                const auto* src = &Kblock1_[p * dimKL + K * maxL];
+                                auto* dst = &TL[I * maxL];
+                                for (size_t idx{0}; idx < maxL; ++idx)
+                                    dst[idx] += s * src[idx];
                             }
                         }
                         scatter_block(TL, sigma, spin, lists_, class_Ja, class_Jb);
@@ -193,8 +202,11 @@ void RelCISigmaBuilder::H2_hz_same_spin(std::span<std::complex<double>> basis,
                                 : lists_.get_beta_2h_list(class_K, K + K_start, class_Ib);
                         for (const auto& [sign_K, q, s, I] : Krlist) {
                             const size_t qs_index = pair_index_gt(q, s);
-                            add(maxL, sign_K, &tr[I * maxL], 1,
-                                &Kblock2_[qs_index * dimKL + K * maxL], 1);
+                            const double sgn = static_cast<double>(sign_K);
+                            const auto* src = &tr[I * maxL];
+                            auto* dst = &Kblock2_[qs_index * dimKL + K * maxL];
+                            for (size_t idx{0}; idx < maxL; ++idx)
+                                dst[idx] += sgn * src[idx];
                         }
                     }
 
@@ -214,8 +226,11 @@ void RelCISigmaBuilder::H2_hz_same_spin(std::span<std::complex<double>> basis,
                                     : lists_.get_beta_2h_list(class_K, K + K_start, class_Jb);
                             for (const auto& [sign_K, p, r, I] : Klist) {
                                 const size_t pr_index = pair_index_gt(p, r);
-                                add(maxL, sign_K, &Kblock1_[pr_index * dimKL + K * maxL], 1,
-                                    &TL[I * maxL], 1);
+                                const double sgn = static_cast<double>(sign_K);
+                                const auto* src = &Kblock1_[pr_index * dimKL + K * maxL];
+                                auto* dst = &TL[I * maxL];
+                                for (size_t idx{0}; idx < maxL; ++idx)
+                                    dst[idx] += sgn * src[idx];
                             }
                         }
                         scatter_block(TL, sigma, spin, lists_, class_Ja, class_Jb);

--- a/forte2/ci/rel_ci_sigma_builder_rdm.cc
+++ b/forte2/ci/rel_ci_sigma_builder_rdm.cc
@@ -97,9 +97,16 @@ np_tensor4_complex RelCISigmaBuilder::compute_2rdm(np_vector_complex C_left,
     int num_2h_classes = is_alpha(spin) ? lists_.alpha_address_2h()->nclasses()
                                         : lists_.beta_address_2h()->nclasses();
 
+    // The contraction gamma[pq,rs] = sum_K sum_idx sign_K sign_L conj(C_L[I,idx]) C_R[J,idx]
+    // can be reformulated into a matrix product over the composite index c = (K, idx)
+    // We gather the (conjugated/signed) left coefficients into B_L[pq, c] and the 
+    // (signed) right coefficients into the transposed B_R[c, rs], then accumulate 
+    // gamma += B_L * B_R via a single zgemm per K-chunk.
     for (int class_K = 0; class_K < num_2h_classes; ++class_K) {
-        size_t maxK = is_alpha(spin) ? lists_.alpha_address_2h()->strpcls(class_K)
-                                     : lists_.beta_address_2h()->strpcls(class_K);
+        const size_t maxK = is_alpha(spin) ? lists_.alpha_address_2h()->strpcls(class_K)
+                                           : lists_.beta_address_2h()->strpcls(class_K);
+        if (maxK == 0)
+            continue;
 
         // loop over blocks of matrix C
         for (const auto& [nI, class_Ia, class_Ib] : lists_.determinant_classes()) {
@@ -107,7 +114,15 @@ np_tensor4_complex RelCISigmaBuilder::compute_2rdm(np_vector_complex C_left,
             if (lists_.block_size(nI) == 0)
                 continue;
 
+            const size_t maxL = is_alpha(spin) ? beta_address->strpcls(class_Ib)
+                                               : alpha_address->strpcls(class_Ia);
+            if (maxL == 0)
+                continue;
+
             auto tl = gather_block(Cl_span, TL, spin, lists_, class_Ia, class_Ib);
+
+            // B_L is npairs x dimKL, B_R^T is dimKL x npairs; both fit in a Kblock buffer.
+            auto [Kblock1, Kblock2, K_chunk_size] = get_Kblock_spans(npairs * maxL, maxK);
 
             for (const auto& [nJ, class_Ja, class_Jb] : lists_.determinant_classes()) {
                 // The string class on which we don't act must be the same for I and J
@@ -117,30 +132,46 @@ np_tensor4_complex RelCISigmaBuilder::compute_2rdm(np_vector_complex C_left,
                 if (lists_.block_size(nJ) == 0)
                     continue;
 
-                const size_t maxL = is_alpha(spin) ? beta_address->strpcls(class_Ib)
-                                                   : alpha_address->strpcls(class_Ia);
-                if (maxL > 0) {
-                    // Get a pointer to the correct block of matrix C
-                    auto tr = gather_block(Cr_span, TR, spin, lists_, class_Ja, class_Jb);
-                    for (size_t K{0}; K < maxK; ++K) {
-                        auto& Kllist = is_alpha(spin)
-                                           ? lists_.get_alpha_2h_list(class_K, K, class_Ia)
-                                           : lists_.get_beta_2h_list(class_K, K, class_Ib);
-                        auto& Krlist = is_alpha(spin)
-                                           ? lists_.get_alpha_2h_list(class_K, K, class_Ja)
-                                           : lists_.get_beta_2h_list(class_K, K, class_Jb);
+                auto tr = gather_block(Cr_span, TR, spin, lists_, class_Ja, class_Jb);
+
+                for (size_t K_start = 0; K_start < maxK; K_start += K_chunk_size) {
+                    const size_t K_end = std::min(K_start + K_chunk_size, maxK);
+                    const size_t K_size = K_end - K_start;
+                    const size_t dimKL = K_size * maxL;
+
+                    // B_L[pq, c] with c = K*maxL + idx, leading dim dimKL
+                    std::fill_n(Kblock1.begin(), npairs * dimKL, 0.0);
+                    // B_R^T[c, rs], leading dim npairs
+                    std::fill_n(Kblock2.begin(), dimKL * npairs, 0.0);
+
+                    for (size_t K = 0; K < K_size; ++K) {
+                        const auto& Kllist =
+                            is_alpha(spin) ? lists_.get_alpha_2h_list(class_K, K_start + K, class_Ia)
+                                           : lists_.get_beta_2h_list(class_K, K_start + K, class_Ib);
+                        const auto& Krlist =
+                            is_alpha(spin) ? lists_.get_alpha_2h_list(class_K, K_start + K, class_Ja)
+                                           : lists_.get_beta_2h_list(class_K, K_start + K, class_Jb);
                         for (const auto& [sign_K, p, q, I] : Kllist) {
                             const size_t pq_index = pair_index_gt(p, q);
-                            for (const auto& [sign_L, r, s, J] : Krlist) {
-                                const size_t rs_index = pair_index_gt(r, s);
-                                const std::complex<double> rdm_element =
-                                    dot(maxL, tl.data() + I * maxL, 1, tr.data() + J * maxL, 1);
-                                rdm_data[pq_index * npairs + rs_index] +=
-                                    static_cast<std::complex<double>>(sign_K * sign_L) *
-                                    rdm_element;
-                            }
+                            const double sgn = static_cast<double>(sign_K);
+                            const auto* src = tl.data() + I * maxL;
+                            auto* dst = Kblock1.data() + pq_index * dimKL + K * maxL;
+                            for (size_t idx{0}; idx < maxL; ++idx)
+                                dst[idx] += sgn * std::conj(src[idx]);
+                        }
+                        for (const auto& [sign_L, r, s, J] : Krlist) {
+                            const size_t rs_index = pair_index_gt(r, s);
+                            const double sgn = static_cast<double>(sign_L);
+                            const auto* src = tr.data() + J * maxL;
+                            auto* dst = Kblock2.data() + (K * maxL) * npairs + rs_index;
+                            for (size_t idx{0}; idx < maxL; ++idx)
+                                dst[idx * npairs] += sgn * src[idx];
                         }
                     }
+
+                    // gamma[pq,rs] += sum_c B_L[pq,c] B_R^T[c,rs]
+                    matrix_product('N', 'N', npairs, npairs, dimKL, 1.0, Kblock1.data(), dimKL,
+                                   Kblock2.data(), npairs, 1.0, rdm_data, npairs);
                 }
             }
         }
@@ -198,16 +229,28 @@ np_tensor6_complex RelCISigmaBuilder::compute_3rdm(np_vector_complex C_left,
     int num_3h_classes = is_alpha(spin) ? lists_.alpha_address_3h()->nclasses()
                                         : lists_.beta_address_3h()->nclasses();
 
+    // Same GEMM reformulation as compute_2rdm, over triplets p>q>r / s>t>u and the 3-hole K
+    // classes: gamma[pqr,stu] += sum_c B_L[pqr,c] B_R^T[c,stu] with c = (K, idx).
     for (int class_K = 0; class_K < num_3h_classes; ++class_K) {
-        size_t maxK = is_alpha(spin) ? lists_.alpha_address_3h()->strpcls(class_K)
-                                     : lists_.beta_address_3h()->strpcls(class_K);
+        const size_t maxK = is_alpha(spin) ? lists_.alpha_address_3h()->strpcls(class_K)
+                                           : lists_.beta_address_3h()->strpcls(class_K);
+        if (maxK == 0)
+            continue;
 
         // loop over blocks of matrix C
         for (const auto& [nI, class_Ia, class_Ib] : lists_.determinant_classes()) {
             if (lists_.block_size(nI) == 0)
                 continue;
 
+            const size_t maxL = is_alpha(spin) ? beta_address->strpcls(class_Ib)
+                                               : alpha_address->strpcls(class_Ia);
+            if (maxL == 0)
+                continue;
+
             auto tl = gather_block(Cl_span, TL, spin, lists_, class_Ia, class_Ib);
+
+            // B_L is ntriplets x dimKL, B_R^T is dimKL x ntriplets.
+            auto [Kblock1, Kblock2, K_chunk_size] = get_Kblock_spans(ntriplets * maxL, maxK);
 
             for (const auto& [nJ, class_Ja, class_Jb] : lists_.determinant_classes()) {
                 // The string class on which we don't act must be the same for I and J
@@ -217,96 +260,99 @@ np_tensor6_complex RelCISigmaBuilder::compute_3rdm(np_vector_complex C_left,
                 if (lists_.block_size(nJ) == 0)
                     continue;
 
-                const size_t maxL = is_alpha(spin) ? beta_address->strpcls(class_Ib)
-                                                   : alpha_address->strpcls(class_Ia);
+                auto tr = gather_block(Cr_span, TR, spin, lists_, class_Ja, class_Jb);
 
-                if (maxL > 0) {
-                    // Get a pointer to the correct block of matrix C
-                    auto tr = gather_block(Cr_span, TR, spin, lists_, class_Ja, class_Jb);
+                for (size_t K_start = 0; K_start < maxK; K_start += K_chunk_size) {
+                    const size_t K_end = std::min(K_start + K_chunk_size, maxK);
+                    const size_t K_size = K_end - K_start;
+                    const size_t dimKL = K_size * maxL;
 
-                    for (size_t K{0}; K < maxK; ++K) {
-                        auto& Kllist = is_alpha(spin)
-                                           ? lists_.get_alpha_3h_list(class_K, K, class_Ia)
-                                           : lists_.get_beta_3h_list(class_K, K, class_Ib);
-                        auto& Krlist = is_alpha(spin)
-                                           ? lists_.get_alpha_3h_list(class_K, K, class_Ja)
-                                           : lists_.get_beta_3h_list(class_K, K, class_Jb);
+                    std::fill_n(Kblock1.begin(), ntriplets * dimKL, 0.0);
+                    std::fill_n(Kblock2.begin(), dimKL * ntriplets, 0.0);
+
+                    for (size_t K = 0; K < K_size; ++K) {
+                        const auto& Kllist =
+                            is_alpha(spin) ? lists_.get_alpha_3h_list(class_K, K_start + K, class_Ia)
+                                           : lists_.get_beta_3h_list(class_K, K_start + K, class_Ib);
+                        const auto& Krlist =
+                            is_alpha(spin) ? lists_.get_alpha_3h_list(class_K, K_start + K, class_Ja)
+                                           : lists_.get_beta_3h_list(class_K, K_start + K, class_Jb);
                         for (const auto& [sign_K, p, q, r, I] : Kllist) {
                             const size_t pqr_index = triplet_index_gt(p, q, r);
-                            for (const auto& [sign_L, s, t, u, J] : Krlist) {
-                                const size_t stu_index = triplet_index_gt(s, t, u);
-                                const std::complex<double> rdm_element =
-                                    dot(maxL, tl.data() + I * maxL, 1, tr.data() + J * maxL, 1);
-                                rdm_data[pqr_index * ntriplets + stu_index] +=
-                                    static_cast<std::complex<double>>(sign_K * sign_L) *
-                                    rdm_element;
-                            }
+                            const double sgn = static_cast<double>(sign_K);
+                            const auto* src = tl.data() + I * maxL;
+                            auto* dst = Kblock1.data() + pqr_index * dimKL + K * maxL;
+                            for (size_t idx{0}; idx < maxL; ++idx)
+                                dst[idx] += sgn * std::conj(src[idx]);
+                        }
+                        for (const auto& [sign_L, s, t, u, J] : Krlist) {
+                            const size_t stu_index = triplet_index_gt(s, t, u);
+                            const double sgn = static_cast<double>(sign_L);
+                            const auto* src = tr.data() + J * maxL;
+                            auto* dst = Kblock2.data() + (K * maxL) * ntriplets + stu_index;
+                            for (size_t idx{0}; idx < maxL; ++idx)
+                                dst[idx * ntriplets] += sgn * src[idx];
                         }
                     }
+
+                    matrix_product('N', 'N', ntriplets, ntriplets, dimKL, 1.0, Kblock1.data(),
+                                   dimKL, Kblock2.data(), ntriplets, 1.0, rdm_data, ntriplets);
                 }
             }
         }
     }
 
-    auto rdm_v = rdm.view();
     auto rdm_full =
         make_zeros<nb::numpy, std::complex<double>, 6>({norb, norb, norb, norb, norb, norb});
-    auto rdm_full_v = rdm_full.view();
+
+    // Expand the unique packed 3-RDM gamma[p>q>r, s>t>u] into the full antisymmetric tensor.
+    // For a fixed bra triplet the entire (s,t,u) sub-block is identical up to the bra-permutation
+    // sign, so we assemble that norb^3 "ket block" once in a small buffer and then
+    // write each of the 6 bra permutations as a signed copy.
+    const auto* rdm_data_packed = rdm.data();
+    auto* full_data = rdm_full.data();
+    const size_t N3 = norb * norb * norb;
+
+    // Zero-initialized once: positions with non-distinct (s,t,u) are never written and stay zero
+    // across all bra iterations; the distinct positions are fully overwritten each iteration.
+    std::vector<std::complex<double>> ketrow(N3, 0.0);
+
+    auto write_block = [&](bool positive, size_t a, size_t b, size_t c) {
+        auto* dst = full_data + ((a * norb + b) * norb + c) * N3;
+        if (positive) {
+            for (size_t i = 0; i < N3; ++i)
+                dst[i] = ketrow[i];
+        } else {
+            for (size_t i = 0; i < N3; ++i)
+                dst[i] = -ketrow[i];
+        }
+    };
+
     for (size_t p{2}, pqr{0}; p < norb; ++p) {
         for (size_t q{1}; q < p; ++q) {
             for (size_t r{0}; r < q; ++r, ++pqr) {
+                const auto* row = rdm_data_packed + pqr * ntriplets;
+                // Scatter the ket triplets into the (d,e,f) block with antisymmetric signs.
                 for (size_t s{2}, stu{0}; s < norb; ++s) {
                     for (size_t t{1}; t < s; ++t) {
                         for (size_t u{0}; u < t; ++u, ++stu) {
-                            // grab the unique element of the 3-RDM
-                            const auto el = rdm_v(pqr, stu);
-
-                            // Place the element in all valid 36 antisymmetric index
-                            // permutations
-                            rdm_full_v(p, q, r, s, t, u) = +el;
-                            rdm_full_v(p, q, r, s, u, t) = -el;
-                            rdm_full_v(p, q, r, u, s, t) = +el;
-                            rdm_full_v(p, q, r, u, t, s) = -el;
-                            rdm_full_v(p, q, r, t, u, s) = +el;
-                            rdm_full_v(p, q, r, t, s, u) = -el;
-
-                            rdm_full_v(p, r, q, s, t, u) = -el;
-                            rdm_full_v(p, r, q, s, u, t) = +el;
-                            rdm_full_v(p, r, q, u, s, t) = -el;
-                            rdm_full_v(p, r, q, u, t, s) = +el;
-                            rdm_full_v(p, r, q, t, u, s) = -el;
-                            rdm_full_v(p, r, q, t, s, u) = +el;
-
-                            rdm_full_v(r, p, q, s, t, u) = +el;
-                            rdm_full_v(r, p, q, s, u, t) = -el;
-                            rdm_full_v(r, p, q, u, s, t) = +el;
-                            rdm_full_v(r, p, q, u, t, s) = -el;
-                            rdm_full_v(r, p, q, t, u, s) = +el;
-                            rdm_full_v(r, p, q, t, s, u) = -el;
-
-                            rdm_full_v(r, q, p, s, t, u) = -el;
-                            rdm_full_v(r, q, p, s, u, t) = +el;
-                            rdm_full_v(r, q, p, u, s, t) = -el;
-                            rdm_full_v(r, q, p, u, t, s) = +el;
-                            rdm_full_v(r, q, p, t, u, s) = -el;
-                            rdm_full_v(r, q, p, t, s, u) = +el;
-
-                            rdm_full_v(q, r, p, s, t, u) = +el;
-                            rdm_full_v(q, r, p, s, u, t) = -el;
-                            rdm_full_v(q, r, p, u, s, t) = +el;
-                            rdm_full_v(q, r, p, u, t, s) = -el;
-                            rdm_full_v(q, r, p, t, u, s) = +el;
-                            rdm_full_v(q, r, p, t, s, u) = -el;
-
-                            rdm_full_v(q, p, r, s, t, u) = -el;
-                            rdm_full_v(q, p, r, s, u, t) = +el;
-                            rdm_full_v(q, p, r, u, s, t) = -el;
-                            rdm_full_v(q, p, r, u, t, s) = +el;
-                            rdm_full_v(q, p, r, t, u, s) = -el;
-                            rdm_full_v(q, p, r, t, s, u) = +el;
+                            const auto el = row[stu];
+                            ketrow[(s * norb + t) * norb + u] = +el;
+                            ketrow[(s * norb + u) * norb + t] = -el;
+                            ketrow[(u * norb + s) * norb + t] = +el;
+                            ketrow[(u * norb + t) * norb + s] = -el;
+                            ketrow[(t * norb + u) * norb + s] = +el;
+                            ketrow[(t * norb + s) * norb + u] = -el;
                         }
                     }
                 }
+                // Write the 6 bra permutations as contiguous streaming signed copies.
+                write_block(true, p, q, r);
+                write_block(false, p, r, q);
+                write_block(true, r, p, q);
+                write_block(false, r, q, p);
+                write_block(true, q, r, p);
+                write_block(false, q, p, r);
             }
         }
     }


### PR DESCRIPTION
1. Inline the axpy in the Hamiltonian functions removing a BLAS call per string substitution in the sigma build.
2. Reformulate 2/3rdm as a GEMMs
3. Optimize the unpacking of 3-rdms

Measured speedups (random Hermitian integrals; results bit-for-bit identical):
  14e/7o  Hamiltonian  12.4ms -> 6.5ms   (1.9x)
  14e/7o  so_2rdm      66.5ms -> 4.5ms   (14.7x)
  14e/7o  so_3rdm     516.8ms -> 133.3ms (3.9x)