### PR TITLE
feat: add relativistic CASSCF and GASSCF gradients

### DIFF
--- a/forte2/mcopt/mc_optimizer.py
+++ b/forte2/mcopt/mc_optimizer.py
@@ -632,12 +632,16 @@ class MCOptimizer(MCOptimizerBase):
         r"""
         Compute a state-specific CASSCF/GASSCF analytic nuclear gradient.
 
-        This implementation supports only real, nonrelativistic,
-        state-specific CASSCF/GASSCF wave functions. State-averaged gradients,
-        frozen-core and frozen-virtual response, active-frozen rotations,
-        frozen inter-GAS rotations, X2C, and Gaussian nuclear charges are not
-        supported. Requesting any unsupported feature raises
-        ``NotImplementedError``.
+        This implementation supports real nonrelativistic and complex
+        two-component state-specific CASSCF/GASSCF wave functions, including
+        SF- and SO-X2C-1e Hamiltonians. State-averaged gradients, frozen-core
+        and frozen-virtual response, active-frozen rotations, frozen inter-GAS
+        rotations are not supported. Point and Gaussian nuclear charge
+        distributions are supported; Gaussian charges require libcint.
+        Requesting any unsupported feature raises ``NotImplementedError``.
+        Both the orbital optimization and all CI roots must be converged; an
+        unconverged wave function raises ``RuntimeError`` because the
+        stationary-gradient expression does not apply.
 
         The gradient is assembled in the same integral-layer form as the RHF
         and UHF gradients:

--- a/forte2/mcopt/mc_optimizer_grad.py
+++ b/forte2/mcopt/mc_optimizer_grad.py
@@ -1,27 +1,34 @@
 import numpy as np
 from numpy.typing import NDArray
 
-from forte2.lib import ints
 from forte2.base_classes import RelCIBase
+from forte2.ci.ci_utils import make_2cumulant_so
 from forte2.gradients import (
     build_metric_inverted_three_center,
     compute_gradient,
 )
-from forte2.system import ModelSystem
+from forte2.gradients.validation import validate_df_gradient_system
 
-from .orbital_optimizer import OrbOptimizer
+from .orbital_optimizer import OrbOptimizer, RelOrbOptimizer
 
 
 def _compute_casscf_gradient(mc) -> NDArray:
     """Compute a state-specific density-fitted CASSCF/GASSCF gradient."""
-    _validate_casscf_gradient_supported(mc, pre_run=True)
+    _validate_casscf_gradient_request(mc)
 
     if not mc.executed:
         mc.run()
 
-    _validate_casscf_gradient_supported(mc, pre_run=False)
+    _validate_converged_casscf_gradient(mc)
 
     C = mc.C[0][:, mc.mo_space.orig_to_contig].copy()
+    if isinstance(mc.ci_solver, RelCIBase):
+        return _compute_rel_casscf_gradient(mc, C)
+    return _compute_nonrel_casscf_gradient(mc, C)
+
+
+def _compute_nonrel_casscf_gradient(mc, C: NDArray) -> NDArray:
+    """Compute a state-specific nonrelativistic CASSCF/GASSCF gradient."""
     gamma1_act = mc.make_sf_1rdm(0)
     gamma2_act = mc.make_sf_2rdm(0)
     Ccore = C[:, mc.mo_space.core]
@@ -33,7 +40,83 @@ def _compute_casscf_gradient(mc) -> NDArray:
         mc.system, Ccore, Cact, gamma1_act, gamma2_act
     )
 
-    return compute_gradient(mc.system, D1.real, W1.real, W2, W3)
+    hcore_gradient = (
+        mc.system.x2c_helper.hcore_gradient(D1)
+        if mc.system.x2c_type is not None
+        else None
+    )
+    return compute_gradient(
+        mc.system,
+        D1.real,
+        W1.real,
+        W2,
+        W3,
+        hcore_gradient=hcore_gradient,
+    )
+
+
+def _compute_rel_casscf_gradient(mc, C: NDArray) -> NDArray:
+    """Compute a state-specific two-component CASSCF/GASSCF gradient."""
+    gamma1_act = mc.ci_solver.make_1rdm(0)
+    gamma2_act = mc.ci_solver.make_2rdm(0)
+    Ccore = C[:, mc.mo_space.core]
+    Cact = C[:, mc.mo_space.actv]
+
+    D_spinor = _build_rel_casscf_one_body_density(Ccore, Cact, gamma1_act)
+    D1 = _spatial_spin_trace(D_spinor, mc.system.nbf)
+    W_spinor = _build_casscf_overlap_weight(mc, C, gamma1_act, gamma2_act)
+    W1 = _spatial_spin_trace(W_spinor, mc.system.nbf)
+    W2, W3 = _build_rel_casscf_df_deriv_weights(
+        mc.system, Ccore, Cact, gamma1_act, gamma2_act
+    )
+
+    hcore_gradient = None
+    if mc.system.x2c_type is not None:
+        x2c_density = D_spinor if mc.system.x2c_type == "so" else D1
+        hcore_gradient = mc.system.x2c_helper.hcore_gradient(x2c_density)
+
+    return compute_gradient(
+        mc.system,
+        D1.real,
+        W1.real,
+        W2,
+        W3,
+        hcore_gradient=hcore_gradient,
+    )
+
+
+def _spatial_spin_trace(matrix: NDArray, nbf: int) -> NDArray:
+    """Trace a spinor AO matrix over its alpha and beta diagonal blocks."""
+    matrix = np.asarray(matrix)
+    if matrix.shape != (2 * nbf, 2 * nbf):
+        raise ValueError(
+            f"Expected a spinor AO matrix with shape {(2 * nbf, 2 * nbf)}, "
+            f"got {matrix.shape}."
+        )
+    return matrix[:nbf, :nbf] + matrix[nbf:, nbf:]
+
+
+def _build_rel_casscf_one_body_density(
+    Ccore: NDArray,
+    Cact: NDArray,
+    gamma1_act: NDArray,
+) -> NDArray:
+    r"""Build the full spinor AO one-particle density.
+
+    Each inactive core spinor has unit occupation. Correlated active-space
+    occupations are supplied by the spin-orbital 1-RDM. The active RDM is
+    transposed because Forte2 contracts relativistic MO integrals and RDMs
+    element by element.
+    """
+    nact = Cact.shape[1]
+    if gamma1_act.shape != (nact, nact):
+        raise ValueError(
+            f"Expected active 1-RDM shape {(nact, nact)}, got {gamma1_act.shape}."
+        )
+
+    D1 = np.einsum("mi,ni->mn", Ccore, Ccore.conj(), optimize=True)
+    D1 += np.einsum("mu,vu,nv->mn", Cact, gamma1_act, Cact.conj(), optimize=True)
+    return D1
 
 
 def _build_casscf_one_body_density(
@@ -146,6 +229,39 @@ def _build_casscf_active_cumulant(
     return lambda2_act
 
 
+def _build_mc_df_hole_weights(
+    gamma_h: NDArray,
+    lambda2_act: NDArray,
+    Z_h: NDArray,
+    ncore: int,
+    exchange_factor: float,
+) -> tuple[NDArray, NDArray]:
+    r"""Build metric and three-center weights in the compact hole space.
+
+    The spin-free and spin-orbital CASSCF expressions differ only in the
+    exchange prefactor.  Forming the exchange and active-cumulant responses
+    once also lets the metric weight reuse the intermediates required by the
+    three-center weight.
+    """
+    R = np.einsum("xy,Pxy->P", gamma_h, Z_h, optimize=True)
+    exchange_h = np.einsum("xz,Pwz,wy->Pxy", gamma_h, Z_h, gamma_h, optimize=True)
+
+    active = slice(ncore, None)
+    Z_act = Z_h[:, active, active]
+    cumulant_h = np.einsum("uvwx,Pvx->Puw", lambda2_act, Z_act, optimize=True)
+
+    W3_h = np.einsum("xy,P->Pxy", gamma_h, R, optimize=True)
+    W3_h -= exchange_factor * exchange_h
+    W3_h[:, active, active] += cumulant_h
+
+    W2 = -0.5 * np.einsum("P,Q->PQ", R, R, optimize=True)
+    W2 += (
+        0.5 * exchange_factor * np.einsum("Pxy,Qxy->PQ", Z_h, exchange_h, optimize=True)
+    )
+    W2 -= 0.5 * np.einsum("Puw,Quw->PQ", Z_act, cumulant_h, optimize=True)
+    return W2, W3_h
+
+
 def _build_casscf_df_deriv_weights(
     system,
     Ccore: NDArray,
@@ -245,22 +361,77 @@ def _build_casscf_df_deriv_weights(
     Z_ao = build_metric_inverted_three_center(system)
     Z_h = np.einsum("mx,Pmn,ny->Pxy", Ch.conj(), Z_ao, Ch, optimize=True)
 
-    R = np.einsum("xy,Pxy->P", gamma_h, Z_h, optimize=True)
-    W3_h = np.einsum("xy,P->Pxy", gamma_h, R, optimize=True)
-    W3_h -= 0.5 * np.einsum("xz,Pwz,wy->Pxy", gamma_h, Z_h, gamma_h, optimize=True)
-
-    Z_act = Z_h[:, ncore:, ncore:]
-    W3_h[:, ncore:, ncore:] += np.einsum(
-        "uvwx,Pvx->Puw", lambda2_act, Z_act, optimize=True
+    W2, W3_h = _build_mc_df_hole_weights(
+        gamma_h,
+        lambda2_act,
+        Z_h,
+        ncore,
+        exchange_factor=0.5,
     )
-
-    W2 = -0.5 * np.einsum("P,Q->PQ", R, R, optimize=True)
-    W2 += 0.25 * np.einsum(
-        "Pxy,xz,Qwz,wy->PQ", Z_h, gamma_h, Z_h, gamma_h, optimize=True
-    )
-    W2 -= 0.5 * np.einsum("uvwx,Puw,Qvx->PQ", lambda2_act, Z_act, Z_act, optimize=True)
 
     W3 = np.einsum("mx,Pxy,ny->Pmn", Ch, W3_h, Ch.conj(), optimize=True)
+    return W2.real, W3.real
+
+
+def _build_rel_casscf_df_deriv_weights(
+    system,
+    Ccore: NDArray,
+    Cact: NDArray,
+    gamma1_act: NDArray,
+    gamma2_act: NDArray,
+) -> tuple[NDArray, NDArray]:
+    r"""Build two-component CASSCF DF derivative weights.
+
+    The hole space contains unit-occupied inactive core spinors and the
+    correlated active spinors. The spin-orbital pair density is decomposed as
+
+    .. math::
+        \Gamma_{xy,zw}
+        = \gamma_{xz}\gamma_{yw}
+        - \gamma_{xw}\gamma_{yz}
+        + \lambda_{xy,zw}.
+
+    Spatial three-center integrals are transformed with the sum over equal
+    alpha and beta spin blocks. This retains spin mixing and complex phases in
+    the compact hole-space intermediates while returning real spatial weights
+    for the scalar Coulomb-integral derivatives.
+    """
+    ncore = Ccore.shape[1]
+    nact = Cact.shape[1]
+    if gamma1_act.shape != (nact, nact):
+        raise ValueError(
+            f"Expected active 1-RDM shape {(nact, nact)}, got {gamma1_act.shape}."
+        )
+    if gamma2_act.shape != (nact, nact, nact, nact):
+        raise ValueError(
+            "Expected active 2-RDM shape "
+            f"{(nact, nact, nact, nact)}, got {gamma2_act.shape}."
+        )
+
+    Ch = np.hstack((Ccore, Cact))
+    nhole = Ch.shape[1]
+    gamma_h = np.zeros((nhole, nhole), dtype=np.complex128)
+    gamma_h[:ncore, :ncore] = np.eye(ncore)
+    gamma_h[ncore:, ncore:] = gamma1_act
+    lambda2_act = make_2cumulant_so(gamma1_act, gamma2_act)
+
+    nbf = system.nbf
+    Ch_a = Ch[:nbf]
+    Ch_b = Ch[nbf:]
+    Z_ao = build_metric_inverted_three_center(system)
+    Z_h = np.einsum("mx,Pmn,ny->Pxy", Ch_a.conj(), Z_ao, Ch_a, optimize=True)
+    Z_h += np.einsum("mx,Pmn,ny->Pxy", Ch_b.conj(), Z_ao, Ch_b, optimize=True)
+
+    W2, W3_h = _build_mc_df_hole_weights(
+        gamma_h,
+        lambda2_act,
+        Z_h,
+        ncore,
+        exchange_factor=1.0,
+    )
+
+    W3 = np.einsum("mx,Pxy,ny->Pmn", Ch_a.conj(), W3_h, Ch_a, optimize=True)
+    W3 += np.einsum("mx,Pxy,ny->Pmn", Ch_b.conj(), W3_h, Ch_b, optimize=True)
     return W2.real, W3.real
 
 
@@ -276,17 +447,17 @@ def _build_casscf_overlap_weight(
     The existing orbital optimizer constructs the matrix :math:`A_{pq}`
     used in the CASSCF/GASSCF orbital gradient
     :math:`g_{pq}=2(A_{pq}-A_{qp})`.  For a fully optimized
-    state-specific CASSCF/GASSCF wave function, the symmetric part of this
+    state-specific CASSCF/GASSCF wave function, the Hermitian part of this
     matrix is the orbital Lagrange multiplier that contracts the overlap
-    derivative.  This helper recomputes :math:`A` in the current final MO
-    basis and transforms
+    derivative. This helper recomputes it in the current final MO basis and
+    transforms
 
     .. math::
         W^S_{\mu\nu}
         =
         C_{\mu p}
-        \frac{1}{2}(A_{pq}+A_{qp})
-        C_{\nu q}.
+        \frac{1}{2}(A_{pq}+A^*_{qp})
+        C^*_{\nu q}.
 
     Parameters
     ----------
@@ -304,29 +475,38 @@ def _build_casscf_overlap_weight(
     NDArray
         AO energy-weighted density with shape ``(nbasis, nbasis)``.
     """
