### PR TITLE
build: default to -O3 build

### DIFF
--- a/forte2/CMakeLists.txt
+++ b/forte2/CMakeLists.txt
@@ -91,6 +91,11 @@ nanobind_add_module(
   # reusing a shared libnanobind across libraries
   NB_STATIC
 
+  # By default nanobind_add_module appends "-Os" (optimize for size)
+  # This can override earlier -O flags. Passing this option stops
+  # nanobind from appending -Os
+  NOMINSIZE
+
   # Source code goes here
   api/forte2_api.cc
   api/ci_api.cc


### PR DESCRIPTION
nanobind have been quietly appending "-Os" (optimize for size) the C++ compilation flags. We had "-O3 -DNDEBUG" from CMAKE_CXX_FLAGS_RELEASE, but the last -O flag wins. We were then leaving a lot of vectorization and other compiler optimizations on the table.

Measured on 16 cores (pre-optimization origin/main code, best-of-N, -Os vs -O3):

  rel-ci Hamiltonian:
    norb=14  12.30 -> 8.78ms   (1.40x)
    norb=16  65.47 -> 48.04ms  (1.36x)
    norb=18 318.51 -> 252.63ms (1.26x)
  rel-ci so_2rdm:
    norb=12   9.98 -> 5.23ms   (1.91x)
    norb=14  68.92 -> 34.51ms  (2.00x)
  rel-ci so_3rdm (norb^6 antisymmetric expansion):
    norb=12  61.95 -> 35.21ms  (1.76x)
    norb=14 514.90 -> 311.71ms (1.65x)