### PR TITLE
perf(ci): optimize sigma build and rdm performance

### DIFF
--- a/forte2/ci/ci_sigma_builder_2rdm.cc
+++ b/forte2/ci/ci_sigma_builder_2rdm.cc
@@ -122,13 +122,10 @@ np_tensor4 CISigmaBuilder::compute_ab_2rdm(np_vector C_left, np_vector C_right) 
     const int num_1h_class_Kb = lists_.beta_address_1h()->nclasses();
 
     // The contraction gamma[uv,xy] = sum_{Ka,Kb} (sign_u sign_v Cl[Ja,Jb]) (sign_x sign_y Cr[Ia,Ib])
-    // is a matrix product over the composite one-hole index K = (Ka, Kb): for a fixed K the creation
-    // maps (u,v) -> (Ja,Jb) and (x,y) -> (Ia,Ib) are bijections, so we gather the (signed) left
-    // coefficients into B_L[(u*norb+v), K] and the (signed) right coefficients into
-    // B_R[(x*norb+y), K], then accumulate gamma[(uv),(xy)] += B_L * B_R^T with one zgemm per
-    // Ka-chunk. This mirrors the already-GEMM'd opposite-spin sigma build (H2_hz_opposite_spin) and
-    // replaces the latency-bound 4-deep rank-1 scatter with a single BLAS-3 call. The (uv)/(xy)
-    // ordering matches the row-major layout of rdm[u,v,x,y], so no repacking is needed.
+    // is a matrix product over the composite one-hole index K = (Ka, Kb)
+    // we can gather the (signed) left coefficients into B_L[(u*norb+v), K] and 
+    // the (signed) right coefficients into B_R[(x*norb+y), K], then accumulate gamma[(uv),(xy)] += B_L * B_R^T 
+    // with one zgemm per Ka-chunk
     for (int class_Ka = 0; class_Ka < num_1h_class_Ka; ++class_Ka) {
         const auto maxKa = lists_.alpha_address_1h()->strpcls(class_Ka);
         for (int class_Kb = 0; class_Kb < num_1h_class_Kb; ++class_Kb) {

--- a/forte2/ci/ci_sigma_builder_2rdm.cc
+++ b/forte2/ci/ci_sigma_builder_2rdm.cc
@@ -113,11 +113,6 @@ np_tensor4 CISigmaBuilder::compute_ab_2rdm(np_vector C_left, np_vector C_right) 
         return rdm;
     }
 
-    // Create a lambda to compute the index in the 4D tensor
-    auto index = [norb, norb2, norb3](size_t p, size_t q, size_t r, size_t s) {
-        return p * norb3 + q * norb2 + r * norb + s;
-    };
-
     auto rdm_data = rdm.data();
 
     auto Cl_span = vector::as_span<double>(C_left);
@@ -126,47 +121,92 @@ np_tensor4 CISigmaBuilder::compute_ab_2rdm(np_vector C_left, np_vector C_right) 
     const int num_1h_class_Ka = lists_.alpha_address_1h()->nclasses();
     const int num_1h_class_Kb = lists_.beta_address_1h()->nclasses();
 
+    // The contraction gamma[uv,xy] = sum_{Ka,Kb} (sign_u sign_v Cl[Ja,Jb]) (sign_x sign_y Cr[Ia,Ib])
+    // is a matrix product over the composite one-hole index K = (Ka, Kb): for a fixed K the creation
+    // maps (u,v) -> (Ja,Jb) and (x,y) -> (Ia,Ib) are bijections, so we gather the (signed) left
+    // coefficients into B_L[(u*norb+v), K] and the (signed) right coefficients into
+    // B_R[(x*norb+y), K], then accumulate gamma[(uv),(xy)] += B_L * B_R^T with one zgemm per
+    // Ka-chunk. This mirrors the already-GEMM'd opposite-spin sigma build (H2_hz_opposite_spin) and
+    // replaces the latency-bound 4-deep rank-1 scatter with a single BLAS-3 call. The (uv)/(xy)
+    // ordering matches the row-major layout of rdm[u,v,x,y], so no repacking is needed.
     for (int class_Ka = 0; class_Ka < num_1h_class_Ka; ++class_Ka) {
         const auto maxKa = lists_.alpha_address_1h()->strpcls(class_Ka);
         for (int class_Kb = 0; class_Kb < num_1h_class_Kb; ++class_Kb) {
             const auto maxKb = lists_.beta_address_1h()->strpcls(class_Kb);
-            // loop over blocks of matrix C
-            for (const auto& [nI, class_Ia, class_Ib] : lists_.determinant_classes()) {
-                if (lists_.block_size(nI) == 0)
-                    continue;
+            if ((maxKa == 0) or (maxKb == 0))
+                continue;
 
-                const auto maxIb = lists_.beta_address()->strpcls(class_Ib);
-                const auto Cr_offset = lists_.block_offset(nI);
+            // B_L and B_R are each norb^2 x Kdim; both fit in a Kblock buffer.
+            auto [Kblock1, Kblock2, Ka_block_size] = get_Kblock_spans(norb2 * maxKb, maxKa);
 
-                for (const auto& [nJ, class_Ja, class_Jb] : lists_.determinant_classes()) {
-                    if (lists_.block_size(nJ) == 0)
+            for (size_t Ka_block_start = 0; Ka_block_start < maxKa;
+                 Ka_block_start += Ka_block_size) {
+                const size_t Ka_block_end = std::min(Ka_block_start + Ka_block_size, maxKa);
+                const size_t Ka_size = Ka_block_end - Ka_block_start;
+                const size_t Kdim = Ka_size * maxKb;
+                const auto temp_dim = norb2 * Kdim;
+
+                // B_L[uv, K] in Kblock1, B_R[xy, K] in Kblock2
+                std::fill_n(Kblock1.begin(), temp_dim, 0.0);
+                std::fill_n(Kblock2.begin(), temp_dim, 0.0);
+
+                // Gather the (signed) right coefficients into B_R[(x*norb+y), K]
+                for (const auto& [nI, class_Ia, class_Ib] : lists_.determinant_classes()) {
+                    if (lists_.block_size(nI) == 0)
                         continue;
-
-                    const auto maxJb = lists_.beta_address()->strpcls(class_Jb);
-                    const auto Cl_offset = lists_.block_offset(nJ);
-
-                    for (size_t Ka = 0; Ka < maxKa; ++Ka) {
-                        auto& Ka_right_list = lists_.get_alpha_1h_list(class_Ka, Ka, class_Ia);
-                        auto& Ka_left_list = lists_.get_alpha_1h_list(class_Ka, Ka, class_Ja);
+                    const auto maxIb = lists_.beta_address()->strpcls(class_Ib);
+                    const auto Cr_offset = lists_.block_offset(nI);
+                    const auto& Ka_right_list = lists_.get_alpha_1h_list2(class_Ka, class_Ia);
+                    const auto& Kb_right_list = lists_.get_beta_1h_list2(class_Kb, class_Ib);
+                    if (Ka_right_list.empty() || Kb_right_list.empty())
+                        continue;
+                    for (size_t Ka = 0; Ka < Ka_size; ++Ka) {
+                        const auto& KaR = Ka_right_list[Ka_block_start + Ka];
                         for (size_t Kb = 0; Kb < maxKb; ++Kb) {
-                            auto& Kb_right_list = lists_.get_beta_1h_list(class_Kb, Kb, class_Ib);
-                            auto& Kb_left_list = lists_.get_beta_1h_list(class_Kb, Kb, class_Jb);
-                            for (const auto& [sign_u, u, Ja] : Ka_left_list) {
-                                for (const auto& [sign_v, v, Jb] : Kb_left_list) {
-                                    const auto ClJ =
-                                        sign_u * sign_v * Cl_span[Cl_offset + Ja * maxJb + Jb];
-                                    for (const auto& [sign_x, x, Ia] : Ka_right_list) {
-                                        const auto Cr_Ia_offset = Cr_offset + Ia * maxIb;
-                                        for (const auto& [sign_y, y, Ib] : Kb_right_list) {
-                                            rdm_data[index(u, v, x, y)] +=
-                                                sign_x * sign_y * ClJ * Cr_span[Cr_Ia_offset + Ib];
-                                        }
-                                    }
+                            const auto& KbR = Kb_right_list[Kb];
+                            const auto Kidx = Ka * maxKb + Kb;
+                            for (const auto& [sign_x, x, Ia] : KaR) {
+                                const size_t xnorb = x * norb;
+                                const auto Cr_Ia_offset = Cr_offset + Ia * maxIb;
+                                for (const auto& [sign_y, y, Ib] : KbR) {
+                                    Kblock2[(xnorb + y) * Kdim + Kidx] =
+                                        sign_x * sign_y * Cr_span[Cr_Ia_offset + Ib];
                                 }
                             }
                         }
                     }
                 }
+
+                // Gather the (signed) left coefficients into B_L[(u*norb+v), K]
+                for (const auto& [nJ, class_Ja, class_Jb] : lists_.determinant_classes()) {
+                    if (lists_.block_size(nJ) == 0)
+                        continue;
+                    const auto maxJb = lists_.beta_address()->strpcls(class_Jb);
+                    const auto Cl_offset = lists_.block_offset(nJ);
+                    const auto& Ka_left_list = lists_.get_alpha_1h_list2(class_Ka, class_Ja);
+                    const auto& Kb_left_list = lists_.get_beta_1h_list2(class_Kb, class_Jb);
+                    if (Ka_left_list.empty() || Kb_left_list.empty())
+                        continue;
+                    for (size_t Ka = 0; Ka < Ka_size; ++Ka) {
+                        const auto& KaL = Ka_left_list[Ka_block_start + Ka];
+                        for (size_t Kb = 0; Kb < maxKb; ++Kb) {
+                            const auto& KbL = Kb_left_list[Kb];
+                            const auto Kidx = Ka * maxKb + Kb;
+                            for (const auto& [sign_u, u, Ja] : KaL) {
+                                const size_t unorb = u * norb;
+                                const auto Cl_Ja_offset = Cl_offset + Ja * maxJb;
+                                for (const auto& [sign_v, v, Jb] : KbL) {
+                                    Kblock1[(unorb + v) * Kdim + Kidx] =
+                                        sign_u * sign_v * Cl_span[Cl_Ja_offset + Jb];
+                                }
+                            }
+                        }
+                    }
+                }
+
+                // gamma[uv,xy] += sum_K B_L[uv,K] B_R[xy,K]
+                matrix_product('N', 'T', norb2, norb2, Kdim, 1.0, Kblock1.data(), Kdim,
+                               Kblock2.data(), Kdim, 1.0, rdm_data, norb2);
             }
         }
     }

--- a/forte2/ci/ci_sigma_builder_3rdm.cc
+++ b/forte2/ci/ci_sigma_builder_3rdm.cc
@@ -112,14 +112,6 @@ np_tensor4 CISigmaBuilder::compute_aab_3rdm(np_vector C_left, np_vector C_right)
 
     auto rdm = make_zeros<nb::numpy, double, 4>({npair, norb, npair, norb});
 
-    auto stride1 = norb;
-    auto stride2 = stride1 * npair;
-    auto stride3 = stride2 * norb;
-
-    auto index = [stride1, stride2, stride3](size_t pq, size_t r, size_t st, size_t u) {
-        return pq * stride3 + r * stride2 + st * stride1 + u;
-    };
-
     // skip building the RDM if there are not enough electrons
     if ((na < 2) or (nb < 1))
         return rdm;
@@ -128,57 +120,100 @@ np_tensor4 CISigmaBuilder::compute_aab_3rdm(np_vector C_left, np_vector C_right)
     auto Cr_span = vector::as_span<double>(C_right);
 
     auto rdm_data = rdm.data();
-    const auto& alpha_address = lists_.alpha_address();
-    const auto& beta_address = lists_.beta_address();
 
     int num_2h_class_Ka = lists_.alpha_address_2h()->nclasses();
     int num_1h_class_Kb = lists_.beta_address_1h()->nclasses();
 
+    // GEMM reformulation, identical in spirit to compute_ab_2rdm: the contraction
+    // gamma[(uv,w),(xy,z)] = sum_{Ka,Kb} (sign_uv sign_w Cl) (sign_xy sign_z Cr) is a matrix
+    // product over the composite hole index K = (Ka, Kb) (Ka: 2-hole alpha, Kb: 1-hole beta).
+    // Gather signed left/right coefficients into B_L[(uv*norb+w), K] and B_R[(xy*norb+z), K], then
+    // gamma[row,col] += B_L * B_R^T with one dgemm per Ka-chunk. Row = uv*norb+w, col = xy*norb+z,
+    // both of dimension M = npair*norb, which matches the row-major layout of rdm[uv,w,xy,z], so no
+    // repack is needed. The alpha 2-hole side has no all-K list accessor, so it uses the per-K
+    // accessor (fetched once per hole index, fewer calls than the old cross-block loop).
+    const size_t M = npair * norb;
     for (int class_Ka{0}; class_Ka < num_2h_class_Ka; ++class_Ka) {
-        size_t maxKa = lists_.alpha_address_2h()->strpcls(class_Ka);
-
+        const size_t maxKa = lists_.alpha_address_2h()->strpcls(class_Ka);
         for (int class_Kb{0}; class_Kb < num_1h_class_Kb; ++class_Kb) {
-            size_t maxKb = lists_.beta_address_1h()->strpcls(class_Kb);
+            const size_t maxKb = lists_.beta_address_1h()->strpcls(class_Kb);
+            if ((maxKa == 0) or (maxKb == 0))
+                continue;
 
-            // loop over blocks of matrix C
-            for (const auto& [nI, class_Ia, class_Ib] : lists_.determinant_classes()) {
-                if (lists_.block_size(nI) == 0)
-                    continue;
+            auto [Kblock1, Kblock2, Ka_block_size] = get_Kblock_spans(M * maxKb, maxKa);
 
-                const auto maxIb = lists_.beta_address()->strpcls(class_Ib);
-                const auto Cr_offset = lists_.block_offset(nI);
+            for (size_t Ka_block_start = 0; Ka_block_start < maxKa;
+                 Ka_block_start += Ka_block_size) {
+                const size_t Ka_block_end = std::min(Ka_block_start + Ka_block_size, maxKa);
+                const size_t Ka_size = Ka_block_end - Ka_block_start;
+                const size_t Kdim = Ka_size * maxKb;
+                const auto temp_dim = M * Kdim;
 
-                for (const auto& [nJ, class_Ja, class_Jb] : lists_.determinant_classes()) {
-                    if (lists_.block_size(nJ) == 0)
+                std::fill_n(Kblock1.begin(), temp_dim, 0.0);
+                std::fill_n(Kblock2.begin(), temp_dim, 0.0);
+
+                // Gather the (signed) right coefficients into B_R[(xy*norb+z), K]
+                for (const auto& [nI, class_Ia, class_Ib] : lists_.determinant_classes()) {
+                    if (lists_.block_size(nI) == 0)
                         continue;
-
-                    const auto maxJb = lists_.beta_address()->strpcls(class_Jb);
-                    const auto Cl_offset = lists_.block_offset(nJ);
-
-                    for (size_t Ka = 0; Ka < maxKa; ++Ka) {
-                        auto& Ka_right_list = lists_.get_alpha_2h_list(class_Ka, Ka, class_Ia);
-                        auto& Ka_left_list = lists_.get_alpha_2h_list(class_Ka, Ka, class_Ja);
+                    const auto maxIb = lists_.beta_address()->strpcls(class_Ib);
+                    const auto Cr_offset = lists_.block_offset(nI);
+                    const auto& Kb_right_list = lists_.get_beta_1h_list2(class_Kb, class_Ib);
+                    if (Kb_right_list.empty())
+                        continue;
+                    for (size_t Ka = 0; Ka < Ka_size; ++Ka) {
+                        const auto& Ka_right_list =
+                            lists_.get_alpha_2h_list(class_Ka, Ka_block_start + Ka, class_Ia);
+                        if (Ka_right_list.empty())
+                            continue;
                         for (size_t Kb = 0; Kb < maxKb; ++Kb) {
-                            auto& Kb_right_list = lists_.get_beta_1h_list(class_Kb, Kb, class_Ib);
-                            auto& Kb_left_list = lists_.get_beta_1h_list(class_Kb, Kb, class_Jb);
-                            for (const auto& [sign_uv, u, v, Ja] : Ka_left_list) {
-                                const auto uv_index = pair_index_gt(u, v);
-                                for (const auto& [sign_w, w, Jb] : Kb_left_list) {
-                                    const auto ClJ =
-                                        sign_uv * sign_w * Cl_span[Cl_offset + Ja * maxJb + Jb];
-                                    for (const auto& [sign_xy, x, y, Ia] : Ka_right_list) {
-                                        const auto xy_index = pair_index_gt(x, y);
-                                        const auto Cr_Ia_offset = Cr_offset + Ia * maxIb;
-                                        for (const auto& [sign_z, z, Ib] : Kb_right_list) {
-                                            rdm_data[index(uv_index, w, xy_index, z)] +=
-                                                sign_xy * sign_z * ClJ * Cr_span[Cr_Ia_offset + Ib];
-                                        }
-                                    }
+                            const auto& KbR = Kb_right_list[Kb];
+                            const auto Kidx = Ka * maxKb + Kb;
+                            for (const auto& [sign_xy, x, y, Ia] : Ka_right_list) {
+                                const auto xy_index = pair_index_gt<size_t>(x, y);
+                                const size_t row_xy = xy_index * norb;
+                                const auto Cr_Ia_offset = Cr_offset + Ia * maxIb;
+                                for (const auto& [sign_z, z, Ib] : KbR) {
+                                    Kblock2[(row_xy + z) * Kdim + Kidx] =
+                                        sign_xy * sign_z * Cr_span[Cr_Ia_offset + Ib];
                                 }
                             }
                         }
                     }
                 }
+
+                // Gather the (signed) left coefficients into B_L[(uv*norb+w), K]
+                for (const auto& [nJ, class_Ja, class_Jb] : lists_.determinant_classes()) {
+                    if (lists_.block_size(nJ) == 0)
+                        continue;
+                    const auto maxJb = lists_.beta_address()->strpcls(class_Jb);
+                    const auto Cl_offset = lists_.block_offset(nJ);
+                    const auto& Kb_left_list = lists_.get_beta_1h_list2(class_Kb, class_Jb);
+                    if (Kb_left_list.empty())
+                        continue;
+                    for (size_t Ka = 0; Ka < Ka_size; ++Ka) {
+                        const auto& Ka_left_list =
+                            lists_.get_alpha_2h_list(class_Ka, Ka_block_start + Ka, class_Ja);
+                        if (Ka_left_list.empty())
+                            continue;
+                        for (size_t Kb = 0; Kb < maxKb; ++Kb) {
+                            const auto& KbL = Kb_left_list[Kb];
+                            const auto Kidx = Ka * maxKb + Kb;
+                            for (const auto& [sign_uv, u, v, Ja] : Ka_left_list) {
+                                const auto uv_index = pair_index_gt<size_t>(u, v);
+                                const size_t row_uv = uv_index * norb;
+                                const auto Cl_Ja_offset = Cl_offset + Ja * maxJb;
+                                for (const auto& [sign_w, w, Jb] : KbL) {
+                                    Kblock1[(row_uv + w) * Kdim + Kidx] =
+                                        sign_uv * sign_w * Cl_span[Cl_Ja_offset + Jb];
+                                }
+                            }
+                        }
+                    }
+                }
+
+                matrix_product('N', 'T', M, M, Kdim, 1.0, Kblock1.data(), Kdim, Kblock2.data(), Kdim,
+                               1.0, rdm_data, M);
             }
         }
     }
@@ -201,14 +236,6 @@ np_tensor4 CISigmaBuilder::compute_abb_3rdm(np_vector C_left, np_vector C_right)
 
     auto rdm = make_zeros<nb::numpy, double, 4>({norb, npair, norb, npair});
 
-    auto stride1 = npair;
-    auto stride2 = stride1 * norb;
-    auto stride3 = stride2 * npair;
-
-    auto index = [stride1, stride2, stride3](size_t p, size_t qr, size_t s, size_t tu) {
-        return p * stride3 + qr * stride2 + s * stride1 + tu;
-    };
-
     // skip building the RDM if there are not enough electrons
     if ((na < 1) or (nb < 2))
         return rdm;
@@ -217,57 +244,101 @@ np_tensor4 CISigmaBuilder::compute_abb_3rdm(np_vector C_left, np_vector C_right)
     auto Cr_span = vector::as_span<double>(C_right);
 
     auto rdm_data = rdm.data();
-    const auto& alpha_address = lists_.alpha_address();
-    const auto& beta_address = lists_.beta_address();
 
     int num_1h_class_Ka = lists_.alpha_address_1h()->nclasses();
     int num_2h_class_Kb = lists_.beta_address_2h()->nclasses();
 
+    // GEMM reformulation, mirroring compute_aab_3rdm with the spins swapped: the composite hole
+    // index is K = (Ka, Kb) (Ka: 1-hole alpha, Kb: 2-hole beta). Gather signed left/right
+    // coefficients into B_L[(u*npair+vw), K] and B_R[(x*npair+yz), K], then gamma[row,col] +=
+    // B_L * B_R^T with one dgemm per Ka-chunk. Row = u*npair+vw, col = x*npair+yz, both of
+    // dimension M = norb*npair, matching the row-major layout of rdm[u,vw,x,yz], so no repack. The
+    // beta 2-hole side has no all-K list accessor, so it uses the per-K accessor.
+    const size_t M = norb * npair;
     for (int class_Ka = 0; class_Ka < num_1h_class_Ka; ++class_Ka) {
-        size_t maxKa = lists_.alpha_address_1h()->strpcls(class_Ka);
-
+        const size_t maxKa = lists_.alpha_address_1h()->strpcls(class_Ka);
         for (int class_Kb = 0; class_Kb < num_2h_class_Kb; ++class_Kb) {
-            size_t maxKb = lists_.beta_address_2h()->strpcls(class_Kb);
+            const size_t maxKb = lists_.beta_address_2h()->strpcls(class_Kb);
+            if ((maxKa == 0) or (maxKb == 0))
+                continue;
 
-            // loop over blocks of matrix C
-            for (const auto& [nI, class_Ia, class_Ib] : lists_.determinant_classes()) {
-                if (lists_.block_size(nI) == 0)
-                    continue;
+            auto [Kblock1, Kblock2, Ka_block_size] = get_Kblock_spans(M * maxKb, maxKa);
 
-                const auto maxIb = lists_.beta_address()->strpcls(class_Ib);
-                const auto Cr_offset = lists_.block_offset(nI);
+            for (size_t Ka_block_start = 0; Ka_block_start < maxKa;
+                 Ka_block_start += Ka_block_size) {
+                const size_t Ka_block_end = std::min(Ka_block_start + Ka_block_size, maxKa);
+                const size_t Ka_size = Ka_block_end - Ka_block_start;
+                const size_t Kdim = Ka_size * maxKb;
+                const auto temp_dim = M * Kdim;
 
-                for (const auto& [nJ, class_Ja, class_Jb] : lists_.determinant_classes()) {
-                    if (lists_.block_size(nJ) == 0)
+                std::fill_n(Kblock1.begin(), temp_dim, 0.0);
+                std::fill_n(Kblock2.begin(), temp_dim, 0.0);
+
+                // Gather the (signed) right coefficients into B_R[(x*npair+yz), K]
+                for (const auto& [nI, class_Ia, class_Ib] : lists_.determinant_classes()) {
+                    if (lists_.block_size(nI) == 0)
                         continue;
-
-                    const auto maxJb = lists_.beta_address()->strpcls(class_Jb);
-                    const auto Cl_offset = lists_.block_offset(nJ);
-
-                    for (size_t Ka = 0; Ka < maxKa; ++Ka) {
-                        auto& Ka_right_list = lists_.get_alpha_1h_list(class_Ka, Ka, class_Ia);
-                        auto& Ka_left_list = lists_.get_alpha_1h_list(class_Ka, Ka, class_Ja);
-                        for (size_t Kb = 0; Kb < maxKb; ++Kb) {
-                            auto& Kb_right_list = lists_.get_beta_2h_list(class_Kb, Kb, class_Ib);
-                            auto& Kb_left_list = lists_.get_beta_2h_list(class_Kb, Kb, class_Jb);
-                            for (const auto& [sign_u, u, Ja] : Ka_left_list) {
-                                for (const auto& [sign_vw, v, w, Jb] : Kb_left_list) {
-                                    const auto vw_index = pair_index_gt(v, w);
-                                    const auto ClJ =
-                                        sign_u * sign_vw * Cl_span[Cl_offset + Ja * maxJb + Jb];
-                                    for (const auto& [sign_x, x, Ia] : Ka_right_list) {
-                                        const auto Cr_Ia_offset = Cr_offset + Ia * maxIb;
-                                        for (const auto& [sign_yz, y, z, Ib] : Kb_right_list) {
-                                            const auto yz_index = pair_index_gt(y, z);
-                                            rdm_data[index(u, vw_index, x, yz_index)] +=
-                                                sign_x * sign_yz * ClJ * Cr_span[Cr_Ia_offset + Ib];
-                                        }
-                                    }
+                    const auto maxIb = lists_.beta_address()->strpcls(class_Ib);
+                    const auto Cr_offset = lists_.block_offset(nI);
+                    const auto& Ka_right_list = lists_.get_alpha_1h_list2(class_Ka, class_Ia);
+                    if (Ka_right_list.empty())
+                        continue;
+                    for (size_t Kb = 0; Kb < maxKb; ++Kb) {
+                        const auto& Kb_right_list =
+                            lists_.get_beta_2h_list(class_Kb, Kb, class_Ib);
+                        if (Kb_right_list.empty())
+                            continue;
+                        // Kidx makes the inner (Ka) loop contiguous so repeated writes to a fixed
+                        // row hit adjacent columns; the mapping is arbitrary but must match B_L.
+                        const auto Kbase = Kb * Ka_size;
+                        for (size_t Ka = 0; Ka < Ka_size; ++Ka) {
+                            const auto& KaR = Ka_right_list[Ka_block_start + Ka];
+                            const auto Kidx = Kbase + Ka;
+                            for (const auto& [sign_x, x, Ia] : KaR) {
+                                const size_t row_x = x * npair;
+                                const auto Cr_Ia_offset = Cr_offset + Ia * maxIb;
+                                for (const auto& [sign_yz, y, z, Ib] : Kb_right_list) {
+                                    const auto yz_index = pair_index_gt<size_t>(y, z);
+                                    Kblock2[(row_x + yz_index) * Kdim + Kidx] =
+                                        sign_x * sign_yz * Cr_span[Cr_Ia_offset + Ib];
                                 }
                             }
                         }
                     }
                 }
+
+                // Gather the (signed) left coefficients into B_L[(u*npair+vw), K]
+                for (const auto& [nJ, class_Ja, class_Jb] : lists_.determinant_classes()) {
+                    if (lists_.block_size(nJ) == 0)
+                        continue;
+                    const auto maxJb = lists_.beta_address()->strpcls(class_Jb);
+                    const auto Cl_offset = lists_.block_offset(nJ);
+                    const auto& Ka_left_list = lists_.get_alpha_1h_list2(class_Ka, class_Ja);
+                    if (Ka_left_list.empty())
+                        continue;
+                    for (size_t Kb = 0; Kb < maxKb; ++Kb) {
+                        const auto& Kb_left_list = lists_.get_beta_2h_list(class_Kb, Kb, class_Jb);
+                        if (Kb_left_list.empty())
+                            continue;
+                        const auto Kbase = Kb * Ka_size;
+                        for (size_t Ka = 0; Ka < Ka_size; ++Ka) {
+                            const auto& KaL = Ka_left_list[Ka_block_start + Ka];
+                            const auto Kidx = Kbase + Ka;
+                            for (const auto& [sign_u, u, Ja] : KaL) {
+                                const size_t row_u = u * npair;
+                                const auto Cl_Ja_offset = Cl_offset + Ja * maxJb;
+                                for (const auto& [sign_vw, v, w, Jb] : Kb_left_list) {
+                                    const auto vw_index = pair_index_gt<size_t>(v, w);
+                                    Kblock1[(row_u + vw_index) * Kdim + Kidx] =
+                                        sign_u * sign_vw * Cl_span[Cl_Ja_offset + Jb];
+                                }
+                            }
+                        }
+                    }
+                }
+
+                matrix_product('N', 'T', M, M, Kdim, 1.0, Kblock1.data(), Kdim, Kblock2.data(), Kdim,
+                               1.0, rdm_data, M);
             }
         }
     }
@@ -282,36 +353,64 @@ np_tensor6 CISigmaBuilder::compute_sf_3rdm(np_vector C_left, np_vector C_right) 
         return rdm_sf; // No 3-RDM for less than 2 orbitals
     }
 
-    auto rdm_sf_v = rdm_sf.view();
-    // The aab contribution (2 orbitals or more)
+    // Strides of the dense row-major spin-free 6-index tensor rdm_sf[p,q,r,s,t,u].
+    const size_t n = norb;
+    const size_t n2 = n * n;
+    const size_t n3 = n2 * n;
+    const size_t n4 = n3 * n;
+    const size_t n5 = n4 * n;
+    const size_t npair = (norb * (norb - 1)) / 2;
+    auto* sf = rdm_sf.data();
+
+    // The aab contribution (2 orbitals or more).
+    // The 12 antisymmetric permutations all share the innermost index u. We hoist every
+    // u-invariant base offset out of the u loop and group the writes by u's stride in rdm_sf
+    // (1, n, or n2) so the stride-1 group vectorizes. This replaces nanobind's view() operator,
+    // which recomputes a 6-stride dot product per element and is not vectorized at this -O level.
     {
         auto rdm_aab = compute_aab_3rdm(C_left, C_right);
-        auto rdm_aab_v = rdm_aab.view();
+        const auto* aab = rdm_aab.data();
 
         for (size_t p{1}, pq{0}; p < norb; ++p) {
             for (size_t q{0}; q < p; ++q, ++pq) {
                 for (size_t r{0}; r < norb; ++r) {
                     for (size_t s{1}, st{0}; s < norb; ++s) {
                         for (size_t t{0}; t < s; ++t, ++st) {
+                            const size_t el_base = ((pq * n + r) * npair + st) * n;
+                            // u has stride 1 in these targets
+                            const size_t g1a = p * n5 + q * n4 + r * n3 + s * n2 + t * n;
+                            const size_t g1b = p * n5 + q * n4 + r * n3 + t * n2 + s * n;
+                            const size_t g1c = q * n5 + p * n4 + r * n3 + s * n2 + t * n;
+                            const size_t g1d = q * n5 + p * n4 + r * n3 + t * n2 + s * n;
+                            // u has stride n in these targets
+                            const size_t g2a = p * n5 + r * n4 + q * n3 + s * n2 + t;
+                            const size_t g2b = p * n5 + r * n4 + q * n3 + t * n2 + s;
+                            const size_t g2c = q * n5 + r * n4 + p * n3 + s * n2 + t;
+                            const size_t g2d = q * n5 + r * n4 + p * n3 + t * n2 + s;
+                            // u has stride n2 in these targets
+                            const size_t g3a = r * n5 + p * n4 + q * n3 + s * n + t;
+                            const size_t g3b = r * n5 + p * n4 + q * n3 + t * n + s;
+                            const size_t g3c = r * n5 + q * n4 + p * n3 + s * n + t;
+                            const size_t g3d = r * n5 + q * n4 + p * n3 + t * n + s;
                             for (size_t u{0}; u < norb; ++u) {
-                                const auto el = rdm_aab_v(pq, r, st, u);
+                                const auto el = aab[el_base + u];
                                 // G3("pqrstu") += g3aab_("pqrstu");
-                                rdm_sf_v(p, q, r, s, t, u) += el;
-                                rdm_sf_v(p, q, r, t, s, u) -= el;
-                                rdm_sf_v(q, p, r, s, t, u) -= el;
-                                rdm_sf_v(q, p, r, t, s, u) += el;
-
+                                sf[g1a + u] += el;
+                                sf[g1b + u] -= el;
+                                sf[g1c + u] -= el;
+                                sf[g1d + u] += el;
                                 // G3("prqsut") += g3aab_("pqrstu");
-                                rdm_sf_v(p, r, q, s, u, t) += el;
-                                rdm_sf_v(p, r, q, t, u, s) -= el;
-                                rdm_sf_v(q, r, p, s, u, t) -= el;
-                                rdm_sf_v(q, r, p, t, u, s) += el;
-
+                                const size_t un = u * n;
+                                sf[g2a + un] += el;
+                                sf[g2b + un] -= el;
+                                sf[g2c + un] -= el;
+                                sf[g2d + un] += el;
                                 // G3("rpqust") += g3aab_("pqrstu");
-                                rdm_sf_v(r, p, q, u, s, t) += el;
-                                rdm_sf_v(r, p, q, u, t, s) -= el;
-                                rdm_sf_v(r, q, p, u, s, t) -= el;
-                                rdm_sf_v(r, q, p, u, t, s) += el;
+                                const size_t un2 = u * n2;
+                                sf[g3a + un2] += el;
+                                sf[g3b + un2] -= el;
+                                sf[g3c + un2] -= el;
+                                sf[g3d + un2] += el;
                             }
                         }
                     }
@@ -320,34 +419,50 @@ np_tensor6 CISigmaBuilder::compute_sf_3rdm(np_vector C_left, np_vector C_right) 
         }
     }
 
-    // The abb contribution (2 orbitals or more)
+    // The abb contribution (2 orbitals or more). Same hoisting strategy as aab: the innermost
+    // packed index is u (with u < t). Every target base (u=0) is hoisted out of the u loop; the
+    // comment on each line is the exact rdm_sf(a,b,c,d,e,f) tuple it writes, and u's stride is n2,
+    // n, or 1 depending on whether u sits in the 4th, 5th, or 6th slot.
     {
         auto rdm_abb = compute_abb_3rdm(C_left, C_right);
-        auto rdm_abb_v = rdm_abb.view();
+        const auto* abb = rdm_abb.data();
         for (size_t p{0}; p < norb; ++p) {
             for (size_t q{1}, qr{0}; q < norb; ++q) {
                 for (size_t r{0}; r < q; ++r, ++qr) {
                     for (size_t s{0}; s < norb; ++s) {
+                        const size_t el_base = ((p * npair + qr) * n + s) * npair;
                         for (size_t t{1}, tu{0}; t < norb; ++t) {
+                            // bases with u at stride 1 (u in 6th slot)
+                            const size_t b1 = p * n5 + q * n4 + r * n3 + s * n2 + t * n;  //(pqrstu)+
+                            const size_t b4 = p * n5 + r * n4 + q * n3 + s * n2 + t * n;  //(prqstu)-
+                            const size_t b5 = q * n5 + p * n4 + r * n3 + t * n2 + s * n;  //(qprtsu)+
+                            const size_t b7 = r * n5 + p * n4 + q * n3 + t * n2 + s * n;  //(rpqtsu)-
+                            // bases with u at stride n (u in 5th slot)
+                            const size_t b2 = p * n5 + q * n4 + r * n3 + s * n2 + t;  //(pqrsut)-
+                            const size_t b3 = p * n5 + r * n4 + q * n3 + s * n2 + t;  //(prqsut)+
+                            const size_t b9 = q * n5 + r * n4 + p * n3 + t * n2 + s;  //(qrptus)+
+                            const size_t b11 = r * n5 + q * n4 + p * n3 + t * n2 + s; //(rqptus)-
+                            // bases with u at stride n2 (u in 4th slot)
+                            const size_t b6 = q * n5 + p * n4 + r * n3 + s * n + t;   //(qprust)-
+                            const size_t b8 = r * n5 + p * n4 + q * n3 + s * n + t;   //(rpqust)+
+                            const size_t b10 = q * n5 + r * n4 + p * n3 + t * n + s;  //(qrputs)-
+                            const size_t b12 = r * n5 + q * n4 + p * n3 + t * n + s;  //(rqputs)+
                             for (size_t u{0}; u < t; ++u, ++tu) {
-                                const auto el = rdm_abb_v(p, qr, s, tu);
-                                // G3("pqrstu") += g3abb_("pqrstu");
-                                rdm_sf_v(p, q, r, s, t, u) += el;
-                                rdm_sf_v(p, q, r, s, u, t) -= el;
-                                rdm_sf_v(p, r, q, s, u, t) += el;
-                                rdm_sf_v(p, r, q, s, t, u) -= el;
-
-                                // G3("qprtsu") += g3abb_("pqrstu");
-                                rdm_sf_v(q, p, r, t, s, u) += el;
-                                rdm_sf_v(q, p, r, u, s, t) -= el;
-                                rdm_sf_v(r, p, q, t, s, u) -= el;
-                                rdm_sf_v(r, p, q, u, s, t) += el;
-
-                                // G3("qrptus") += g3abb_("pqrstu");
-                                rdm_sf_v(q, r, p, t, u, s) += el;
-                                rdm_sf_v(q, r, p, u, t, s) -= el;
-                                rdm_sf_v(r, q, p, t, u, s) -= el;
-                                rdm_sf_v(r, q, p, u, t, s) += el;
+                                const auto el = abb[el_base + tu];
+                                const size_t un = u * n;
+                                const size_t un2 = u * n2;
+                                sf[b1 + u] += el;
+                                sf[b4 + u] -= el;
+                                sf[b5 + u] += el;
+                                sf[b7 + u] -= el;
+                                sf[b2 + un] -= el;
+                                sf[b3 + un] += el;
+                                sf[b9 + un] += el;
+                                sf[b11 + un] -= el;
+                                sf[b6 + un2] -= el;
+                                sf[b8 + un2] += el;
+                                sf[b10 + un2] -= el;
+                                sf[b12 + un2] += el;
                             }
                         }
                     }
@@ -360,67 +475,59 @@ np_tensor6 CISigmaBuilder::compute_sf_3rdm(np_vector C_left, np_vector C_right) 
         return rdm_sf; // No same-spin contributions to the 3-RDM for less than 3 orbitals
     }
 
-    // To reduce the  memory footprint, we compute the aaa and bbb contributions in a packed
-    // format and one at a time.
+    // The aaa/bbb (same-spin) contributions. For a fixed bra triplet (p>q>r) the whole (d,e,f)
+    // ket sub-block is identical up to the bra-permutation sign, so we assemble that norb^3 block
+    // once in a small L2-resident buffer with the antisymmetric ket signs, then add each of the 6
+    // bra permutations as a contiguous, streaming signed accumulation onto rdm_sf (which already
+    // holds the aab+abb data). This replaces 36 strided writes through the 6-D view operator with
+    // sequential block updates, making the same-spin expansion memory-bandwidth bound. This is the
+    // approach validated in the relativistic 3-RDM; here it accumulates (+=/-=) instead of
+    // assigning, and runs once per spin. Non-distinct (d,e,f) positions stay zero in ketrow and so
+    // contribute nothing (they retain their aab/abb values).
+    const size_t ntriplets = (norb * (norb - 1) * (norb - 2)) / 6;
+    const size_t N3 = n3;
+    std::vector<double> ketrow(N3, 0.0);
+
+    auto add_block = [&](bool positive, size_t a, size_t b, size_t c) {
+        auto* dst = sf + ((a * n + b) * n + c) * N3;
+        if (positive) {
+            for (size_t i = 0; i < N3; ++i)
+                dst[i] += ketrow[i];
+        } else {
+            for (size_t i = 0; i < N3; ++i)
+                dst[i] -= ketrow[i];
+        }
+    };
+
     for (auto spin : {Spin::Alpha, Spin::Beta}) {
         auto rdm_sss = compute_sss_3rdm(C_left, C_right, spin);
-        auto rdm_sss_v = rdm_sss.view();
+        const auto* sss_data = rdm_sss.data();
 
         for (size_t p{2}, pqr{0}; p < norb; ++p) {
             for (size_t q{1}; q < p; ++q) {
                 for (size_t r{0}; r < q; ++r, ++pqr) {
+                    const auto* row = sss_data + pqr * ntriplets;
+                    // Scatter the ket triplets into the (d,e,f) block with antisymmetric signs.
                     for (size_t s{2}, stu{0}; s < norb; ++s) {
                         for (size_t t{1}; t < s; ++t) {
                             for (size_t u{0}; u < t; ++u, ++stu) {
-                                // grab the unique element of the 3-RDM
-                                const auto el = rdm_sss_v(pqr, stu);
-
-                                // Place the element in all valid 36 antisymmetric index
-                                // permutations
-                                rdm_sf_v(p, q, r, s, t, u) += el;
-                                rdm_sf_v(p, q, r, s, u, t) -= el;
-                                rdm_sf_v(p, q, r, u, s, t) += el;
-                                rdm_sf_v(p, q, r, u, t, s) -= el;
-                                rdm_sf_v(p, q, r, t, u, s) += el;
-                                rdm_sf_v(p, q, r, t, s, u) -= el;
-
-                                rdm_sf_v(p, r, q, s, t, u) -= el;
-                                rdm_sf_v(p, r, q, s, u, t) += el;
-                                rdm_sf_v(p, r, q, u, s, t) -= el;
-                                rdm_sf_v(p, r, q, u, t, s) += el;
-                                rdm_sf_v(p, r, q, t, u, s) -= el;
-                                rdm_sf_v(p, r, q, t, s, u) += el;
-
-                                rdm_sf_v(r, p, q, s, t, u) += el;
-                                rdm_sf_v(r, p, q, s, u, t) -= el;
-                                rdm_sf_v(r, p, q, u, s, t) += el;
-                                rdm_sf_v(r, p, q, u, t, s) -= el;
-                                rdm_sf_v(r, p, q, t, u, s) += el;
-                                rdm_sf_v(r, p, q, t, s, u) -= el;
-
-                                rdm_sf_v(r, q, p, s, t, u) -= el;
-                                rdm_sf_v(r, q, p, s, u, t) += el;
-                                rdm_sf_v(r, q, p, u, s, t) -= el;
-                                rdm_sf_v(r, q, p, u, t, s) += el;
-                                rdm_sf_v(r, q, p, t, u, s) -= el;
-                                rdm_sf_v(r, q, p, t, s, u) += el;
-
-                                rdm_sf_v(q, r, p, s, t, u) += el;
-                                rdm_sf_v(q, r, p, s, u, t) -= el;
-                                rdm_sf_v(q, r, p, u, s, t) += el;
-                                rdm_sf_v(q, r, p, u, t, s) -= el;
-                                rdm_sf_v(q, r, p, t, u, s) += el;
-                                rdm_sf_v(q, r, p, t, s, u) -= el;
-
-                                rdm_sf_v(q, p, r, s, t, u) -= el;
-                                rdm_sf_v(q, p, r, s, u, t) += el;
-                                rdm_sf_v(q, p, r, u, s, t) -= el;
-                                rdm_sf_v(q, p, r, u, t, s) += el;
-                                rdm_sf_v(q, p, r, t, u, s) -= el;
-                                rdm_sf_v(q, p, r, t, s, u) += el;
+                                const auto el = row[stu];
+                                ketrow[(s * n + t) * n + u] = +el;
+                                ketrow[(s * n + u) * n + t] = -el;
+                                ketrow[(u * n + s) * n + t] = +el;
+                                ketrow[(u * n + t) * n + s] = -el;
+                                ketrow[(t * n + u) * n + s] = +el;
+                                ketrow[(t * n + s) * n + u] = -el;
                             }
                         }
                     }
+                    // Add the 6 bra permutations as contiguous streaming signed accumulations.
+                    add_block(true, p, q, r);
+                    add_block(false, p, r, q);
+                    add_block(true, r, p, q);
+                    add_block(false, r, q, p);
+                    add_block(true, q, r, p);
+                    add_block(false, q, p, r);
                 }
             }
         }

--- a/forte2/ci/ci_sigma_builder_3rdm.cc
+++ b/forte2/ci/ci_sigma_builder_3rdm.cc
@@ -124,14 +124,10 @@ np_tensor4 CISigmaBuilder::compute_aab_3rdm(np_vector C_left, np_vector C_right)
     int num_2h_class_Ka = lists_.alpha_address_2h()->nclasses();
     int num_1h_class_Kb = lists_.beta_address_1h()->nclasses();
 
-    // GEMM reformulation, identical in spirit to compute_ab_2rdm: the contraction
-    // gamma[(uv,w),(xy,z)] = sum_{Ka,Kb} (sign_uv sign_w Cl) (sign_xy sign_z Cr) is a matrix
+    // the contraction gamma[(uv,w),(xy,z)] = sum_{Ka,Kb} (sign_uv sign_w Cl) (sign_xy sign_z Cr) is a matrix
     // product over the composite hole index K = (Ka, Kb) (Ka: 2-hole alpha, Kb: 1-hole beta).
     // Gather signed left/right coefficients into B_L[(uv*norb+w), K] and B_R[(xy*norb+z), K], then
-    // gamma[row,col] += B_L * B_R^T with one dgemm per Ka-chunk. Row = uv*norb+w, col = xy*norb+z,
-    // both of dimension M = npair*norb, which matches the row-major layout of rdm[uv,w,xy,z], so no
-    // repack is needed. The alpha 2-hole side has no all-K list accessor, so it uses the per-K
-    // accessor (fetched once per hole index, fewer calls than the old cross-block loop).
+    // gamma[row,col] += B_L * B_R^T with one dgemm per Ka-chunk.
     const size_t M = npair * norb;
     for (int class_Ka{0}; class_Ka < num_2h_class_Ka; ++class_Ka) {
         const size_t maxKa = lists_.alpha_address_2h()->strpcls(class_Ka);
@@ -251,9 +247,7 @@ np_tensor4 CISigmaBuilder::compute_abb_3rdm(np_vector C_left, np_vector C_right)
     // GEMM reformulation, mirroring compute_aab_3rdm with the spins swapped: the composite hole
     // index is K = (Ka, Kb) (Ka: 1-hole alpha, Kb: 2-hole beta). Gather signed left/right
     // coefficients into B_L[(u*npair+vw), K] and B_R[(x*npair+yz), K], then gamma[row,col] +=
-    // B_L * B_R^T with one dgemm per Ka-chunk. Row = u*npair+vw, col = x*npair+yz, both of
-    // dimension M = norb*npair, matching the row-major layout of rdm[u,vw,x,yz], so no repack. The
-    // beta 2-hole side has no all-K list accessor, so it uses the per-K accessor.
+    // B_L * B_R^T with one dgemm per Ka-chunk.
     const size_t M = norb * npair;
     for (int class_Ka = 0; class_Ka < num_1h_class_Ka; ++class_Ka) {
         const size_t maxKa = lists_.alpha_address_1h()->strpcls(class_Ka);
@@ -362,11 +356,7 @@ np_tensor6 CISigmaBuilder::compute_sf_3rdm(np_vector C_left, np_vector C_right) 
     const size_t npair = (norb * (norb - 1)) / 2;
     auto* sf = rdm_sf.data();
 
-    // The aab contribution (2 orbitals or more).
-    // The 12 antisymmetric permutations all share the innermost index u. We hoist every
-    // u-invariant base offset out of the u loop and group the writes by u's stride in rdm_sf
-    // (1, n, or n2) so the stride-1 group vectorizes. This replaces nanobind's view() operator,
-    // which recomputes a 6-stride dot product per element and is not vectorized at this -O level.
+    // The aab contribution
     {
         auto rdm_aab = compute_aab_3rdm(C_left, C_right);
         const auto* aab = rdm_aab.data();
@@ -376,7 +366,7 @@ np_tensor6 CISigmaBuilder::compute_sf_3rdm(np_vector C_left, np_vector C_right) 
                 for (size_t r{0}; r < norb; ++r) {
                     for (size_t s{1}, st{0}; s < norb; ++s) {
                         for (size_t t{0}; t < s; ++t, ++st) {
-                            const size_t el_base = ((pq * n + r) * npair + st) * n;
+                            const size_t offset = ((pq * n + r) * npair + st) * n;
                             // u has stride 1 in these targets
                             const size_t g1a = p * n5 + q * n4 + r * n3 + s * n2 + t * n;
                             const size_t g1b = p * n5 + q * n4 + r * n3 + t * n2 + s * n;
@@ -393,7 +383,7 @@ np_tensor6 CISigmaBuilder::compute_sf_3rdm(np_vector C_left, np_vector C_right) 
                             const size_t g3c = r * n5 + q * n4 + p * n3 + s * n + t;
                             const size_t g3d = r * n5 + q * n4 + p * n3 + t * n + s;
                             for (size_t u{0}; u < norb; ++u) {
-                                const auto el = aab[el_base + u];
+                                const auto el = aab[offset + u];
                                 // G3("pqrstu") += g3aab_("pqrstu");
                                 sf[g1a + u] += el;
                                 sf[g1b + u] -= el;
@@ -419,10 +409,7 @@ np_tensor6 CISigmaBuilder::compute_sf_3rdm(np_vector C_left, np_vector C_right) 
         }
     }
 
-    // The abb contribution (2 orbitals or more). Same hoisting strategy as aab: the innermost
-    // packed index is u (with u < t). Every target base (u=0) is hoisted out of the u loop; the
-    // comment on each line is the exact rdm_sf(a,b,c,d,e,f) tuple it writes, and u's stride is n2,
-    // n, or 1 depending on whether u sits in the 4th, 5th, or 6th slot.
+    // The abb contribution 
     {
         auto rdm_abb = compute_abb_3rdm(C_left, C_right);
         const auto* abb = rdm_abb.data();
@@ -430,7 +417,7 @@ np_tensor6 CISigmaBuilder::compute_sf_3rdm(np_vector C_left, np_vector C_right) 
             for (size_t q{1}, qr{0}; q < norb; ++q) {
                 for (size_t r{0}; r < q; ++r, ++qr) {
                     for (size_t s{0}; s < norb; ++s) {
-                        const size_t el_base = ((p * npair + qr) * n + s) * npair;
+                        const size_t offset = ((p * npair + qr) * n + s) * npair;
                         for (size_t t{1}, tu{0}; t < norb; ++t) {
                             // bases with u at stride 1 (u in 6th slot)
                             const size_t b1 = p * n5 + q * n4 + r * n3 + s * n2 + t * n;  //(pqrstu)+
@@ -448,7 +435,7 @@ np_tensor6 CISigmaBuilder::compute_sf_3rdm(np_vector C_left, np_vector C_right) 
                             const size_t b10 = q * n5 + r * n4 + p * n3 + t * n + s;  //(qrputs)-
                             const size_t b12 = r * n5 + q * n4 + p * n3 + t * n + s;  //(rqputs)+
                             for (size_t u{0}; u < t; ++u, ++tu) {
-                                const auto el = abb[el_base + tu];
+                                const auto el = abb[offset + tu];
                                 const size_t un = u * n;
                                 const size_t un2 = u * n2;
                                 sf[b1 + u] += el;
@@ -475,15 +462,10 @@ np_tensor6 CISigmaBuilder::compute_sf_3rdm(np_vector C_left, np_vector C_right) 
         return rdm_sf; // No same-spin contributions to the 3-RDM for less than 3 orbitals
     }
 
-    // The aaa/bbb (same-spin) contributions. For a fixed bra triplet (p>q>r) the whole (d,e,f)
+    // The aaa/bbb (same-spin) contributions. For a fixed bra triplet (p>q>r) the whole (s,t,u)
     // ket sub-block is identical up to the bra-permutation sign, so we assemble that norb^3 block
-    // once in a small L2-resident buffer with the antisymmetric ket signs, then add each of the 6
-    // bra permutations as a contiguous, streaming signed accumulation onto rdm_sf (which already
-    // holds the aab+abb data). This replaces 36 strided writes through the 6-D view operator with
-    // sequential block updates, making the same-spin expansion memory-bandwidth bound. This is the
-    // approach validated in the relativistic 3-RDM; here it accumulates (+=/-=) instead of
-    // assigning, and runs once per spin. Non-distinct (d,e,f) positions stay zero in ketrow and so
-    // contribute nothing (they retain their aab/abb values).
+    // once in a buffer with the ket signs, then add each of the 6
+    // bra permutations as a contiguous block onto rdm_sf
     const size_t ntriplets = (norb * (norb - 1) * (norb - 2)) / 6;
     const size_t N3 = n3;
     std::vector<double> ketrow(N3, 0.0);
@@ -507,7 +489,7 @@ np_tensor6 CISigmaBuilder::compute_sf_3rdm(np_vector C_left, np_vector C_right) 
             for (size_t q{1}; q < p; ++q) {
                 for (size_t r{0}; r < q; ++r, ++pqr) {
                     const auto* row = sss_data + pqr * ntriplets;
-                    // Scatter the ket triplets into the (d,e,f) block with antisymmetric signs.
+                    // Scatter the ket triplets into the (s,t,u) block with antisymmetric signs.
                     for (size_t s{2}, stu{0}; s < norb; ++s) {
                         for (size_t t{1}; t < s; ++t) {
                             for (size_t u{0}; u < t; ++u, ++stu) {
@@ -521,7 +503,7 @@ np_tensor6 CISigmaBuilder::compute_sf_3rdm(np_vector C_left, np_vector C_right) 
                             }
                         }
                     }
-                    // Add the 6 bra permutations as contiguous streaming signed accumulations.
+                    // Add the 6 bra permutations as contiguous signed accumulations.
                     add_block(true, p, q, r);
                     add_block(false, p, r, q);
                     add_block(true, r, p, q);

--- a/forte2/ci/ci_sigma_builder_harrison_zarrabian.cc
+++ b/forte2/ci/ci_sigma_builder_harrison_zarrabian.cc
@@ -5,6 +5,7 @@
 #include "helpers/np_vector_functions.h"
 #include "helpers/indexing.hpp"
 #include "helpers/blas.h"
+#include "helpers/parallel.h"
 
 #include "ci_sigma_builder.h"
 
@@ -238,53 +239,68 @@ void CISigmaBuilder::H2_hz_opposite_spin(std::span<double> basis, std::span<doub
                     const auto& Kb_right_list = lists_.get_beta_1h_list2(class_Kb, class_Ib);
                     if (Ka_right_list.empty() || Kb_right_list.empty())
                         continue;
-                    for (size_t Ka = 0; Ka < Ka_block_size; ++Ka) {
-                        const auto& KaL = Ka_right_list[Ka_block_start + Ka];
-                        for (size_t Kb = 0; Kb < Kb_block_size; ++Kb) {
-                            const auto& KbL = Kb_right_list[Kb_block_start + Kb];
-                            const auto Kidx = Ka * Kb_block_size + Kb;
-                            for (const auto& [sign_q, q, Ia] : KaL) {
-                                const size_t qnorb = q * norb;
-                                const size_t b_offset = Cr_offset + Ia * maxIb;
-                                for (const auto& [sign_s, s, Ib] : KbL) {
-                                    const size_t qs_index = qnorb + s;
-                                    Kblock1[qs_index * Kdim + Kidx] =
-                                        sign_q * sign_s * basis[b_offset + Ib];
+                    // Parallelize over Ka: each Ka writes a disjoint block of columns
+                    // (Kidx = Ka * Kb_block_size + Kb) of Kblock1, so there is no write race.
+                    parallel_for_chunked(Ka_block_size, [&](size_t Ka_begin, size_t Ka_end) {
+                        for (size_t Ka = Ka_begin; Ka < Ka_end; ++Ka) {
+                            const auto& KaL = Ka_right_list[Ka_block_start + Ka];
+                            for (size_t Kb = 0; Kb < Kb_block_size; ++Kb) {
+                                const auto& KbL = Kb_right_list[Kb_block_start + Kb];
+                                const auto Kidx = Ka * Kb_block_size + Kb;
+                                for (const auto& [sign_q, q, Ia] : KaL) {
+                                    const size_t qnorb = q * norb;
+                                    const size_t b_offset = Cr_offset + Ia * maxIb;
+                                    for (const auto& [sign_s, s, Ib] : KbL) {
+                                        const size_t qs_index = qnorb + s;
+                                        Kblock1[qs_index * Kdim + Kidx] =
+                                            sign_q * sign_s * basis[b_offset + Ib];
+                                    }
                                 }
                             }
                         }
-                    }
+                    });
                 }
 
                 matrix_product('N', 'N', norb2, Kdim, norb2, 1.0, v_pr_qs.data(), norb2,
                                Kblock1.data(), Kdim, 0.0, Kblock2.data(), Kdim);
 
-                // D([qs],[Ka Kb]) = \sum_{Ia,Ib} B^{Ka,Kb,Ia,Ib}_{pq} C_{Ia,Ib}
+                // sigma(Ia,Ib) += \sum_{p,r,Ka,Kb} sign_p sign_r E([pr],[Ka Kb])
                 for (const auto& [nI, class_Ia, class_Ib] : lists_.determinant_classes()) {
                     if (lists_.block_size(nI) == 0)
                         continue;
+                    const auto maxIa = lists_.alpha_address()->strpcls(class_Ia);
                     const auto maxIb = lists_.beta_address()->strpcls(class_Ib);
                     const auto Cr_offset = lists_.block_offset(nI);
                     const auto& Ka_right_list = lists_.get_alpha_1h_list2(class_Ka, class_Ia);
                     const auto& Kb_right_list = lists_.get_beta_1h_list2(class_Kb, class_Ib);
                     if (Ka_right_list.empty() || Kb_right_list.empty())
                         continue;
-                    for (size_t Ka = 0; Ka < Ka_block_size; ++Ka) {
-                        const auto& KaL = Ka_right_list[Ka_block_start + Ka];
-                        for (size_t Kb = 0; Kb < Kb_block_size; ++Kb) {
-                            const auto& KbL = Kb_right_list[Kb_block_start + Kb];
-                            const auto Kidx = Ka * Kb_block_size + Kb;
+                    // The scatter accumulates into sigma(Ia,Ib), so parallelizing over Ka would
+                    // race (many Ka map to the same output Ia). Instead we parallelize over the
+                    // output alpha string Ia: each thread owns a disjoint stripe
+                    // of Ia values, iterates all Ka/Kb, but only writes rows it owns. 
+                    parallel_for_chunked(maxIa, [&](size_t Ia_begin, size_t Ia_end) {
+                        for (size_t Ka = 0; Ka < Ka_block_size; ++Ka) {
+                            const auto& KaL = Ka_right_list[Ka_block_start + Ka];
+                            const size_t Ka_col = Ka * Kb_block_size;
                             for (const auto& [sign_p, p, Ia] : KaL) {
+                                // skip if this thread does not own this row
+                                if (Ia < Ia_begin || Ia >= Ia_end)
+                                    continue;
                                 const size_t pnorb = p * norb;
                                 const size_t s_offset = Cr_offset + Ia * maxIb;
-                                for (const auto& [sign_r, r, Ib] : KbL) {
-                                    const size_t pr_index = pnorb + r;
-                                    sigma[s_offset + Ib] +=
-                                        sign_p * sign_r * Kblock2[pr_index * Kdim + Kidx];
+                                for (size_t Kb = 0; Kb < Kb_block_size; ++Kb) {
+                                    const auto& KbL = Kb_right_list[Kb_block_start + Kb];
+                                    const auto Kidx = Ka_col + Kb;
+                                    for (const auto& [sign_r, r, Ib] : KbL) {
+                                        const size_t pr_index = pnorb + r;
+                                        sigma[s_offset + Ib] +=
+                                            sign_p * sign_r * Kblock2[pr_index * Kdim + Kidx];
+                                    }
                                 }
                             }
                         }
-                    }
+                    });
                 }
             }
         }


### PR DESCRIPTION
This PR optimizes the non-relativistic CI code in the following places:
1. 2/3 RDMs: using GEMMs where possible
2. sf-3RDM: optimize cache locality for the writes
3. H2_hz_opposite_spin: parallelization of the gather/scatter operations