-    orb_opt = OrbOptimizer(
-        C,
-        (mc.mo_space.core, mc.mo_space.actv, mc.mo_space.virt),
-        mc.system.fock_builder,
-        mc.system.ints_hcore(),
-        mc.system.nuclear_repulsion,
-        mc.nrr,
-        compute_active_hessian=False,
+    optimizer_type = (
+        RelOrbOptimizer if isinstance(mc.ci_solver, RelCIBase) else OrbOptimizer
     )
-    orb_opt.set_rdms(gamma1_act, gamma2_act)
-    orb_opt._compute_Fcore()
-    orb_opt.get_eri_gaaa()
-    lagrangian_mo = orb_opt.compute_orbital_lagrangian()
-    return np.einsum("mp,pq,nq->mn", C, lagrangian_mo, C, optimize=True)
-
-
-def _validate_casscf_gradient_supported(mc, pre_run: bool = False) -> None:
-    """Reject CASSCF/GASSCF gradient cases outside the first implementation scope."""
-    if isinstance(mc.ci_solver, RelCIBase):
-        raise NotImplementedError(
-            "CASSCF/GASSCF gradients are implemented only for nonrelativistic "
-            "CASSCF/GASSCF."
+    orb_opt = getattr(mc, "orb_opt", None)
+    can_reuse = (
+        isinstance(orb_opt, optimizer_type)
+        and hasattr(orb_opt, "Fcore")
+        and hasattr(orb_opt, "eri_gaaa")
+        and orb_opt.C.shape == C.shape
+        and np.allclose(orb_opt.C, C, rtol=0.0, atol=1.0e-12)
+    )
+    if not can_reuse:
+        orb_opt = optimizer_type(
+            C,
+            (mc.mo_space.core, mc.mo_space.actv, mc.mo_space.virt),
+            mc.system.fock_builder,
+            mc.system.ints_hcore(),
+            mc.system.nuclear_repulsion,
+            mc.nrr,
+            compute_active_hessian=False,
         )
+        orb_opt._compute_Fcore()
+        orb_opt.get_eri_gaaa()
+
+    orb_opt.set_rdms(gamma1_act, gamma2_act)
+    lagrangian_mo = orb_opt.compute_orbital_lagrangian()
+    return np.einsum("mp,pq,nq->mn", C, lagrangian_mo, C.conj(), optimize=True)
+
+
+def _validate_casscf_gradient_request(mc) -> None:
+    """Reject unsupported CASSCF/GASSCF options before running the method."""
+    is_relativistic = isinstance(mc.ci_solver, RelCIBase)
 
     if mc.ci_solver.sa_info.ncis != 1 or mc.ci_solver.sa_info.nroots_sum != 1:
         raise NotImplementedError(
@@ -343,35 +523,12 @@ def _validate_casscf_gradient_supported(mc, pre_run: bool = False) -> None:
             "GASSCF gradients with frozen inter-GAS rotations are not implemented."
         )
 
-    system = mc.system if hasattr(mc, "system") else mc.parent_method.system
-    if isinstance(system, ModelSystem):
-        raise NotImplementedError(
-            "CASSCF/GASSCF gradients are not implemented for ModelSystem."
-        )
-    if system.cholesky_tei:
-        raise NotImplementedError(
-            "CASSCF/GASSCF gradients are implemented only for density fitting, "
-            "not cholesky_tei."
-        )
-    if system.use_gaussian_charges:
-        raise NotImplementedError(
-            "CASSCF/GASSCF gradients with Gaussian nuclear charges are not implemented."
-        )
-    if system.x2c_type is not None or system.two_component:
-        raise NotImplementedError(
-            "CASSCF/GASSCF gradients with X2C are not implemented."
-        )
-    if system.auxiliary_basis is None:
-        raise NotImplementedError(
-            "CASSCF/GASSCF gradients require an auxiliary basis set for density "
-            "fitting."
-        )
+    system = _find_upstream_system(mc)
+    validate_df_gradient_system(system, "CASSCF/GASSCF")
 
-    max_l = max(system.basis.max_l, system.auxiliary_basis.max_l)
-    if max_l > ints.libint2_max_am:
+    if system.two_component and not is_relativistic:
         raise NotImplementedError(
-            "CASSCF/GASSCF gradients require derivative integrals supported by Libint2 "
-            f"(max_l = {max_l}, Libint2 max_l = {ints.libint2_max_am})."
+            "Two-component CASSCF/GASSCF gradients require a relativistic CI solver."
         )
 
     frozen_core = getattr(mc.ci_solver, "frozen_core_orbitals", None)
@@ -385,9 +542,22 @@ def _validate_casscf_gradient_supported(mc, pre_run: bool = False) -> None:
             "CASSCF/GASSCF gradients with frozen virtual orbitals are not implemented."
         )
 
-    if pre_run:
-        return
 
+def _validate_converged_casscf_gradient(mc) -> None:
+    """Validate restrictions that require a materialized CASSCF wave function."""
+    if not mc.converged:
+        raise RuntimeError(
+            "CASSCF/GASSCF gradients require a converged orbital optimization."
+        )
+
+    convergence_status = mc.ci_solver.get_convergence_status()
+    if convergence_status is not None and not all(convergence_status):
+        raise RuntimeError(
+            "CASSCF/GASSCF gradients require converged CI roots; "
+            f"convergence status: {convergence_status}."
+        )
+
+    is_relativistic = isinstance(mc.ci_solver, RelCIBase)
     if mc.mo_space.nfrozen_core > 0:
         raise NotImplementedError(
             "CASSCF/GASSCF gradients with frozen core orbitals are not implemented."
@@ -400,9 +570,15 @@ def _validate_casscf_gradient_supported(mc, pre_run: bool = False) -> None:
         raise NotImplementedError(
             "GASSCF gradients with frozen inter-GAS rotations are not implemented."
         )
-    if np.iscomplexobj(mc.C[0]):
+    if np.iscomplexobj(mc.C[0]) and not is_relativistic:
         raise NotImplementedError(
-            "CASSCF/GASSCF gradients with complex orbitals are not implemented."
+            "Nonrelativistic CASSCF/GASSCF gradients with complex orbitals are not "
+            "implemented."
+        )
+    if is_relativistic and mc.C[0].shape[0] != 2 * mc.system.nbf:
+        raise ValueError(
+            "Relativistic CASSCF/GASSCF gradients require spinor AO coefficients "
+            "with 2 * system.nbf rows."
         )
 
 
@@ -418,3 +594,13 @@ def _ci_solver_requests_multiple_gas(ci_solver) -> bool:
         )
     mo_space = getattr(ci_solver, "mo_space", None)
     return mo_space is not None and mo_space.ngas > 1
+
+
+def _find_upstream_system(method):
+    """Return the System before an unexecuted composition chain is materialized."""
+    current = method
+    while current is not None:
+        if hasattr(current, "system"):
+            return current.system
+        current = getattr(current, "parent_method", None)
+    raise ValueError("Could not find a System in the CASSCF parent-method chain.")

--- a/forte2/mcopt/orbital_optimizer.py
+++ b/forte2/mcopt/orbital_optimizer.py
@@ -275,6 +275,13 @@ class RelOrbOptimizer(OrbOptimizer):
         # '2RDM' defined as in [eq (6)]
         self.g2 = g2.swapaxes(1, 2)
 
+    def compute_orbital_lagrangian(self):
+        """Return the Hermitian two-component CASSCF orbital Lagrangian."""
+        self._compute_orbgrad()
+        # RelOrbOptimizer stores its generalized Fock matrix with the
+        # Lagrangian indices transposed relative to the AO transformation.
+        return 0.5 * (self.Fock + self.Fock.T.conj()).T
+
     def _compute_reference_energy(self):
         energy = self.Ecore + self.e_nuc
         energy += np.einsum("uv,uv->", self.Fcore[self.actv, self.actv], self.g1)

--- a/tests/mcopt/test_casscf_gradient.py
+++ b/tests/mcopt/test_casscf_gradient.py
@@ -2,18 +2,16 @@ import numpy as np
 import pytest
 
 from forte2 import System, RHF, MCOptimizer, State, CISolver
-
-
-def _xyz(symbols, coordinates):
-    return "\n".join(
-        f"{symbol} {xyz[0]:.16f} {xyz[1]:.16f} {xyz[2]:.16f}"
-        for symbol, xyz in zip(symbols, coordinates)
-    )
+from forte2.integrals import LIBCINT_AVAILABLE
+from tests.gradient_test_utils import (
+    four_point_central_difference_gradient_component,
+    xyz_string,
+)
 
 
 def _system(symbols, coordinates, **kwargs):
     return System(
-        xyz=_xyz(symbols, coordinates),
+        xyz=xyz_string(symbols, coordinates),
         basis_set=kwargs.pop("basis_set", "sto-3g"),
         auxiliary_basis_set=kwargs.pop("auxiliary_basis_set", "def2-universal-JKFIT"),
         unit="bohr",
@@ -118,24 +116,6 @@ def _gasscf_n2_three_gas_energy(symbols, coordinates):
     return _gasscf_n2_three_gas(symbols, coordinates).E
 
 
-def _four_point_central_difference_component(
-    energy_fn, symbols, coordinates, atom, cart, *args, step=1.0e-3, **kwargs
-):
-    coordinates = np.asarray(coordinates, dtype=float)
-
-    def shifted_energy(scale):
-        shifted_coordinates = coordinates.copy()
-        shifted_coordinates[atom, cart] += scale * step
-        return energy_fn(symbols, shifted_coordinates, *args, **kwargs)
-
-    return (
-        -shifted_energy(2.0)
-        + 8.0 * shifted_energy(1.0)
-        - 8.0 * shifted_energy(-1.0)
-        + shifted_energy(-2.0)
-    ) / (12.0 * step)
-
-
 def test_casscf_gradient_h2_full_active_finite_difference_and_translation():
     """Validate the all-active state-specific CASSCF gradient by finite differences."""
     symbols = ["H", "H"]
@@ -146,7 +126,7 @@ def test_casscf_gradient_h2_full_active_finite_difference_and_translation():
 
     for atom in range(2):
         for cart in range(3):
-            numerical = _four_point_central_difference_component(
+            numerical = four_point_central_difference_gradient_component(
                 _casscf_energy, symbols, coordinates, atom, cart, **kwargs
             )
             assert gradient[atom, cart] == pytest.approx(numerical, abs=1.0e-7)
@@ -161,7 +141,7 @@ def test_casscf_gradient_lih_core_active_selected_finite_difference():
     kwargs = {"core_orbitals": [0], "active_orbitals": [1, 2]}
 
     gradient = _casscf_gradient(symbols, coordinates, **kwargs)
-    numerical = _four_point_central_difference_component(
+    numerical = four_point_central_difference_gradient_component(
         _casscf_energy, symbols, coordinates, 1, 2, **kwargs
     )
 
@@ -184,7 +164,7 @@ def test_gasscf_gradient_h2_two_gas_finite_difference_and_translation():
 
     for atom in range(2):
         for cart in range(3):
-            numerical = _four_point_central_difference_component(
+            numerical = four_point_central_difference_gradient_component(
                 _gasscf_h2_energy, symbols, coordinates, atom, cart
             )
             assert gradient[atom, cart] == pytest.approx(numerical, abs=1.0e-7)
@@ -214,7 +194,7 @@ def test_gasscf_gradient_n2_three_gas_selected_finite_difference():
     assert mc.ci_solver.sub_solvers[0].state.gas_max == [4, 4, 2]
     assert len(mc.ci_solver.sub_solvers[0].ci_strings.gas_occupations) > 1
 
-    numerical = _four_point_central_difference_component(
+    numerical = four_point_central_difference_gradient_component(
         _gasscf_n2_three_gas_energy, symbols, coordinates, 1, 2
     )
 
@@ -249,6 +229,44 @@ def test_casscf_gradient_auto_runs_and_reuses_executed_object():
     assert mc.E == pytest.approx(energy1)
     assert gradient1 == pytest.approx(gradient2, abs=1.0e-12)
     assert gradient1.shape == (system.natoms, 3)
+
+
+def test_casscf_gradient_rejects_unconverged_wavefunction(monkeypatch):
+    """Require both orbital and CI stationarity before using the gradient."""
+    mc = _casscf(
+        ["H", "H"],
+        np.array([[0.0, 0.0, 0.0], [0.0, 0.0, 1.7]]),
+        active_orbitals=2,
+    )
+
+    mc.converged = False
+    with pytest.raises(RuntimeError, match="converged orbital optimization"):
+        mc.gradient()
+
+    mc.converged = True
+    monkeypatch.setattr(mc.ci_solver, "get_convergence_status", lambda: [False])
+    with pytest.raises(RuntimeError, match="converged CI roots"):
+        mc.gradient()
+
+
+def test_casscf_gradient_reuses_orbital_optimizer_intermediates(monkeypatch):
+    """Avoid rebuilding orbital intermediates when the final MO basis is unchanged."""
+    mc = _casscf(
+        ["H", "H"],
+        np.array([[0.0, 0.0, 0.0], [0.0, 0.0, 1.7]]),
+        active_orbitals=2,
+        final_orbitals="original",
+    )
+
+    def fail(*args, **kwargs):
+        raise AssertionError("CASSCF gradient rebuilt converged orbital intermediates")
+
+    monkeypatch.setattr(type(mc.orb_opt), "__init__", fail)
+    monkeypatch.setattr(mc.orb_opt, "_compute_Fcore", fail)
+    monkeypatch.setattr(mc.orb_opt, "get_eri_gaaa", fail)
+
+    gradient = mc.gradient()
+    assert gradient.shape == (mc.system.natoms, 3)
 
 
 def test_casscf_gradient_rejects_state_average():
@@ -340,37 +358,79 @@ def test_casscf_gradient_rejects_cholesky_tei():
         mc.gradient()
 
 
-def test_casscf_gradient_rejects_gaussian_nuclear_charges():
-    """Reject Gaussian nuclear charges until their derivative terms are added."""
-    system = _system(
-        ["H", "H"],
-        np.array([[0.0, 0.0, 0.0], [0.0, 0.0, 1.7]]),
-        use_gaussian_charges=True,
-    )
-    rhf = RHF(charge=0)(system)
-    ci_solver = CISolver(
-        State(system=system, multiplicity=1, ms=0.0),
-        active_orbitals=2,
-    )
-    mc = MCOptimizer(ci_solver, final_orbitals="original")(rhf)
+@pytest.mark.skipif(not LIBCINT_AVAILABLE, reason="Libcint is not available")
+def test_casscf_gradient_gaussian_nuclear_charges_finite_difference():
+    """Validate the Gaussian nuclear model in the CASSCF gradient."""
+    symbols = ["H", "H"]
+    coordinates = np.array([[0.0, 0.0, 0.0], [0.0, 0.0, 1.7]])
 
-    with pytest.raises(NotImplementedError, match="Gaussian nuclear charges"):
-        mc.gradient()
+    def casscf(distance, gradient=False):
+        system = _system(
+            symbols,
+            np.array([[0.0, 0.0, 0.0], [0.0, 0.0, distance]]),
+            use_gaussian_charges=True,
+        )
+        rhf = RHF(charge=0, e_tol=1.0e-12, d_tol=1.0e-10)(system)
+        ci_solver = CISolver(
+            State(system=system, multiplicity=1, ms=0.0),
+            active_orbitals=2,
+        )
+        mc = MCOptimizer(
+            ci_solver,
+            e_tol=1.0e-12,
+            g_tol=1.0e-9,
+            final_orbitals="original",
+        )(rhf)
+        return mc.gradient() if gradient else mc.run().E
 
+    def energy(_symbols, displaced):
+        return casscf(displaced[1, 2])
 
-def test_casscf_gradient_rejects_x2c():
-    """Reject X2C CASSCF gradients until relativistic derivative terms are added."""
-    system = _system(
-        ["H", "H"],
-        np.array([[0.0, 0.0, 0.0], [0.0, 0.0, 1.7]]),
-        x2c_type="sf",
+    gradient = casscf(coordinates[1, 2], gradient=True)
+    numerical = four_point_central_difference_gradient_component(
+        energy,
+        symbols,
+        coordinates,
+        1,
+        2,
     )
-    rhf = RHF(charge=0)(system)
-    ci_solver = CISolver(
-        State(system=system, multiplicity=1, ms=0.0),
-        active_orbitals=2,
-    )
-    mc = MCOptimizer(ci_solver, final_orbitals="original")(rhf)
 
-    with pytest.raises(NotImplementedError, match="X2C"):
-        mc.gradient()
+    assert gradient[1, 2] == pytest.approx(numerical, abs=1.0e-8)
+    assert gradient.sum(axis=0) == pytest.approx(np.zeros(3), abs=1.0e-10)
+
+
+def test_sf_x2c_casscf_gradient_finite_difference():
+    """Validate scalar-X2C CASSCF through the shared X2C hcore derivative."""
+    symbols = ["H", "H"]
+    coordinates = np.array([[0.0, 0.0, 0.0], [0.0, 0.0, 1.7]])
+
+    def casscf(distance, gradient=False):
+        system = _system(
+            symbols,
+            np.array([[0.0, 0.0, 0.0], [0.0, 0.0, distance]]),
+            x2c_type="sf",
+            minao_basis_set=None,
+        )
+        rhf = RHF(charge=0, e_tol=1.0e-12, d_tol=1.0e-10)(system)
+        ci_solver = CISolver(
+            State(system=system, multiplicity=1, ms=0.0),
+            active_orbitals=2,
+        )
+        mc = MCOptimizer(
+            ci_solver,
+            e_tol=1.0e-12,
+            g_tol=1.0e-9,
+            final_orbitals="original",
+        )(rhf)
+        return mc.gradient()[1, 2] if gradient else mc.run().E
+
+    analytical = casscf(coordinates[1, 2], gradient=True)
+    step = 1.0e-3
+    energies = [
+        casscf(coordinates[1, 2] + scale * step) for scale in (-2.0, -1.0, 1.0, 2.0)
+    ]
+    numerical = (energies[0] - 8.0 * energies[1] + 8.0 * energies[2] - energies[3]) / (
+        12.0 * step
+    )
+
+    assert analytical == pytest.approx(numerical, abs=1.0e-8)

--- a/tests/mcopt/test_rel_casscf_gradient.py
+++ b/tests/mcopt/test_rel_casscf_gradient.py
@@ -168,9 +168,17 @@ def test_so_x2c_rel_casscf_gradient_finite_difference_and_translation():
         snso_type="row-dependent",
     )
 
-    gradient = _rel_casscf(symbols, coordinates, **options).gradient()
+    mc = _rel_casscf(symbols, coordinates, **options)
+    gradient = mc.gradient()
+
+    def branch_following_energy(symbols, coordinates, **kwargs):
+        displaced = _rel_casscf(symbols, coordinates, **kwargs)
+        # Follow the reference member of the open-shell Kramers pair.
+        displaced.parent_method.C = [mc.parent_method.C[0].copy()]
+        return displaced.run().E.real
+
     numerical = four_point_central_difference_gradient_component(
-        _rel_casscf_energy,
+        branch_following_energy,
         symbols,
         coordinates,
         1,

--- a/tests/mcopt/test_rel_casscf_gradient.py
+++ b/tests/mcopt/test_rel_casscf_gradient.py
@@ -1,0 +1,279 @@
+import numpy as np
+import pytest
+
+from forte2 import (
+    CISolver,
+    GHF,
+    MCOptimizer,
+    RHF,
+    RelCISolver,
+    RelState,
+    SpinorUpcaster,
+    State,
+    System,
+)
+from forte2.integrals import LIBCINT_AVAILABLE
+from tests.gradient_test_utils import (
+    four_point_central_difference_gradient_component,
+    xyz_string,
+)
+
+
+def _system(
+    symbols,
+    coordinates,
+    x2c_type=None,
+    snso_type=None,
+    use_gaussian_charges=False,
+):
+    return System(
+        xyz=xyz_string(symbols, coordinates),
+        basis_set="sto-3g",
+        auxiliary_basis_set="def2-universal-JKFIT",
+        unit="bohr",
+        x2c_type=x2c_type,
+        snso_type=snso_type,
+        use_gaussian_charges=use_gaussian_charges,
+        minao_basis_set=None,
+    )
+
+
+def _rel_casscf(
+    symbols,
+    coordinates,
+    *,
+    nel,
+    active_orbitals,
+    core_orbitals=None,
+    x2c_type=None,
+    snso_type=None,
+    use_gaussian_charges=False,
+    apply_random_phase=False,
+    gas_min=None,
+    gas_max=None,
+):
+    system = _system(
+        symbols,
+        coordinates,
+        x2c_type=x2c_type,
+        snso_type=snso_type,
+        use_gaussian_charges=use_gaussian_charges,
+    )
+    if x2c_type == "so":
+        parent = GHF(charge=0, e_tol=1.0e-10, d_tol=1.0e-6)(system)
+    else:
+        rhf = RHF(charge=0, e_tol=1.0e-12, d_tol=1.0e-10)(system)
+        parent = SpinorUpcaster(
+            apply_random_phase=apply_random_phase,
+            rng=11,
+        )(rhf)
+
+    solver_options = dict(
+        core_orbitals=[] if core_orbitals is None else core_orbitals,
+        active_orbitals=active_orbitals,
+    )
+    if gas_min is None and gas_max is None:
+        ci_solver = RelCISolver(nel=nel, **solver_options)
+    else:
+        ci_solver = RelCISolver(
+            RelState(
+                nel=nel,
+                gas_min=[] if gas_min is None else gas_min,
+                gas_max=[] if gas_max is None else gas_max,
+            ),
+            **solver_options,
+        )
+    return MCOptimizer(
+        ci_solver,
+        e_tol=1.0e-11,
+        g_tol=1.0e-8,
+        maxiter=50,
+        final_orbitals="original",
+    )(parent)
+
+
+def _rel_casscf_energy(symbols, coordinates, **kwargs):
+    return _rel_casscf(symbols, coordinates, **kwargs).run().E.real
+
+
+def test_rel_casscf_gradient_upcast_limit_and_phase_invariance():
+    symbols = ["Li", "H"]
+    coordinates = np.array([[0.0, 0.0, 0.0], [0.0, 0.0, 3.0]])
+
+    system = _system(symbols, coordinates)
+    rhf = RHF(charge=0, e_tol=1.0e-12, d_tol=1.0e-10)(system)
+    ci_solver = CISolver(
+        State(system=system, multiplicity=1, ms=0.0),
+        core_orbitals=[0],
+        active_orbitals=[1, 2],
+    )
+    nonrel = MCOptimizer(
+        ci_solver,
+        e_tol=1.0e-11,
+        g_tol=1.0e-8,
+        maxiter=50,
+        final_orbitals="original",
+    )(rhf)
+    reference = nonrel.gradient()
+
+    options = dict(
+        nel=4,
+        core_orbitals=[0, 1],
+        active_orbitals=[2, 3, 4, 5],
+    )
+    unphased = _rel_casscf(symbols, coordinates, **options).gradient()
+    phased = _rel_casscf(
+        symbols,
+        coordinates,
+        apply_random_phase=True,
+        **options,
+    ).gradient()
+
+    assert unphased == pytest.approx(reference, abs=1.0e-10)
+    assert phased == pytest.approx(reference, abs=1.0e-10)
+
+
+def test_sf_x2c_rel_casscf_gradient_finite_difference_and_translation():
+    symbols = ["H", "H"]
+    coordinates = np.array([[0.0, 0.0, 0.0], [0.0, 0.0, 1.7]])
+    options = dict(
+        nel=2,
+        active_orbitals=4,
+        x2c_type="sf",
+        apply_random_phase=True,
+    )
+
+    gradient = _rel_casscf(symbols, coordinates, **options).gradient()
+    numerical = four_point_central_difference_gradient_component(
+        _rel_casscf_energy,
+        symbols,
+        coordinates,
+        1,
+        2,
+        **options,
+    )
+
+    assert gradient[1, 2] == pytest.approx(numerical, abs=1.0e-8)
+    assert gradient.sum(axis=0) == pytest.approx(np.zeros(3), abs=1.0e-10)
+
+
+def test_so_x2c_rel_casscf_gradient_finite_difference_and_translation():
+    symbols = ["O", "H"]
+    coordinates = np.array([[0.0, 0.0, 0.0], [0.0, 0.0, 1.8]])
+    options = dict(
+        nel=9,
+        core_orbitals=list(range(8)),
+        active_orbitals=list(range(8, 12)),
+        x2c_type="so",
+        snso_type="row-dependent",
+    )
+
+    gradient = _rel_casscf(symbols, coordinates, **options).gradient()
+    numerical = four_point_central_difference_gradient_component(
+        _rel_casscf_energy,
+        symbols,
+        coordinates,
+        1,
+        2,
+        step=5.0e-4,
+        **options,
+    )
+
+    assert gradient[1, 2] == pytest.approx(numerical, abs=5.0e-7)
+    assert gradient.sum(axis=0) == pytest.approx(np.zeros(3), abs=1.0e-9)
+
+
+def test_snso_x2c_rel_casscf_gradient_triatomic_finite_difference():
+    """Exercise correlated two-component CASSCF response with SNSO."""
+    symbols = ["S", "H", "H"]
+    coordinates = np.array(
+        [
+            [0.0, 0.0, 0.0],
+            [0.0, 1.70, 1.80],
+            [0.0, -1.55, 1.95],
+        ]
+    )
+    options = dict(
+        nel=18,
+        core_orbitals=list(range(14)),
+        active_orbitals=list(range(14, 22)),
+        x2c_type="so",
+        snso_type="row-dependent",
+    )
+
+    gradient = _rel_casscf(symbols, coordinates, **options).gradient()
+    numerical = four_point_central_difference_gradient_component(
+        _rel_casscf_energy,
+        symbols,
+        coordinates,
+        1,
+        1,
+        step=5.0e-4,
+        **options,
+    )
+
+    assert gradient[1, 1] == pytest.approx(numerical, abs=2.0e-7)
+    assert np.linalg.norm(gradient) > 1.0e-3
+    assert gradient.sum(axis=0) == pytest.approx(np.zeros(3), abs=1.0e-8)
+
+
+@pytest.mark.parametrize(
+    "use_gaussian_charges",
+    [
+        pytest.param(False, id="point"),
+        pytest.param(
+            True,
+            marks=pytest.mark.skipif(
+                not LIBCINT_AVAILABLE, reason="Libcint is not available"
+            ),
+            id="gaussian",
+        ),
+    ],
+)
+def test_snso_x2c_rel_gasscf_gradient_finite_difference(use_gaussian_charges):
+    """Validate two-component GASSCF with optimized inter-GAS rotations."""
+    symbols = ["Li", "H"]
+    coordinates = np.array([[0.0, 0.0, 0.0], [0.0, 0.0, 3.0]])
+    options = dict(
+        nel=4,
+        core_orbitals=[0, 1],
+        active_orbitals=[[2, 3], [4, 5]],
+        gas_min=[1],
+        gas_max=[2],
+        x2c_type="so",
+        snso_type="row-dependent",
+        use_gaussian_charges=use_gaussian_charges,
+    )
+
+    mc = _rel_casscf(symbols, coordinates, **options)
+    gradient = mc.gradient()
+    numerical = four_point_central_difference_gradient_component(
+        _rel_casscf_energy,
+        symbols,
+        coordinates,
+        1,
+        2,
+        step=5.0e-4,
+        **options,
+    )
+
+    assert mc.mo_space.ngas == 2
+    assert not mc.freeze_inter_gas_rots
+    assert gradient[1, 2] == pytest.approx(numerical, abs=5.0e-7)
+    assert gradient.sum(axis=0) == pytest.approx(np.zeros(3), abs=1.0e-9)
+
+
+def test_rel_casscf_gradient_rejects_state_average_before_auto_run():
+    symbols = ["H", "H"]
+    coordinates = np.array([[0.0, 0.0, 0.0], [0.0, 0.0, 1.7]])
+    system = _system(symbols, coordinates)
+    parent = SpinorUpcaster()(RHF(charge=0)(system))
+    mc = MCOptimizer(
+        RelCISolver(nel=2, nroots=2, active_orbitals=4),
+        final_orbitals="original",
+    )(parent)
+
+    with pytest.raises(NotImplementedError, match="state-specific"):
+        mc.gradient()
+
+    assert not mc.executed


### PR DESCRIPTION
## Stack

This PR is stacked on #209, which provides the derivative-integral, X2C, and
complex GHF gradient infrastructure. Review only the five-file delta against
`x2c-ghf-grad`. Merge #209 first, then retarget this PR to `main` before
merging it; the resulting `main...x2c-mcscf-grad` diff will contain only this
MC-SCF commit.

The complete derivation and implementation notes are included in #209.

## Summary

This PR extends the state-specific CASSCF/GASSCF gradient to complex
two-component wave functions. It also separates the existing nonrelativistic
gradient into its own driver so dispatch between real and relativistic paths is
explicit and both paths share only validation and final assembly.

## Capabilities

| Capability | Wave functions | Hamiltonians/options | Nuclear model |
|---|---|---|---|
| Relativistic single-state gradients | Two-component CASSCF | Spinor-upcast nonrelativistic, SF-X2C-1e, SO-X2C-1e, and SNSO | Point and Gaussian |
| Relativistic single-state gradients | Two-component GASSCF | Spinor-upcast nonrelativistic, SF-X2C-1e, SO-X2C-1e, and SNSO | Point and Gaussian |
| Nonrelativistic driver cleanup | CASSCF/GASSCF | Nonrelativistic | Point and Gaussian |
| Gradient validity checks | CASSCF/GASSCF | All supported cases | Supported models above |

The relativistic path builds complex spinor RDMs, cumulants, orbital
Lagrangians, and density-fitted derivative weights. GASSCF gradients require
all inter-GAS rotations to be optimized.

## Polyene Timings

Environment: Apple M1 Max (64 GB), Release build with libcint, single-threaded
OpenBLAS 0.3.30, `cc-pVTZ/cc-pVTZ-JKFIT`, idealized planar all-trans geometries,
full pi active spaces, and SO-X2C-1e without SNSO. Results are one independent
wall-time sample per case from ground-truth commit `6da257c`. Total excludes
Python startup and `System` construction.

| Molecule | CAS | nbf | Method | SCF | AVAS | CASSCF | Gradient | Total |
|---|---:|---:|---|---:|---:|---:|---:|---:|
| C2H4 | (2,2) | 116 | Nonrelativistic | 0.275 | 0.003 | 0.774 | 0.222 | 1.274 |
| C2H4 | (2,2) | 116 | SO-X2C | 2.675 | 0.039 | 12.594 | 2.047 | 17.354 |
| C4H6 | (4,4) | 204 | Nonrelativistic | 1.429 | 0.008 | 4.191 | 1.263 | 6.891 |
| C4H6 | (4,4) | 204 | SO-X2C | 21.869 | 0.202 | 91.177 | 11.983 | 125.230 |
| C6H8 | (6,6) | 292 | Nonrelativistic | 4.834 | 0.020 | 15.170 | 4.530 | 24.553 |
| C6H8 | (6,6) | 292 | SO-X2C | 91.484 | 0.557 | 347.119 | 39.161 | 478.321 |

All CASSCF cases converged in four macroiterations. The relativistic gradient
overhead is 9.21x, 9.49x, and 8.64x from C2H4 through C6H8. A three-point
log-log fit against spatial AO count gives observed gradient exponents of 3.25
for the nonrelativistic path and 3.19 for SO-X2C. The dominant relativistic cost
in these cases is orbital optimization, not the analytic gradient.

## Validation

- Standalone full non-slow suite: `632 passed, 2 skipped, 28 deselected`.
- Focused MC-SCF gradient suite: `21 passed`.
- Tests cover the spinor-upcast limit, arbitrary spinor phases, SF-X2C,
  SO-X2C, a correlated SNSO triatomic CASSCF case, and an SNSO GASSCF case with
  optimized inter-GAS rotations.
- Gaussian-nucleus gradients are checked against finite differences for
  nonrelativistic CASSCF and SO-X2C/SNSO GASSCF.
- Unconverged orbital optimizations, unconverged CI roots, and unsupported
  nonstationary response cases are rejected before evaluating the gradient.
- The final stacked tree is byte-for-byte identical to the reviewed `x2cgrad`
  ground-truth branch.

## Current Limitations

- Gradients require density-fitted two-electron integrals; Cholesky derivatives
  are not implemented.
- MC-SCF gradients are state-specific and require converged orbital and CI
  optimizations; state-averaged gradients are not implemented.
- Frozen core, frozen virtual, active-frozen, and frozen inter-GAS response
  terms are not implemented.
- Gaussian nuclear models require libcint.
- The relativistic implementation is X2C-1e and does not include two-electron
  picture-change corrections.

## Reviewer Focus

- Verify relativistic RDM transpose conventions and conjugated AO
  back-transformation of the three-center adjoint.
- Verify complex orbital-Lagrangian and DF-weight orientation.
- Confirm unsupported nonstationary CASSCF/GASSCF cases fail before the
  gradient expression is evaluated.
