### PR TITLE
fix(ci): enforce memory and thread limits

### DIFF
--- a/forte2/api/cpp_helpers_api.cc
+++ b/forte2/api/cpp_helpers_api.cc
@@ -5,6 +5,7 @@
 #include "helpers/indexing.hpp"
 #include "helpers/np_matrix_functions.h"
 #include "helpers/logger.h"
+#include "helpers/parallel.h"
 
 namespace nb = nanobind;
 using namespace nb::literals;
@@ -14,6 +15,7 @@ namespace forte2 {
 namespace {
 void export_indexing_api(nb::module_& m);
 void export_logging_api(nb::module_& m);
+void export_parallel_api(nb::module_& m);
 } // namespace
 
 void export_cpp_helpers_api(nb::module_& m) {
@@ -22,6 +24,8 @@ void export_cpp_helpers_api(nb::module_& m) {
     export_indexing_api(sub_m);
 
     export_logging_api(sub_m);
+
+    export_parallel_api(sub_m);
 }
 
 namespace {
@@ -52,6 +56,10 @@ void export_logging_api(nb::module_& sub_m) {
     sub_m.def(
         "get_log_level", []() { return static_cast<int>(Logger::getInstance().getLevel()); },
         "Get the current logging verbosity level");
+}
+
+void export_parallel_api(nb::module_& sub_m) {
+    sub_m.def("get_num_threads", &get_num_threads);
 }
 } // namespace
 } // namespace forte2

--- a/forte2/ci/ci_sigma_builder.cc
+++ b/forte2/ci/ci_sigma_builder.cc
@@ -1,5 +1,7 @@
 #include <iostream>
 #include <iomanip>
+#include <limits>
+#include <string>
 
 #include "helpers/timer.hpp"
 #include "helpers/np_vector_functions.h"
@@ -7,6 +9,7 @@
 #include "helpers/indexing.hpp"
 #include "helpers/blas.h"
 #include "helpers/logger.h"
+#include "helpers/memory.h"
 #include "helpers/unordered_dense.h"
 
 #include "ci_sigma_builder.h"
@@ -69,8 +72,31 @@ void CISigmaBuilder::set_memory(int mb) {
         throw std::invalid_argument("CI builder memory must be non-negative.");
     }
     memory_size_ = static_cast<size_t>(mb) * 1024 * 1024; // Convert MB to bytes
-    std::vector<double>{}.swap(Kblock1_);
-    std::vector<double>{}.swap(Kblock2_);
+    // release the Kblock1_ and Kblock2_ buffers to free up memory
+    free_std_vector_memory(Kblock1_);
+    free_std_vector_memory(Kblock2_);
+}
+
+size_t CISigmaBuilder::max_composite_hole_dimension(const StringAddress& alpha_address,
+                                                    const StringAddress& beta_address,
+                                                    std::string_view rdm_name) {
+    size_t max_alpha = 0;
+    for (int class_Ka = 0; class_Ka < alpha_address.nclasses(); ++class_Ka) {
+        max_alpha = std::max(max_alpha, alpha_address.strpcls(class_Ka));
+    }
+
+    size_t max_beta = 0;
+    for (int class_Kb = 0; class_Kb < beta_address.nclasses(); ++class_Kb) {
+        max_beta = std::max(max_beta, beta_address.strpcls(class_Kb));
+    }
+
+    if ((max_alpha == 0) or (max_beta == 0))
+        return 0;
+    if (max_alpha > std::numeric_limits<size_t>::max() / max_beta) {
+        throw std::overflow_error("The composite " + std::string(rdm_name) +
+                                  " hole dimension is too large.");
+    }
+    return max_alpha * max_beta;
 }
 
 void CISigmaBuilder::set_Hamiltonian(double E, np_matrix H, np_tensor4 V) {

--- a/forte2/ci/ci_sigma_builder.cc
+++ b/forte2/ci/ci_sigma_builder.cc
@@ -65,7 +65,12 @@ std::string CISigmaBuilder::get_algorithm() const {
 }
 
 void CISigmaBuilder::set_memory(int mb) {
-    memory_size_ = mb * 1024 * 1024; // Convert MB to bytes
+    if (mb < 0) {
+        throw std::invalid_argument("CI builder memory must be non-negative.");
+    }
+    memory_size_ = static_cast<size_t>(mb) * 1024 * 1024; // Convert MB to bytes
+    std::vector<double>{}.swap(Kblock1_);
+    std::vector<double>{}.swap(Kblock2_);
 }
 
 void CISigmaBuilder::set_Hamiltonian(double E, np_matrix H, np_tensor4 V) {

--- a/forte2/ci/ci_sigma_builder.h
+++ b/forte2/ci/ci_sigma_builder.h
@@ -3,6 +3,7 @@
 #include <functional>
 #include <cmath>
 #include <span>
+#include <string_view>
 #include <tuple>
 #include <vector>
 
@@ -367,6 +368,11 @@ class CISigmaBuilder {
     /// algorithm.
     void H2_kh(std::span<double> basis, std::span<double> sigma) const;
 
+    /// @brief Get the spans of the Kblock buffers for a given number of rows and columns
+    /// @param nrows The number of rows in the block
+    /// @param ncols The number of columns in the block
+    /// @return A tuple containing the spans of the Kblock buffers and the number of columns
+    ///         that fit in each buffer
     std::tuple<std::span<double>, std::span<double>, size_t> get_Kblock_spans(size_t nrows,
                                                                               size_t ncols) const;
 
@@ -374,6 +380,14 @@ class CISigmaBuilder {
     /// @return The number of columns that fit in each buffer.
     size_t acquire_local_Kblock_buffers(std::vector<double>& Kblock1, std::vector<double>& Kblock2,
                                         size_t nrows, size_t ncols) const;
+
+    /// @brief Find the largest product of class sizes in two hole-string address spaces.
+    /// @param alpha_address Alpha hole-string address space.
+    /// @param beta_address Beta hole-string address space.
+    /// @param rdm_name RDM name used to identify an overflowing dimension.
+    static size_t max_composite_hole_dimension(const StringAddress& alpha_address,
+                                               const StringAddress& beta_address,
+                                               std::string_view rdm_name);
 };
 
 [[nodiscard]] std::span<double> gather_block(std::span<double> source, std::span<double> dest,

--- a/forte2/ci/ci_sigma_builder.h
+++ b/forte2/ci/ci_sigma_builder.h
@@ -1,9 +1,10 @@
 #pragma once
 
 #include <functional>
-#include <vector>
 #include <cmath>
 #include <span>
+#include <tuple>
+#include <vector>
 
 #include "helpers/ndarray.h"
 #include "helpers/spin.h"
@@ -366,8 +367,13 @@ class CISigmaBuilder {
     /// algorithm.
     void H2_kh(std::span<double> basis, std::span<double> sigma) const;
 
-    std::tuple<std::span<double>, std::span<double>, size_t> get_Kblock_spans(size_t dim,
-                                                                              size_t maxKa) const;
+    std::tuple<std::span<double>, std::span<double>, size_t> get_Kblock_spans(size_t nrows,
+                                                                              size_t ncols) const;
+
+    /// @brief Acquire call-local K-block buffers subject to the CI builder memory limit.
+    /// @return The number of columns that fit in each buffer.
+    size_t acquire_local_Kblock_buffers(std::vector<double>& Kblock1, std::vector<double>& Kblock2,
+                                        size_t nrows, size_t ncols) const;
 };
 
 [[nodiscard]] std::span<double> gather_block(std::span<double> source, std::span<double> dest,

--- a/forte2/ci/ci_sigma_builder_2rdm.cc
+++ b/forte2/ci/ci_sigma_builder_2rdm.cc
@@ -1,3 +1,6 @@
+#include <limits>
+#include <stdexcept>
+
 #include "helpers/timer.hpp"
 #include "helpers/np_matrix_functions.h"
 #include "helpers/np_vector_functions.h"
@@ -104,7 +107,6 @@ np_tensor4 CISigmaBuilder::compute_ab_2rdm(np_vector C_left, np_vector C_right) 
     const auto nb = lists_.nb();
     const auto norb = lists_.norb();
     const auto norb2 = norb * norb;
-    const auto norb3 = norb2 * norb;
 
     auto rdm = make_zeros<nb::numpy, double, 4>({norb, norb, norb, norb});
 
@@ -121,11 +123,33 @@ np_tensor4 CISigmaBuilder::compute_ab_2rdm(np_vector C_left, np_vector C_right) 
     const int num_1h_class_Ka = lists_.alpha_address_1h()->nclasses();
     const int num_1h_class_Kb = lists_.beta_address_1h()->nclasses();
 
-    // The contraction gamma[uv,xy] = sum_{Ka,Kb} (sign_u sign_v Cl[Ja,Jb]) (sign_x sign_y Cr[Ia,Ib])
-    // is a matrix product over the composite one-hole index K = (Ka, Kb)
-    // we can gather the (signed) left coefficients into B_L[(u*norb+v), K] and 
-    // the (signed) right coefficients into B_R[(x*norb+y), K], then accumulate gamma[(uv),(xy)] += B_L * B_R^T 
-    // with one zgemm per Ka-chunk
+    size_t max_composite_K = 0;
+    for (int class_Ka = 0; class_Ka < num_1h_class_Ka; ++class_Ka) {
+        const size_t maxKa = lists_.alpha_address_1h()->strpcls(class_Ka);
+        for (int class_Kb = 0; class_Kb < num_1h_class_Kb; ++class_Kb) {
+            const size_t maxKb = lists_.beta_address_1h()->strpcls(class_Kb);
+            if ((maxKa == 0) or (maxKb == 0))
+                continue;
+            if (maxKa > std::numeric_limits<size_t>::max() / maxKb) {
+                throw std::overflow_error("The composite 2-RDM hole dimension is too large.");
+            }
+            max_composite_K = std::max(max_composite_K, maxKa * maxKb);
+        }
+    }
+    if (max_composite_K == 0) {
+        rdm2_ab_timer_ += timer.elapsed_seconds();
+        return rdm;
+    }
+
+    std::vector<double> Kblock1;
+    std::vector<double> Kblock2;
+    const size_t Kblock_size =
+        acquire_local_Kblock_buffers(Kblock1, Kblock2, norb2, max_composite_K);
+
+    // The contraction gamma[uv,xy] = sum_{Ka,Kb} (sign_u sign_v Cl[Ja,Jb])
+    // (sign_x sign_y Cr[Ia,Ib]) is a matrix product over the composite one-hole index
+    // K = (Ka, Kb). Gather the signed coefficients into B_L[(uv),K] and B_R[(xy),K],
+    // then accumulate gamma += B_L * B_R^T one bounded composite-K chunk at a time.
     for (int class_Ka = 0; class_Ka < num_1h_class_Ka; ++class_Ka) {
         const auto maxKa = lists_.alpha_address_1h()->strpcls(class_Ka);
         for (int class_Kb = 0; class_Kb < num_1h_class_Kb; ++class_Kb) {
@@ -133,14 +157,10 @@ np_tensor4 CISigmaBuilder::compute_ab_2rdm(np_vector C_left, np_vector C_right) 
             if ((maxKa == 0) or (maxKb == 0))
                 continue;
 
-            // B_L and B_R are each norb^2 x Kdim; both fit in a Kblock buffer.
-            auto [Kblock1, Kblock2, Ka_block_size] = get_Kblock_spans(norb2 * maxKb, maxKa);
+            const size_t maxK = maxKa * maxKb;
 
-            for (size_t Ka_block_start = 0; Ka_block_start < maxKa;
-                 Ka_block_start += Ka_block_size) {
-                const size_t Ka_block_end = std::min(Ka_block_start + Ka_block_size, maxKa);
-                const size_t Ka_size = Ka_block_end - Ka_block_start;
-                const size_t Kdim = Ka_size * maxKb;
+            for (size_t Kblock_start = 0; Kblock_start < maxK;) {
+                const size_t Kdim = std::min(Kblock_size, maxK - Kblock_start);
                 const auto temp_dim = norb2 * Kdim;
 
                 // B_L[uv, K] in Kblock1, B_R[xy, K] in Kblock2
@@ -157,18 +177,18 @@ np_tensor4 CISigmaBuilder::compute_ab_2rdm(np_vector C_left, np_vector C_right) 
                     const auto& Kb_right_list = lists_.get_beta_1h_list2(class_Kb, class_Ib);
                     if (Ka_right_list.empty() || Kb_right_list.empty())
                         continue;
-                    for (size_t Ka = 0; Ka < Ka_size; ++Ka) {
-                        const auto& KaR = Ka_right_list[Ka_block_start + Ka];
-                        for (size_t Kb = 0; Kb < maxKb; ++Kb) {
-                            const auto& KbR = Kb_right_list[Kb];
-                            const auto Kidx = Ka * maxKb + Kb;
-                            for (const auto& [sign_x, x, Ia] : KaR) {
-                                const size_t xnorb = x * norb;
-                                const auto Cr_Ia_offset = Cr_offset + Ia * maxIb;
-                                for (const auto& [sign_y, y, Ib] : KbR) {
-                                    Kblock2[(xnorb + y) * Kdim + Kidx] =
-                                        sign_x * sign_y * Cr_span[Cr_Ia_offset + Ib];
-                                }
+                    for (size_t Kidx = 0; Kidx < Kdim; ++Kidx) {
+                        const size_t K = Kblock_start + Kidx;
+                        const size_t Ka = K / maxKb;
+                        const size_t Kb = K % maxKb;
+                        const auto& KaR = Ka_right_list[Ka];
+                        const auto& KbR = Kb_right_list[Kb];
+                        for (const auto& [sign_x, x, Ia] : KaR) {
+                            const size_t xnorb = x * norb;
+                            const auto Cr_Ia_offset = Cr_offset + Ia * maxIb;
+                            for (const auto& [sign_y, y, Ib] : KbR) {
+                                Kblock2[(xnorb + y) * Kdim + Kidx] =
+                                    sign_x * sign_y * Cr_span[Cr_Ia_offset + Ib];
                             }
                         }
                     }
@@ -184,18 +204,18 @@ np_tensor4 CISigmaBuilder::compute_ab_2rdm(np_vector C_left, np_vector C_right) 
                     const auto& Kb_left_list = lists_.get_beta_1h_list2(class_Kb, class_Jb);
                     if (Ka_left_list.empty() || Kb_left_list.empty())
                         continue;
-                    for (size_t Ka = 0; Ka < Ka_size; ++Ka) {
-                        const auto& KaL = Ka_left_list[Ka_block_start + Ka];
-                        for (size_t Kb = 0; Kb < maxKb; ++Kb) {
-                            const auto& KbL = Kb_left_list[Kb];
-                            const auto Kidx = Ka * maxKb + Kb;
-                            for (const auto& [sign_u, u, Ja] : KaL) {
-                                const size_t unorb = u * norb;
-                                const auto Cl_Ja_offset = Cl_offset + Ja * maxJb;
-                                for (const auto& [sign_v, v, Jb] : KbL) {
-                                    Kblock1[(unorb + v) * Kdim + Kidx] =
-                                        sign_u * sign_v * Cl_span[Cl_Ja_offset + Jb];
-                                }
+                    for (size_t Kidx = 0; Kidx < Kdim; ++Kidx) {
+                        const size_t K = Kblock_start + Kidx;
+                        const size_t Ka = K / maxKb;
+                        const size_t Kb = K % maxKb;
+                        const auto& KaL = Ka_left_list[Ka];
+                        const auto& KbL = Kb_left_list[Kb];
+                        for (const auto& [sign_u, u, Ja] : KaL) {
+                            const size_t unorb = u * norb;
+                            const auto Cl_Ja_offset = Cl_offset + Ja * maxJb;
+                            for (const auto& [sign_v, v, Jb] : KbL) {
+                                Kblock1[(unorb + v) * Kdim + Kidx] =
+                                    sign_u * sign_v * Cl_span[Cl_Ja_offset + Jb];
                             }
                         }
                     }
@@ -204,6 +224,7 @@ np_tensor4 CISigmaBuilder::compute_ab_2rdm(np_vector C_left, np_vector C_right) 
                 // gamma[uv,xy] += sum_K B_L[uv,K] B_R[xy,K]
                 matrix_product('N', 'T', norb2, norb2, Kdim, 1.0, Kblock1.data(), Kdim,
                                Kblock2.data(), Kdim, 1.0, rdm_data, norb2);
+                Kblock_start += Kdim;
             }
         }
     }

--- a/forte2/ci/ci_sigma_builder_2rdm.cc
+++ b/forte2/ci/ci_sigma_builder_2rdm.cc
@@ -1,6 +1,3 @@
-#include <limits>
-#include <stdexcept>
-
 #include "helpers/timer.hpp"
 #include "helpers/np_matrix_functions.h"
 #include "helpers/np_vector_functions.h"
@@ -10,6 +7,41 @@
 #include "ci_sigma_builder.h"
 
 namespace forte2 {
+
+namespace {
+
+/// Gather signed alpha/beta one-hole coefficients into a composite-hole K-block.
+void gather_ab_2rdm_block(const CIStrings& lists, int class_Ka, int class_Kb, size_t maxKb,
+                          size_t Kblock_start, size_t Kdim, size_t norb,
+                          std::span<const double> coefficients, std::span<double> Kblock) {
+    for (const auto& [nI, class_Ia, class_Ib] : lists.determinant_classes()) {
+        if (lists.block_size(nI) == 0)
+            continue;
+
+        const auto maxIb = lists.beta_address()->strpcls(class_Ib);
+        const auto coefficient_offset = lists.block_offset(nI);
+        const auto& Ka_list = lists.get_alpha_1h_list2(class_Ka, class_Ia);
+        const auto& Kb_list = lists.get_beta_1h_list2(class_Kb, class_Ib);
+        if (Ka_list.empty() || Kb_list.empty())
+            continue;
+
+        for (size_t Kidx = 0; Kidx < Kdim; ++Kidx) {
+            const size_t K = Kblock_start + Kidx;
+            const size_t Ka = K / maxKb;
+            const size_t Kb = K % maxKb;
+            for (const auto& [sign_p, p, Ia] : Ka_list[Ka]) {
+                const size_t pnorb = p * norb;
+                const auto coefficient_Ia_offset = coefficient_offset + Ia * maxIb;
+                for (const auto& [sign_q, q, Ib] : Kb_list[Kb]) {
+                    Kblock[(pnorb + q) * Kdim + Kidx] =
+                        sign_p * sign_q * coefficients[coefficient_Ia_offset + Ib];
+                }
+            }
+        }
+    }
+}
+
+} // namespace
 
 np_matrix CISigmaBuilder::compute_ss_2rdm(np_vector C_left, np_vector C_right, Spin spin) const {
     local_timer timer;
@@ -123,19 +155,8 @@ np_tensor4 CISigmaBuilder::compute_ab_2rdm(np_vector C_left, np_vector C_right) 
     const int num_1h_class_Ka = lists_.alpha_address_1h()->nclasses();
     const int num_1h_class_Kb = lists_.beta_address_1h()->nclasses();
 
-    size_t max_composite_K = 0;
-    for (int class_Ka = 0; class_Ka < num_1h_class_Ka; ++class_Ka) {
-        const size_t maxKa = lists_.alpha_address_1h()->strpcls(class_Ka);
-        for (int class_Kb = 0; class_Kb < num_1h_class_Kb; ++class_Kb) {
-            const size_t maxKb = lists_.beta_address_1h()->strpcls(class_Kb);
-            if ((maxKa == 0) or (maxKb == 0))
-                continue;
-            if (maxKa > std::numeric_limits<size_t>::max() / maxKb) {
-                throw std::overflow_error("The composite 2-RDM hole dimension is too large.");
-            }
-            max_composite_K = std::max(max_composite_K, maxKa * maxKb);
-        }
-    }
+    const size_t max_composite_K = max_composite_hole_dimension(
+        *lists_.alpha_address_1h(), *lists_.beta_address_1h(), "2-RDM");
     if (max_composite_K == 0) {
         rdm2_ab_timer_ += timer.elapsed_seconds();
         return rdm;
@@ -167,59 +188,11 @@ np_tensor4 CISigmaBuilder::compute_ab_2rdm(np_vector C_left, np_vector C_right) 
                 std::fill_n(Kblock1.begin(), temp_dim, 0.0);
                 std::fill_n(Kblock2.begin(), temp_dim, 0.0);
 
-                // Gather the (signed) right coefficients into B_R[(x*norb+y), K]
-                for (const auto& [nI, class_Ia, class_Ib] : lists_.determinant_classes()) {
-                    if (lists_.block_size(nI) == 0)
-                        continue;
-                    const auto maxIb = lists_.beta_address()->strpcls(class_Ib);
-                    const auto Cr_offset = lists_.block_offset(nI);
-                    const auto& Ka_right_list = lists_.get_alpha_1h_list2(class_Ka, class_Ia);
-                    const auto& Kb_right_list = lists_.get_beta_1h_list2(class_Kb, class_Ib);
-                    if (Ka_right_list.empty() || Kb_right_list.empty())
-                        continue;
-                    for (size_t Kidx = 0; Kidx < Kdim; ++Kidx) {
-                        const size_t K = Kblock_start + Kidx;
-                        const size_t Ka = K / maxKb;
-                        const size_t Kb = K % maxKb;
-                        const auto& KaR = Ka_right_list[Ka];
-                        const auto& KbR = Kb_right_list[Kb];
-                        for (const auto& [sign_x, x, Ia] : KaR) {
-                            const size_t xnorb = x * norb;
-                            const auto Cr_Ia_offset = Cr_offset + Ia * maxIb;
-                            for (const auto& [sign_y, y, Ib] : KbR) {
-                                Kblock2[(xnorb + y) * Kdim + Kidx] =
-                                    sign_x * sign_y * Cr_span[Cr_Ia_offset + Ib];
-                            }
-                        }
-                    }
-                }
-
-                // Gather the (signed) left coefficients into B_L[(u*norb+v), K]
-                for (const auto& [nJ, class_Ja, class_Jb] : lists_.determinant_classes()) {
-                    if (lists_.block_size(nJ) == 0)
-                        continue;
-                    const auto maxJb = lists_.beta_address()->strpcls(class_Jb);
-                    const auto Cl_offset = lists_.block_offset(nJ);
-                    const auto& Ka_left_list = lists_.get_alpha_1h_list2(class_Ka, class_Ja);
-                    const auto& Kb_left_list = lists_.get_beta_1h_list2(class_Kb, class_Jb);
-                    if (Ka_left_list.empty() || Kb_left_list.empty())
-                        continue;
-                    for (size_t Kidx = 0; Kidx < Kdim; ++Kidx) {
-                        const size_t K = Kblock_start + Kidx;
-                        const size_t Ka = K / maxKb;
-                        const size_t Kb = K % maxKb;
-                        const auto& KaL = Ka_left_list[Ka];
-                        const auto& KbL = Kb_left_list[Kb];
-                        for (const auto& [sign_u, u, Ja] : KaL) {
-                            const size_t unorb = u * norb;
-                            const auto Cl_Ja_offset = Cl_offset + Ja * maxJb;
-                            for (const auto& [sign_v, v, Jb] : KbL) {
-                                Kblock1[(unorb + v) * Kdim + Kidx] =
-                                    sign_u * sign_v * Cl_span[Cl_Ja_offset + Jb];
-                            }
-                        }
-                    }
-                }
+                // Gather the signed right and left coefficients into B_R[(xy),K] and B_L[(uv),K].
+                gather_ab_2rdm_block(lists_, class_Ka, class_Kb, maxKb, Kblock_start, Kdim, norb,
+                                     Cr_span, Kblock2);
+                gather_ab_2rdm_block(lists_, class_Ka, class_Kb, maxKb, Kblock_start, Kdim, norb,
+                                     Cl_span, Kblock1);
 
                 // gamma[uv,xy] += sum_K B_L[uv,K] B_R[xy,K]
                 matrix_product('N', 'T', norb2, norb2, Kdim, 1.0, Kblock1.data(), Kdim,

--- a/forte2/ci/ci_sigma_builder_3rdm.cc
+++ b/forte2/ci/ci_sigma_builder_3rdm.cc
@@ -1,6 +1,3 @@
-#include <limits>
-#include <stdexcept>
-
 #include "helpers/timer.hpp"
 #include "helpers/np_matrix_functions.h"
 #include "helpers/np_vector_functions.h"
@@ -10,6 +7,79 @@
 #include "ci_sigma_builder.h"
 
 namespace forte2 {
+
+namespace {
+
+/// Gather signed two-alpha-hole/one-beta-hole coefficients into an AAB 3-RDM K-block.
+void gather_aab_3rdm_block(const CIStrings& lists, int class_Ka, int class_Kb, size_t maxKb,
+                           size_t Kblock_start, size_t Kdim, size_t norb,
+                           std::span<const double> coefficients, std::span<double> Kblock) {
+    for (const auto& [nI, class_Ia, class_Ib] : lists.determinant_classes()) {
+        if (lists.block_size(nI) == 0)
+            continue;
+
+        const auto maxIb = lists.beta_address()->strpcls(class_Ib);
+        const auto coefficient_offset = lists.block_offset(nI);
+        const auto& Kb_list = lists.get_beta_1h_list2(class_Kb, class_Ib);
+        if (Kb_list.empty())
+            continue;
+
+        for (size_t Kidx = 0; Kidx < Kdim; ++Kidx) {
+            const size_t K = Kblock_start + Kidx;
+            const size_t Ka = K / maxKb;
+            const size_t Kb = K % maxKb;
+            const auto& Ka_list = lists.get_alpha_2h_list(class_Ka, Ka, class_Ia);
+            if (Ka_list.empty())
+                continue;
+
+            for (const auto& [sign_pq, p, q, Ia] : Ka_list) {
+                const size_t row = pair_index_gt<size_t>(p, q) * norb;
+                const auto coefficient_Ia_offset = coefficient_offset + Ia * maxIb;
+                for (const auto& [sign_r, r, Ib] : Kb_list[Kb]) {
+                    Kblock[(row + r) * Kdim + Kidx] =
+                        sign_pq * sign_r * coefficients[coefficient_Ia_offset + Ib];
+                }
+            }
+        }
+    }
+}
+
+/// Gather signed one-alpha-hole/two-beta-hole coefficients into an ABB 3-RDM K-block.
+void gather_abb_3rdm_block(const CIStrings& lists, int class_Ka, int class_Kb, size_t maxKb,
+                           size_t Kblock_start, size_t Kdim, size_t npair,
+                           std::span<const double> coefficients, std::span<double> Kblock) {
+    for (const auto& [nI, class_Ia, class_Ib] : lists.determinant_classes()) {
+        if (lists.block_size(nI) == 0)
+            continue;
+
+        const auto maxIb = lists.beta_address()->strpcls(class_Ib);
+        const auto coefficient_offset = lists.block_offset(nI);
+        const auto& Ka_list = lists.get_alpha_1h_list2(class_Ka, class_Ia);
+        if (Ka_list.empty())
+            continue;
+
+        for (size_t Kidx = 0; Kidx < Kdim; ++Kidx) {
+            const size_t K = Kblock_start + Kidx;
+            const size_t Ka = K / maxKb;
+            const size_t Kb = K % maxKb;
+            const auto& Kb_list = lists.get_beta_2h_list(class_Kb, Kb, class_Ib);
+            if (Kb_list.empty())
+                continue;
+
+            for (const auto& [sign_p, p, Ia] : Ka_list[Ka]) {
+                const size_t row = p * npair;
+                const auto coefficient_Ia_offset = coefficient_offset + Ia * maxIb;
+                for (const auto& [sign_qr, q, r, Ib] : Kb_list) {
+                    const size_t qr_index = pair_index_gt<size_t>(q, r);
+                    Kblock[(row + qr_index) * Kdim + Kidx] =
+                        sign_p * sign_qr * coefficients[coefficient_Ia_offset + Ib];
+                }
+            }
+        }
+    }
+}
+
+} // namespace
 
 np_matrix CISigmaBuilder::compute_sss_3rdm(np_vector C_left, np_vector C_right, Spin spin) const {
     local_timer timer;
@@ -127,19 +197,8 @@ np_tensor4 CISigmaBuilder::compute_aab_3rdm(np_vector C_left, np_vector C_right)
     int num_2h_class_Ka = lists_.alpha_address_2h()->nclasses();
     int num_1h_class_Kb = lists_.beta_address_1h()->nclasses();
 
-    size_t max_composite_K = 0;
-    for (int class_Ka = 0; class_Ka < num_2h_class_Ka; ++class_Ka) {
-        const size_t maxKa = lists_.alpha_address_2h()->strpcls(class_Ka);
-        for (int class_Kb = 0; class_Kb < num_1h_class_Kb; ++class_Kb) {
-            const size_t maxKb = lists_.beta_address_1h()->strpcls(class_Kb);
-            if ((maxKa == 0) or (maxKb == 0))
-                continue;
-            if (maxKa > std::numeric_limits<size_t>::max() / maxKb) {
-                throw std::overflow_error("The composite AAB 3-RDM hole dimension is too large.");
-            }
-            max_composite_K = std::max(max_composite_K, maxKa * maxKb);
-        }
-    }
+    const size_t max_composite_K = max_composite_hole_dimension(
+        *lists_.alpha_address_2h(), *lists_.beta_address_1h(), "AAB 3-RDM");
     if (max_composite_K == 0)
         return rdm;
 
@@ -168,64 +227,12 @@ np_tensor4 CISigmaBuilder::compute_aab_3rdm(np_vector C_left, np_vector C_right)
                 std::fill_n(Kblock1.begin(), temp_dim, 0.0);
                 std::fill_n(Kblock2.begin(), temp_dim, 0.0);
 
-                // Gather the (signed) right coefficients into B_R[(xy*norb+z), K]
-                for (const auto& [nI, class_Ia, class_Ib] : lists_.determinant_classes()) {
-                    if (lists_.block_size(nI) == 0)
-                        continue;
-                    const auto maxIb = lists_.beta_address()->strpcls(class_Ib);
-                    const auto Cr_offset = lists_.block_offset(nI);
-                    const auto& Kb_right_list = lists_.get_beta_1h_list2(class_Kb, class_Ib);
-                    if (Kb_right_list.empty())
-                        continue;
-                    for (size_t Kidx = 0; Kidx < Kdim; ++Kidx) {
-                        const size_t K = Kblock_start + Kidx;
-                        const size_t Ka = K / maxKb;
-                        const size_t Kb = K % maxKb;
-                        const auto& Ka_right_list =
-                            lists_.get_alpha_2h_list(class_Ka, Ka, class_Ia);
-                        if (Ka_right_list.empty())
-                            continue;
-                        const auto& KbR = Kb_right_list[Kb];
-                        for (const auto& [sign_xy, x, y, Ia] : Ka_right_list) {
-                            const auto xy_index = pair_index_gt<size_t>(x, y);
-                            const size_t row_xy = xy_index * norb;
-                            const auto Cr_Ia_offset = Cr_offset + Ia * maxIb;
-                            for (const auto& [sign_z, z, Ib] : KbR) {
-                                Kblock2[(row_xy + z) * Kdim + Kidx] =
-                                    sign_xy * sign_z * Cr_span[Cr_Ia_offset + Ib];
-                            }
-                        }
-                    }
-                }
-
-                // Gather the (signed) left coefficients into B_L[(uv*norb+w), K]
-                for (const auto& [nJ, class_Ja, class_Jb] : lists_.determinant_classes()) {
-                    if (lists_.block_size(nJ) == 0)
-                        continue;
-                    const auto maxJb = lists_.beta_address()->strpcls(class_Jb);
-                    const auto Cl_offset = lists_.block_offset(nJ);
-                    const auto& Kb_left_list = lists_.get_beta_1h_list2(class_Kb, class_Jb);
-                    if (Kb_left_list.empty())
-                        continue;
-                    for (size_t Kidx = 0; Kidx < Kdim; ++Kidx) {
-                        const size_t K = Kblock_start + Kidx;
-                        const size_t Ka = K / maxKb;
-                        const size_t Kb = K % maxKb;
-                        const auto& Ka_left_list = lists_.get_alpha_2h_list(class_Ka, Ka, class_Ja);
-                        if (Ka_left_list.empty())
-                            continue;
-                        const auto& KbL = Kb_left_list[Kb];
-                        for (const auto& [sign_uv, u, v, Ja] : Ka_left_list) {
-                            const auto uv_index = pair_index_gt<size_t>(u, v);
-                            const size_t row_uv = uv_index * norb;
-                            const auto Cl_Ja_offset = Cl_offset + Ja * maxJb;
-                            for (const auto& [sign_w, w, Jb] : KbL) {
-                                Kblock1[(row_uv + w) * Kdim + Kidx] =
-                                    sign_uv * sign_w * Cl_span[Cl_Ja_offset + Jb];
-                            }
-                        }
-                    }
-                }
+                // Gather the signed right and left coefficients into B_R[(xy,z),K] and
+                // B_L[(uv,w),K].
+                gather_aab_3rdm_block(lists_, class_Ka, class_Kb, maxKb, Kblock_start, Kdim, norb,
+                                      Cr_span, Kblock2);
+                gather_aab_3rdm_block(lists_, class_Ka, class_Kb, maxKb, Kblock_start, Kdim, norb,
+                                      Cl_span, Kblock1);
 
                 matrix_product('N', 'T', M, M, Kdim, 1.0, Kblock1.data(), Kdim, Kblock2.data(),
                                Kdim, 1.0, rdm_data, M);
@@ -264,19 +271,8 @@ np_tensor4 CISigmaBuilder::compute_abb_3rdm(np_vector C_left, np_vector C_right)
     int num_1h_class_Ka = lists_.alpha_address_1h()->nclasses();
     int num_2h_class_Kb = lists_.beta_address_2h()->nclasses();
 
-    size_t max_composite_K = 0;
-    for (int class_Ka = 0; class_Ka < num_1h_class_Ka; ++class_Ka) {
-        const size_t maxKa = lists_.alpha_address_1h()->strpcls(class_Ka);
-        for (int class_Kb = 0; class_Kb < num_2h_class_Kb; ++class_Kb) {
-            const size_t maxKb = lists_.beta_address_2h()->strpcls(class_Kb);
-            if ((maxKa == 0) or (maxKb == 0))
-                continue;
-            if (maxKa > std::numeric_limits<size_t>::max() / maxKb) {
-                throw std::overflow_error("The composite ABB 3-RDM hole dimension is too large.");
-            }
-            max_composite_K = std::max(max_composite_K, maxKa * maxKb);
-        }
-    }
+    const size_t max_composite_K = max_composite_hole_dimension(
+        *lists_.alpha_address_1h(), *lists_.beta_address_2h(), "ABB 3-RDM");
     if (max_composite_K == 0)
         return rdm;
 
@@ -305,63 +301,12 @@ np_tensor4 CISigmaBuilder::compute_abb_3rdm(np_vector C_left, np_vector C_right)
                 std::fill_n(Kblock1.begin(), temp_dim, 0.0);
                 std::fill_n(Kblock2.begin(), temp_dim, 0.0);
 
-                // Gather the (signed) right coefficients into B_R[(x*npair+yz), K]
-                for (const auto& [nI, class_Ia, class_Ib] : lists_.determinant_classes()) {
-                    if (lists_.block_size(nI) == 0)
-                        continue;
-                    const auto maxIb = lists_.beta_address()->strpcls(class_Ib);
-                    const auto Cr_offset = lists_.block_offset(nI);
-                    const auto& Ka_right_list = lists_.get_alpha_1h_list2(class_Ka, class_Ia);
-                    if (Ka_right_list.empty())
-                        continue;
-                    for (size_t Kidx = 0; Kidx < Kdim; ++Kidx) {
-                        const size_t K = Kblock_start + Kidx;
-                        const size_t Ka = K / maxKb;
-                        const size_t Kb = K % maxKb;
-                        const auto& Kb_right_list = lists_.get_beta_2h_list(class_Kb, Kb, class_Ib);
-                        if (Kb_right_list.empty())
-                            continue;
-                        const auto& KaR = Ka_right_list[Ka];
-                        for (const auto& [sign_x, x, Ia] : KaR) {
-                            const size_t row_x = x * npair;
-                            const auto Cr_Ia_offset = Cr_offset + Ia * maxIb;
-                            for (const auto& [sign_yz, y, z, Ib] : Kb_right_list) {
-                                const auto yz_index = pair_index_gt<size_t>(y, z);
-                                Kblock2[(row_x + yz_index) * Kdim + Kidx] =
-                                    sign_x * sign_yz * Cr_span[Cr_Ia_offset + Ib];
-                            }
-                        }
-                    }
-                }
-
-                // Gather the (signed) left coefficients into B_L[(u*npair+vw), K]
-                for (const auto& [nJ, class_Ja, class_Jb] : lists_.determinant_classes()) {
-                    if (lists_.block_size(nJ) == 0)
-                        continue;
-                    const auto maxJb = lists_.beta_address()->strpcls(class_Jb);
-                    const auto Cl_offset = lists_.block_offset(nJ);
-                    const auto& Ka_left_list = lists_.get_alpha_1h_list2(class_Ka, class_Ja);
-                    if (Ka_left_list.empty())
-                        continue;
-                    for (size_t Kidx = 0; Kidx < Kdim; ++Kidx) {
-                        const size_t K = Kblock_start + Kidx;
-                        const size_t Ka = K / maxKb;
-                        const size_t Kb = K % maxKb;
-                        const auto& Kb_left_list = lists_.get_beta_2h_list(class_Kb, Kb, class_Jb);
-                        if (Kb_left_list.empty())
-                            continue;
-                        const auto& KaL = Ka_left_list[Ka];
-                        for (const auto& [sign_u, u, Ja] : KaL) {
-                            const size_t row_u = u * npair;
-                            const auto Cl_Ja_offset = Cl_offset + Ja * maxJb;
-                            for (const auto& [sign_vw, v, w, Jb] : Kb_left_list) {
-                                const auto vw_index = pair_index_gt<size_t>(v, w);
-                                Kblock1[(row_u + vw_index) * Kdim + Kidx] =
-                                    sign_u * sign_vw * Cl_span[Cl_Ja_offset + Jb];
-                            }
-                        }
-                    }
-                }
+                // Gather the signed right and left coefficients into B_R[(x,yz),K] and
+                // B_L[(u,vw),K].
+                gather_abb_3rdm_block(lists_, class_Ka, class_Kb, maxKb, Kblock_start, Kdim, npair,
+                                      Cr_span, Kblock2);
+                gather_abb_3rdm_block(lists_, class_Ka, class_Kb, maxKb, Kblock_start, Kdim, npair,
+                                      Cl_span, Kblock1);
 
                 matrix_product('N', 'T', M, M, Kdim, 1.0, Kblock1.data(), Kdim, Kblock2.data(),
                                Kdim, 1.0, rdm_data, M);

--- a/forte2/ci/ci_sigma_builder_3rdm.cc
+++ b/forte2/ci/ci_sigma_builder_3rdm.cc
@@ -1,3 +1,6 @@
+#include <limits>
+#include <stdexcept>
+
 #include "helpers/timer.hpp"
 #include "helpers/np_matrix_functions.h"
 #include "helpers/np_vector_functions.h"
@@ -124,11 +127,31 @@ np_tensor4 CISigmaBuilder::compute_aab_3rdm(np_vector C_left, np_vector C_right)
     int num_2h_class_Ka = lists_.alpha_address_2h()->nclasses();
     int num_1h_class_Kb = lists_.beta_address_1h()->nclasses();
 
-    // the contraction gamma[(uv,w),(xy,z)] = sum_{Ka,Kb} (sign_uv sign_w Cl) (sign_xy sign_z Cr) is a matrix
-    // product over the composite hole index K = (Ka, Kb) (Ka: 2-hole alpha, Kb: 1-hole beta).
-    // Gather signed left/right coefficients into B_L[(uv*norb+w), K] and B_R[(xy*norb+z), K], then
-    // gamma[row,col] += B_L * B_R^T with one dgemm per Ka-chunk.
+    size_t max_composite_K = 0;
+    for (int class_Ka = 0; class_Ka < num_2h_class_Ka; ++class_Ka) {
+        const size_t maxKa = lists_.alpha_address_2h()->strpcls(class_Ka);
+        for (int class_Kb = 0; class_Kb < num_1h_class_Kb; ++class_Kb) {
+            const size_t maxKb = lists_.beta_address_1h()->strpcls(class_Kb);
+            if ((maxKa == 0) or (maxKb == 0))
+                continue;
+            if (maxKa > std::numeric_limits<size_t>::max() / maxKb) {
+                throw std::overflow_error("The composite AAB 3-RDM hole dimension is too large.");
+            }
+            max_composite_K = std::max(max_composite_K, maxKa * maxKb);
+        }
+    }
+    if (max_composite_K == 0)
+        return rdm;
+
+    std::vector<double> Kblock1;
+    std::vector<double> Kblock2;
+
+    // The contraction gamma[(uv,w),(xy,z)] is a matrix product over the composite hole
+    // index K = (Ka, Kb) (Ka: 2-hole alpha, Kb: 1-hole beta). Gather signed left/right
+    // coefficients into B_L[(uv*norb+w),K] and B_R[(xy*norb+z),K], then accumulate
+    // gamma += B_L * B_R^T one bounded composite-K chunk at a time.
     const size_t M = npair * norb;
+    const size_t Kblock_size = acquire_local_Kblock_buffers(Kblock1, Kblock2, M, max_composite_K);
     for (int class_Ka{0}; class_Ka < num_2h_class_Ka; ++class_Ka) {
         const size_t maxKa = lists_.alpha_address_2h()->strpcls(class_Ka);
         for (int class_Kb{0}; class_Kb < num_1h_class_Kb; ++class_Kb) {
@@ -136,13 +159,10 @@ np_tensor4 CISigmaBuilder::compute_aab_3rdm(np_vector C_left, np_vector C_right)
             if ((maxKa == 0) or (maxKb == 0))
                 continue;
 
-            auto [Kblock1, Kblock2, Ka_block_size] = get_Kblock_spans(M * maxKb, maxKa);
+            const size_t maxK = maxKa * maxKb;
 
-            for (size_t Ka_block_start = 0; Ka_block_start < maxKa;
-                 Ka_block_start += Ka_block_size) {
-                const size_t Ka_block_end = std::min(Ka_block_start + Ka_block_size, maxKa);
-                const size_t Ka_size = Ka_block_end - Ka_block_start;
-                const size_t Kdim = Ka_size * maxKb;
+            for (size_t Kblock_start = 0; Kblock_start < maxK;) {
+                const size_t Kdim = std::min(Kblock_size, maxK - Kblock_start);
                 const auto temp_dim = M * Kdim;
 
                 std::fill_n(Kblock1.begin(), temp_dim, 0.0);
@@ -157,22 +177,22 @@ np_tensor4 CISigmaBuilder::compute_aab_3rdm(np_vector C_left, np_vector C_right)
                     const auto& Kb_right_list = lists_.get_beta_1h_list2(class_Kb, class_Ib);
                     if (Kb_right_list.empty())
                         continue;
-                    for (size_t Ka = 0; Ka < Ka_size; ++Ka) {
+                    for (size_t Kidx = 0; Kidx < Kdim; ++Kidx) {
+                        const size_t K = Kblock_start + Kidx;
+                        const size_t Ka = K / maxKb;
+                        const size_t Kb = K % maxKb;
                         const auto& Ka_right_list =
-                            lists_.get_alpha_2h_list(class_Ka, Ka_block_start + Ka, class_Ia);
+                            lists_.get_alpha_2h_list(class_Ka, Ka, class_Ia);
                         if (Ka_right_list.empty())
                             continue;
-                        for (size_t Kb = 0; Kb < maxKb; ++Kb) {
-                            const auto& KbR = Kb_right_list[Kb];
-                            const auto Kidx = Ka * maxKb + Kb;
-                            for (const auto& [sign_xy, x, y, Ia] : Ka_right_list) {
-                                const auto xy_index = pair_index_gt<size_t>(x, y);
-                                const size_t row_xy = xy_index * norb;
-                                const auto Cr_Ia_offset = Cr_offset + Ia * maxIb;
-                                for (const auto& [sign_z, z, Ib] : KbR) {
-                                    Kblock2[(row_xy + z) * Kdim + Kidx] =
-                                        sign_xy * sign_z * Cr_span[Cr_Ia_offset + Ib];
-                                }
+                        const auto& KbR = Kb_right_list[Kb];
+                        for (const auto& [sign_xy, x, y, Ia] : Ka_right_list) {
+                            const auto xy_index = pair_index_gt<size_t>(x, y);
+                            const size_t row_xy = xy_index * norb;
+                            const auto Cr_Ia_offset = Cr_offset + Ia * maxIb;
+                            for (const auto& [sign_z, z, Ib] : KbR) {
+                                Kblock2[(row_xy + z) * Kdim + Kidx] =
+                                    sign_xy * sign_z * Cr_span[Cr_Ia_offset + Ib];
                             }
                         }
                     }
@@ -187,29 +207,29 @@ np_tensor4 CISigmaBuilder::compute_aab_3rdm(np_vector C_left, np_vector C_right)
                     const auto& Kb_left_list = lists_.get_beta_1h_list2(class_Kb, class_Jb);
                     if (Kb_left_list.empty())
                         continue;
-                    for (size_t Ka = 0; Ka < Ka_size; ++Ka) {
-                        const auto& Ka_left_list =
-                            lists_.get_alpha_2h_list(class_Ka, Ka_block_start + Ka, class_Ja);
+                    for (size_t Kidx = 0; Kidx < Kdim; ++Kidx) {
+                        const size_t K = Kblock_start + Kidx;
+                        const size_t Ka = K / maxKb;
+                        const size_t Kb = K % maxKb;
+                        const auto& Ka_left_list = lists_.get_alpha_2h_list(class_Ka, Ka, class_Ja);
                         if (Ka_left_list.empty())
                             continue;
-                        for (size_t Kb = 0; Kb < maxKb; ++Kb) {
-                            const auto& KbL = Kb_left_list[Kb];
-                            const auto Kidx = Ka * maxKb + Kb;
-                            for (const auto& [sign_uv, u, v, Ja] : Ka_left_list) {
-                                const auto uv_index = pair_index_gt<size_t>(u, v);
-                                const size_t row_uv = uv_index * norb;
-                                const auto Cl_Ja_offset = Cl_offset + Ja * maxJb;
-                                for (const auto& [sign_w, w, Jb] : KbL) {
-                                    Kblock1[(row_uv + w) * Kdim + Kidx] =
-                                        sign_uv * sign_w * Cl_span[Cl_Ja_offset + Jb];
-                                }
+                        const auto& KbL = Kb_left_list[Kb];
+                        for (const auto& [sign_uv, u, v, Ja] : Ka_left_list) {
+                            const auto uv_index = pair_index_gt<size_t>(u, v);
+                            const size_t row_uv = uv_index * norb;
+                            const auto Cl_Ja_offset = Cl_offset + Ja * maxJb;
+                            for (const auto& [sign_w, w, Jb] : KbL) {
+                                Kblock1[(row_uv + w) * Kdim + Kidx] =
+                                    sign_uv * sign_w * Cl_span[Cl_Ja_offset + Jb];
                             }
                         }
                     }
                 }
 
-                matrix_product('N', 'T', M, M, Kdim, 1.0, Kblock1.data(), Kdim, Kblock2.data(), Kdim,
-                               1.0, rdm_data, M);
+                matrix_product('N', 'T', M, M, Kdim, 1.0, Kblock1.data(), Kdim, Kblock2.data(),
+                               Kdim, 1.0, rdm_data, M);
+                Kblock_start += Kdim;
             }
         }
     }
@@ -244,11 +264,31 @@ np_tensor4 CISigmaBuilder::compute_abb_3rdm(np_vector C_left, np_vector C_right)
     int num_1h_class_Ka = lists_.alpha_address_1h()->nclasses();
     int num_2h_class_Kb = lists_.beta_address_2h()->nclasses();
 
-    // GEMM reformulation, mirroring compute_aab_3rdm with the spins swapped: the composite hole
-    // index is K = (Ka, Kb) (Ka: 1-hole alpha, Kb: 2-hole beta). Gather signed left/right
-    // coefficients into B_L[(u*npair+vw), K] and B_R[(x*npair+yz), K], then gamma[row,col] +=
-    // B_L * B_R^T with one dgemm per Ka-chunk.
+    size_t max_composite_K = 0;
+    for (int class_Ka = 0; class_Ka < num_1h_class_Ka; ++class_Ka) {
+        const size_t maxKa = lists_.alpha_address_1h()->strpcls(class_Ka);
+        for (int class_Kb = 0; class_Kb < num_2h_class_Kb; ++class_Kb) {
+            const size_t maxKb = lists_.beta_address_2h()->strpcls(class_Kb);
+            if ((maxKa == 0) or (maxKb == 0))
+                continue;
+            if (maxKa > std::numeric_limits<size_t>::max() / maxKb) {
+                throw std::overflow_error("The composite ABB 3-RDM hole dimension is too large.");
+            }
+            max_composite_K = std::max(max_composite_K, maxKa * maxKb);
+        }
+    }
+    if (max_composite_K == 0)
+        return rdm;
+
+    std::vector<double> Kblock1;
+    std::vector<double> Kblock2;
+
+    // GEMM reformulation, mirroring compute_aab_3rdm with the spins swapped: the composite
+    // hole index is K = (Ka, Kb) (Ka: 1-hole alpha, Kb: 2-hole beta). Gather signed
+    // coefficients into B_L[(u*npair+vw),K] and B_R[(x*npair+yz),K], then accumulate
+    // gamma += B_L * B_R^T one bounded composite-K chunk at a time.
     const size_t M = norb * npair;
+    const size_t Kblock_size = acquire_local_Kblock_buffers(Kblock1, Kblock2, M, max_composite_K);
     for (int class_Ka = 0; class_Ka < num_1h_class_Ka; ++class_Ka) {
         const size_t maxKa = lists_.alpha_address_1h()->strpcls(class_Ka);
         for (int class_Kb = 0; class_Kb < num_2h_class_Kb; ++class_Kb) {
@@ -256,13 +296,10 @@ np_tensor4 CISigmaBuilder::compute_abb_3rdm(np_vector C_left, np_vector C_right)
             if ((maxKa == 0) or (maxKb == 0))
                 continue;
 
-            auto [Kblock1, Kblock2, Ka_block_size] = get_Kblock_spans(M * maxKb, maxKa);
+            const size_t maxK = maxKa * maxKb;
 
-            for (size_t Ka_block_start = 0; Ka_block_start < maxKa;
-                 Ka_block_start += Ka_block_size) {
-                const size_t Ka_block_end = std::min(Ka_block_start + Ka_block_size, maxKa);
-                const size_t Ka_size = Ka_block_end - Ka_block_start;
-                const size_t Kdim = Ka_size * maxKb;
+            for (size_t Kblock_start = 0; Kblock_start < maxK;) {
+                const size_t Kdim = std::min(Kblock_size, maxK - Kblock_start);
                 const auto temp_dim = M * Kdim;
 
                 std::fill_n(Kblock1.begin(), temp_dim, 0.0);
@@ -277,25 +314,21 @@ np_tensor4 CISigmaBuilder::compute_abb_3rdm(np_vector C_left, np_vector C_right)
                     const auto& Ka_right_list = lists_.get_alpha_1h_list2(class_Ka, class_Ia);
                     if (Ka_right_list.empty())
                         continue;
-                    for (size_t Kb = 0; Kb < maxKb; ++Kb) {
-                        const auto& Kb_right_list =
-                            lists_.get_beta_2h_list(class_Kb, Kb, class_Ib);
+                    for (size_t Kidx = 0; Kidx < Kdim; ++Kidx) {
+                        const size_t K = Kblock_start + Kidx;
+                        const size_t Ka = K / maxKb;
+                        const size_t Kb = K % maxKb;
+                        const auto& Kb_right_list = lists_.get_beta_2h_list(class_Kb, Kb, class_Ib);
                         if (Kb_right_list.empty())
                             continue;
-                        // Kidx makes the inner (Ka) loop contiguous so repeated writes to a fixed
-                        // row hit adjacent columns; the mapping is arbitrary but must match B_L.
-                        const auto Kbase = Kb * Ka_size;
-                        for (size_t Ka = 0; Ka < Ka_size; ++Ka) {
-                            const auto& KaR = Ka_right_list[Ka_block_start + Ka];
-                            const auto Kidx = Kbase + Ka;
-                            for (const auto& [sign_x, x, Ia] : KaR) {
-                                const size_t row_x = x * npair;
-                                const auto Cr_Ia_offset = Cr_offset + Ia * maxIb;
-                                for (const auto& [sign_yz, y, z, Ib] : Kb_right_list) {
-                                    const auto yz_index = pair_index_gt<size_t>(y, z);
-                                    Kblock2[(row_x + yz_index) * Kdim + Kidx] =
-                                        sign_x * sign_yz * Cr_span[Cr_Ia_offset + Ib];
-                                }
+                        const auto& KaR = Ka_right_list[Ka];
+                        for (const auto& [sign_x, x, Ia] : KaR) {
+                            const size_t row_x = x * npair;
+                            const auto Cr_Ia_offset = Cr_offset + Ia * maxIb;
+                            for (const auto& [sign_yz, y, z, Ib] : Kb_right_list) {
+                                const auto yz_index = pair_index_gt<size_t>(y, z);
+                                Kblock2[(row_x + yz_index) * Kdim + Kidx] =
+                                    sign_x * sign_yz * Cr_span[Cr_Ia_offset + Ib];
                             }
                         }
                     }
@@ -310,29 +343,29 @@ np_tensor4 CISigmaBuilder::compute_abb_3rdm(np_vector C_left, np_vector C_right)
                     const auto& Ka_left_list = lists_.get_alpha_1h_list2(class_Ka, class_Ja);
                     if (Ka_left_list.empty())
                         continue;
-                    for (size_t Kb = 0; Kb < maxKb; ++Kb) {
+                    for (size_t Kidx = 0; Kidx < Kdim; ++Kidx) {
+                        const size_t K = Kblock_start + Kidx;
+                        const size_t Ka = K / maxKb;
+                        const size_t Kb = K % maxKb;
                         const auto& Kb_left_list = lists_.get_beta_2h_list(class_Kb, Kb, class_Jb);
                         if (Kb_left_list.empty())
                             continue;
-                        const auto Kbase = Kb * Ka_size;
-                        for (size_t Ka = 0; Ka < Ka_size; ++Ka) {
-                            const auto& KaL = Ka_left_list[Ka_block_start + Ka];
-                            const auto Kidx = Kbase + Ka;
-                            for (const auto& [sign_u, u, Ja] : KaL) {
-                                const size_t row_u = u * npair;
-                                const auto Cl_Ja_offset = Cl_offset + Ja * maxJb;
-                                for (const auto& [sign_vw, v, w, Jb] : Kb_left_list) {
-                                    const auto vw_index = pair_index_gt<size_t>(v, w);
-                                    Kblock1[(row_u + vw_index) * Kdim + Kidx] =
-                                        sign_u * sign_vw * Cl_span[Cl_Ja_offset + Jb];
-                                }
+                        const auto& KaL = Ka_left_list[Ka];
+                        for (const auto& [sign_u, u, Ja] : KaL) {
+                            const size_t row_u = u * npair;
+                            const auto Cl_Ja_offset = Cl_offset + Ja * maxJb;
+                            for (const auto& [sign_vw, v, w, Jb] : Kb_left_list) {
+                                const auto vw_index = pair_index_gt<size_t>(v, w);
+                                Kblock1[(row_u + vw_index) * Kdim + Kidx] =
+                                    sign_u * sign_vw * Cl_span[Cl_Ja_offset + Jb];
                             }
                         }
                     }
                 }
 
-                matrix_product('N', 'T', M, M, Kdim, 1.0, Kblock1.data(), Kdim, Kblock2.data(), Kdim,
-                               1.0, rdm_data, M);
+                matrix_product('N', 'T', M, M, Kdim, 1.0, Kblock1.data(), Kdim, Kblock2.data(),
+                               Kdim, 1.0, rdm_data, M);
+                Kblock_start += Kdim;
             }
         }
     }
@@ -409,7 +442,7 @@ np_tensor6 CISigmaBuilder::compute_sf_3rdm(np_vector C_left, np_vector C_right) 
         }
     }
 
-    // The abb contribution 
+    // The abb contribution
     {
         auto rdm_abb = compute_abb_3rdm(C_left, C_right);
         const auto* abb = rdm_abb.data();
@@ -420,20 +453,20 @@ np_tensor6 CISigmaBuilder::compute_sf_3rdm(np_vector C_left, np_vector C_right) 
                         const size_t offset = ((p * npair + qr) * n + s) * npair;
                         for (size_t t{1}, tu{0}; t < norb; ++t) {
                             // bases with u at stride 1 (u in 6th slot)
-                            const size_t b1 = p * n5 + q * n4 + r * n3 + s * n2 + t * n;  //(pqrstu)+
-                            const size_t b4 = p * n5 + r * n4 + q * n3 + s * n2 + t * n;  //(prqstu)-
-                            const size_t b5 = q * n5 + p * n4 + r * n3 + t * n2 + s * n;  //(qprtsu)+
-                            const size_t b7 = r * n5 + p * n4 + q * n3 + t * n2 + s * n;  //(rpqtsu)-
+                            const size_t b1 = p * n5 + q * n4 + r * n3 + s * n2 + t * n; //(pqrstu)+
+                            const size_t b4 = p * n5 + r * n4 + q * n3 + s * n2 + t * n; //(prqstu)-
+                            const size_t b5 = q * n5 + p * n4 + r * n3 + t * n2 + s * n; //(qprtsu)+
+                            const size_t b7 = r * n5 + p * n4 + q * n3 + t * n2 + s * n; //(rpqtsu)-
                             // bases with u at stride n (u in 5th slot)
                             const size_t b2 = p * n5 + q * n4 + r * n3 + s * n2 + t;  //(pqrsut)-
                             const size_t b3 = p * n5 + r * n4 + q * n3 + s * n2 + t;  //(prqsut)+
                             const size_t b9 = q * n5 + r * n4 + p * n3 + t * n2 + s;  //(qrptus)+
                             const size_t b11 = r * n5 + q * n4 + p * n3 + t * n2 + s; //(rqptus)-
                             // bases with u at stride n2 (u in 4th slot)
-                            const size_t b6 = q * n5 + p * n4 + r * n3 + s * n + t;   //(qprust)-
-                            const size_t b8 = r * n5 + p * n4 + q * n3 + s * n + t;   //(rpqust)+
-                            const size_t b10 = q * n5 + r * n4 + p * n3 + t * n + s;  //(qrputs)-
-                            const size_t b12 = r * n5 + q * n4 + p * n3 + t * n + s;  //(rqputs)+
+                            const size_t b6 = q * n5 + p * n4 + r * n3 + s * n + t;  //(qprust)-
+                            const size_t b8 = r * n5 + p * n4 + q * n3 + s * n + t;  //(rpqust)+
+                            const size_t b10 = q * n5 + r * n4 + p * n3 + t * n + s; //(qrputs)-
+                            const size_t b12 = r * n5 + q * n4 + p * n3 + t * n + s; //(rqputs)+
                             for (size_t u{0}; u < t; ++u, ++tu) {
                                 const auto el = abb[offset + tu];
                                 const size_t un = u * n;

--- a/forte2/ci/ci_sigma_builder_knowles_handy.cc
+++ b/forte2/ci/ci_sigma_builder_knowles_handy.cc
@@ -1,11 +1,10 @@
 #include <algorithm>
-#include <future>
-#include <iostream>
+#include <limits>
+#include <stdexcept>
 
 #include "helpers/timer.hpp"
 #include "helpers/blas.h"
 #include "helpers/logger.h"
-#include "helpers/memory.h"
 #include "helpers/parallel.h"
 
 #include "ci_sigma_builder.h"
@@ -13,6 +12,25 @@
 namespace forte2 {
 
 namespace {
+size_t Kblock_column_capacity(size_t nrows, size_t ncols, size_t memory_size) {
+    if ((nrows == 0) or (ncols == 0)) {
+        throw std::invalid_argument("K-block dimensions must be nonzero.");
+    }
+
+    // The memory setting covers both equally sized K-block buffers.
+    const size_t max_elements_per_buffer = memory_size / (2 * sizeof(double));
+    if (max_elements_per_buffer < nrows) {
+        throw std::runtime_error("The CI builder memory limit (" + std::to_string(memory_size) +
+                                 " bytes) is too small for one K-block column of " +
+                                 std::to_string(nrows) + " elements per buffer.");
+    }
+
+    // BLAS dimensions are 32-bit integers, so a single contraction must not exceed INT_MAX
+    // columns even when the configured memory limit is larger.
+    return std::min({max_elements_per_buffer / nrows, ncols,
+                     static_cast<size_t>(std::numeric_limits<int>::max())});
+}
+
 void transpose_23(std::span<double> in, std::span<double> out, size_t dim1, size_t dim2,
                   size_t dim3);
 void gather_alpha_block(const CIStrings& lists, size_t class_Ka, size_t class_Kb, size_t Ka_start,
@@ -154,39 +172,56 @@ void CISigmaBuilder::H2_kh(std::span<double> basis, std::span<double> sigma) con
 
 std::tuple<std::span<double>, std::span<double>, size_t>
 CISigmaBuilder::get_Kblock_spans(size_t nrows, size_t ncols) const {
-    // Find the maximum size of the temporary block to allocate. This is either set by the full
-    // size of the block (nrows * ncols) or by the available memory size, whichever is smaller
-    std::size_t block_size = std::min(nrows * ncols, memory_size_ / (2 * sizeof(double)));
+    const size_t cols_chunk_size = Kblock_column_capacity(nrows, ncols, memory_size_);
+    const size_t block_size = nrows * cols_chunk_size;
+    const size_t max_elements_per_buffer = memory_size_ / (2 * sizeof(double));
 
-    // Find the corresponding chunk size for K
-    size_t cols_chunk_size = std::min(block_size / nrows, ncols);
-
-    // If the chunk size is too small to store one row, resize it
-    bool need_resize = false;
-    if (cols_chunk_size < 1) {
-        // resize to a reasonable minimum and update block_size
-        cols_chunk_size = std::min(static_cast<size_t>(64), ncols);
-        block_size = nrows * cols_chunk_size;
-        need_resize = true;
-    }
-
-    // If the temporary buffers are too small, resize them
-    if (Kblock1_.size() < block_size) {
+    const bool can_reuse = Kblock1_.capacity() >= block_size && Kblock2_.capacity() >= block_size &&
+                           Kblock1_.capacity() <= max_elements_per_buffer &&
+                           Kblock2_.capacity() <= max_elements_per_buffer;
+    if (can_reuse) {
         Kblock1_.resize(block_size);
         Kblock2_.resize(block_size);
-        if (need_resize) {
-            auto block_size_MB = to_mb<double>(2 * block_size);
-            LOG(log_level_) << "Available memory is too small to hold a row of the CI buffers.\n"
-                               "Block size has been adjusted to 2 x "
-                            << block_size << " (" << block_size_MB << " MB) to hold "
-                            << cols_chunk_size
-                            << " columns.\n"
-                               "For best performance, increase the memory limit.";
-        }
+    } else {
+        // Drop both allocations before growing either one. This prevents geometric vector growth
+        // from exceeding the pair budget and leaves a failed partial allocation safe to retry.
+        std::vector<double>{}.swap(Kblock1_);
+        std::vector<double>{}.swap(Kblock2_);
+        Kblock1_ = std::vector<double>(block_size);
+        Kblock2_ = std::vector<double>(block_size);
     }
 
     return {std::span<double>{Kblock1_.data(), block_size},
             std::span<double>{Kblock2_.data(), block_size}, cols_chunk_size};
+}
+
+size_t CISigmaBuilder::acquire_local_Kblock_buffers(std::vector<double>& Kblock1,
+                                                    std::vector<double>& Kblock2, size_t nrows,
+                                                    size_t ncols) const {
+    // Transfer ownership so sigma-build cache and RDM-local scratch never coexist. The local
+    // vectors release the storage when the RDM call returns, avoiding permanent cache inflation.
+    Kblock1.swap(Kblock1_);
+    Kblock2.swap(Kblock2_);
+
+    const size_t cols_chunk_size = Kblock_column_capacity(nrows, ncols, memory_size_);
+    const size_t block_size = nrows * cols_chunk_size;
+    const size_t max_elements_per_buffer = memory_size_ / (2 * sizeof(double));
+
+    const bool can_reuse = Kblock1.capacity() >= block_size && Kblock2.capacity() >= block_size &&
+                           Kblock1.capacity() <= max_elements_per_buffer &&
+                           Kblock2.capacity() <= max_elements_per_buffer;
+    if (can_reuse) {
+        Kblock1.resize(block_size);
+        Kblock2.resize(block_size);
+    } else {
+        // Release both old allocations before growing either one, keeping peak scratch within the
+        // configured pair budget even when the limit was lowered after a sigma build.
+        std::vector<double>{}.swap(Kblock1);
+        std::vector<double>{}.swap(Kblock2);
+        Kblock1 = std::vector<double>(block_size);
+        Kblock2 = std::vector<double>(block_size);
+    }
+    return cols_chunk_size;
 }
 
 // The following functions are used to gather and scatter blocks of data and

--- a/forte2/ci/ci_sigma_builder_knowles_handy.cc
+++ b/forte2/ci/ci_sigma_builder_knowles_handy.cc
@@ -176,13 +176,12 @@ CISigmaBuilder::get_Kblock_spans(size_t nrows, size_t ncols) const {
     const size_t block_size = nrows * cols_chunk_size;
     const size_t max_elements_per_buffer = memory_size_ / (2 * sizeof(double));
 
-    const bool can_reuse = Kblock1_.capacity() >= block_size && Kblock2_.capacity() >= block_size &&
+    // Keep a larger live size: shrinking here makes a later larger kernel value-initialize the
+    // same scratch storage again. The returned spans still expose only block_size elements.
+    const bool can_reuse = Kblock1_.size() >= block_size && Kblock2_.size() >= block_size &&
                            Kblock1_.capacity() <= max_elements_per_buffer &&
                            Kblock2_.capacity() <= max_elements_per_buffer;
-    if (can_reuse) {
-        Kblock1_.resize(block_size);
-        Kblock2_.resize(block_size);
-    } else {
+    if (!can_reuse) {
         // Drop both allocations before growing either one. This prevents geometric vector growth
         // from exceeding the pair budget and leaves a failed partial allocation safe to retry.
         std::vector<double>{}.swap(Kblock1_);

--- a/forte2/ci/ci_sigma_builder_knowles_handy.cc
+++ b/forte2/ci/ci_sigma_builder_knowles_handy.cc
@@ -182,10 +182,7 @@ CISigmaBuilder::get_Kblock_spans(size_t nrows, size_t ncols) const {
                            Kblock1_.capacity() <= max_elements_per_buffer &&
                            Kblock2_.capacity() <= max_elements_per_buffer;
     if (!can_reuse) {
-        // Drop both allocations before growing either one. This prevents geometric vector growth
-        // from exceeding the pair budget and leaves a failed partial allocation safe to retry.
-        std::vector<double>{}.swap(Kblock1_);
-        std::vector<double>{}.swap(Kblock2_);
+        // Drop both allocations before growing either one.
         Kblock1_ = std::vector<double>(block_size);
         Kblock2_ = std::vector<double>(block_size);
     }

--- a/forte2/ci/rel_ci_sigma_builder.cc
+++ b/forte2/ci/rel_ci_sigma_builder.cc
@@ -61,7 +61,12 @@ std::string RelCISigmaBuilder::get_algorithm() const {
 }
 
 void RelCISigmaBuilder::set_memory(int mb) {
-    memory_size_ = mb * 1024 * 1024; // Convert MB to bytes
+    if (mb < 0) {
+        throw std::invalid_argument("CI builder memory must be non-negative.");
+    }
+    memory_size_ = static_cast<size_t>(mb) * 1024 * 1024; // Convert MB to bytes
+    std::vector<std::complex<double>>{}.swap(Kblock1_);
+    std::vector<std::complex<double>>{}.swap(Kblock2_);
 }
 
 void RelCISigmaBuilder::set_Hamiltonian(double E, np_matrix_complex H, np_tensor4_complex V) {

--- a/forte2/ci/rel_ci_sigma_builder.h
+++ b/forte2/ci/rel_ci_sigma_builder.h
@@ -190,7 +190,7 @@ class RelCISigmaBuilder {
     void H2_kh(std::span<std::complex<double>> basis, std::span<std::complex<double>> sigma) const;
 
     std::tuple<std::span<std::complex<double>>, std::span<std::complex<double>>, size_t>
-    get_Kblock_spans(size_t dim, size_t maxKa) const;
+    get_Kblock_spans(size_t nrows, size_t ncols) const;
 };
 
 [[nodiscard]] std::span<std::complex<double>> gather_block(std::span<std::complex<double>> source,

--- a/forte2/ci/rel_ci_sigma_builder_harrison_zarrabian.cc
+++ b/forte2/ci/rel_ci_sigma_builder_harrison_zarrabian.cc
@@ -1,4 +1,6 @@
 #include <algorithm>
+#include <limits>
+#include <stdexcept>
 #include <vector>
 
 #include "helpers/timer.hpp"
@@ -25,30 +27,33 @@ template <typename F> inline void gated_parallel_for_chunked(size_t count, F&& f
 
 std::tuple<std::span<std::complex<double>>, std::span<std::complex<double>>, size_t>
 RelCISigmaBuilder::get_Kblock_spans(size_t nrows, size_t ncols) const {
-    // Find the maximum size of the temporary block to allocate. This is either set by the full
-    // size of the block (nrows * ncols) or by the available memory size, whichever is smaller
-    std::size_t block_size =
-        std::min(nrows * ncols, memory_size_ / (2 * sizeof(std::complex<double>)));
-
-    // Find the corresponding chunk size for K
-    size_t cols_chunk_size = std::min(block_size / nrows, ncols);
-
-    // If the chunk size is too small to store one row, resize it
-    bool need_resize = false;
-    if (cols_chunk_size < 1) {
-        // resize to a reasonable minimum and update block_size
-        cols_chunk_size = std::min(static_cast<size_t>(64), ncols);
-        block_size = nrows * cols_chunk_size;
-        need_resize = true;
+    if ((nrows == 0) or (ncols == 0)) {
+        throw std::invalid_argument("K-block dimensions must be nonzero.");
     }
 
-    // If the temporary buffers are too small, resize them
-    if (Kblock1_.size() < block_size) {
+    const size_t max_elements_per_buffer = memory_size_ / (2 * sizeof(std::complex<double>));
+    if (max_elements_per_buffer < nrows) {
+        throw std::runtime_error("The CI builder memory limit (" + std::to_string(memory_size_) +
+                                 " bytes) is too small for one complex K-block column of " +
+                                 std::to_string(nrows) + " elements per buffer.");
+    }
+    const size_t cols_chunk_size = std::min({max_elements_per_buffer / nrows, ncols,
+                                             static_cast<size_t>(std::numeric_limits<int>::max())});
+    const size_t block_size = nrows * cols_chunk_size;
+
+    const bool can_reuse = Kblock1_.capacity() >= block_size && Kblock2_.capacity() >= block_size &&
+                           Kblock1_.capacity() <= max_elements_per_buffer &&
+                           Kblock2_.capacity() <= max_elements_per_buffer;
+    if (can_reuse) {
         Kblock1_.resize(block_size);
         Kblock2_.resize(block_size);
-        if (need_resize) {
-            auto block_size_MB = to_mb<std::complex<double>>(2 * block_size);
-        }
+    } else {
+        // Drop both allocations before growing either one. This prevents geometric vector growth
+        // from exceeding the pair budget and leaves a failed partial allocation safe to retry.
+        std::vector<std::complex<double>>{}.swap(Kblock1_);
+        std::vector<std::complex<double>>{}.swap(Kblock2_);
+        Kblock1_ = std::vector<std::complex<double>>(block_size);
+        Kblock2_ = std::vector<std::complex<double>>(block_size);
     }
 
     return {std::span<std::complex<double>>{Kblock1_.data(), block_size},

--- a/forte2/ci/rel_ci_sigma_builder_harrison_zarrabian.cc
+++ b/forte2/ci/rel_ci_sigma_builder_harrison_zarrabian.cc
@@ -41,13 +41,12 @@ RelCISigmaBuilder::get_Kblock_spans(size_t nrows, size_t ncols) const {
                                              static_cast<size_t>(std::numeric_limits<int>::max())});
     const size_t block_size = nrows * cols_chunk_size;
 
-    const bool can_reuse = Kblock1_.capacity() >= block_size && Kblock2_.capacity() >= block_size &&
+    // Keep a larger live size: shrinking here makes a later larger kernel value-initialize the
+    // same scratch storage again. The returned spans still expose only block_size elements.
+    const bool can_reuse = Kblock1_.size() >= block_size && Kblock2_.size() >= block_size &&
                            Kblock1_.capacity() <= max_elements_per_buffer &&
                            Kblock2_.capacity() <= max_elements_per_buffer;
-    if (can_reuse) {
-        Kblock1_.resize(block_size);
-        Kblock2_.resize(block_size);
-    } else {
+    if (!can_reuse) {
         // Drop both allocations before growing either one. This prevents geometric vector growth
         // from exceeding the pair budget and leaves a failed partial allocation safe to retry.
         std::vector<std::complex<double>>{}.swap(Kblock1_);

--- a/forte2/helpers/blas.h
+++ b/forte2/helpers/blas.h
@@ -1,5 +1,8 @@
 #pragma once
+
+#include <climits>
 #include <complex>
+
 namespace forte2 {
 
 extern "C" {

--- a/forte2/helpers/memory.h
+++ b/forte2/helpers/memory.h
@@ -11,6 +11,14 @@ namespace forte2 {
 /// @brief Express the amount of memory needed to store `n` elements of type T in megabytes
 template <typename T> int to_mb(size_t n) { return n * sizeof(T) / (1024 * 1024); }
 
+/// @brief Free the memory used by a std::vector by swapping it with an empty vector
+/// This should be preferred over using std::vector::clear() as it releases the memory
+/// @tparam T The type of the elements in the vector
+/// @param vec The vector to free
+template <typename T> void free_std_vector_memory(std::vector<T>& vec) {
+    std::vector<T>().swap(vec);
+}
+
 /// @brief A templated buffer class used to store elements of type T
 /// This class is a simple wrapper around std::vector<T> which provides a variable-size buffer.
 /// The buffer is initialized with a given size and is automatically resized when needed.

--- a/forte2/helpers/parallel.h
+++ b/forte2/helpers/parallel.h
@@ -12,6 +12,7 @@
 #include <utility>
 #include <vector>
 #include <version>
+#include <charconv>
 
 #ifdef __linux__
 #include <sched.h>
@@ -27,7 +28,7 @@ namespace forte2 {
 
 namespace detail {
 
-constexpr std::size_t no_thread_limit = std::numeric_limits<std::size_t>::max();
+constexpr std::size_t max_threads = std::numeric_limits<std::size_t>::max();
 
 constexpr bool is_space(const char c) noexcept {
     return c == ' ' || c == '\t' || c == '\n' || c == '\r' || c == '\f' || c == '\v';
@@ -35,36 +36,31 @@ constexpr bool is_space(const char c) noexcept {
 
 /// @brief Parse a positive thread count from an environment variable.
 /// @param value Environment variable value, or nullptr when it is unset.
-/// @param allow_list Whether to accept the comma-separated list syntax used by OMP_NUM_THREADS.
-/// @return The parsed limit, or no_thread_limit when the value is unset or invalid.
+/// @param allow_list Whether to allow commas. Only the first value is used if true.
+/// @return The parsed limit, or max_threads when the value is unset or invalid.
 inline std::size_t parse_thread_limit(const char* value, const bool allow_list = false) noexcept {
     if (value == nullptr)
-        return no_thread_limit;
+        return max_threads;
 
     while (is_space(*value))
         ++value;
-    if (*value < '0' || *value > '9')
-        return no_thread_limit;
+
+    const char* end = value;
+    while (*end != '\0')
+        ++end;
 
     std::size_t limit = 0;
-    bool overflow = false;
-    while (*value >= '0' && *value <= '9') {
-        const auto digit = static_cast<std::size_t>(*value - '0');
-        if (limit > (no_thread_limit - digit) / 10) {
-            overflow = true;
-        } else if (!overflow) {
-            limit = limit * 10 + digit;
-        }
-        ++value;
-    }
+    auto [ptr, ec] = std::from_chars(value, end, limit);
+    if (ec != std::errc{}) // bail on any error
+        return max_threads;
 
-    while (is_space(*value))
-        ++value;
-    if (*value != '\0' && !(allow_list && *value == ','))
-        return no_thread_limit;
-    if (limit == 0 && !overflow)
-        return no_thread_limit;
-    return overflow ? no_thread_limit : limit;
+    while (is_space(*ptr))
+        ++ptr;
+    if (*ptr != '\0' && !(allow_list && *ptr == ','))
+        return max_threads;
+    if (limit == 0)
+        return max_threads;
+    return limit;
 }
 
 /// @brief Return the number of CPUs in the process affinity mask when available.
@@ -82,11 +78,11 @@ inline std::size_t get_affinity_thread_limit() noexcept {
             return count;
     }
 #endif
-    return no_thread_limit;
+    return max_threads;
 }
 
 /// @brief Join every joinable thread in a worker container when leaving scope.
-///
+/// Allows exceptions to propagate if a thread fails.
 /// This guard must be declared immediately after the worker vector. If creating a later worker
 /// throws, the guard joins the workers that were already created before their destructors run.
 class ThreadJoiner {
@@ -110,11 +106,24 @@ class ThreadJoiner {
 } // namespace detail
 
 /// @brief Get the number of threads to use for parallel execution
-/// This function bounds the hardware thread count by the process affinity mask, OpenMP limits, and
-/// the per-task CPU count reported by Slurm. It always returns at least one thread.
+/// FORTE_NUM_THREADS_OVERRIDE is used if set/valid.
+/// Otherwise, the smallest set value among 
+/// {   physical cores, 
+///     # of CPUs in affinity mask,
+///     OMP_NUM_THREADS, 
+///     OMP_THREAD_LIMIT, 
+///     SLURM_CPUS_PER_TASK,
+/// } is used.
+/// It always returns at least one thread.
 /// @return The number of threads to use for parallel execution.
-static std::size_t get_num_threads() {
-    auto num_threads = static_cast<std::size_t>(std::max(1u, std::thread::hardware_concurrency()));
+inline std::size_t get_num_threads() {
+    auto num_threads = detail::parse_thread_limit(std::getenv("FORTE_NUM_THREADS_OVERRIDE"));
+    
+    if (num_threads != detail::max_threads) {
+        return std::max<std::size_t>(1, num_threads);
+    }
+
+    num_threads = static_cast<std::size_t>(std::max(1u, std::thread::hardware_concurrency()));
     num_threads = std::min(num_threads, detail::get_affinity_thread_limit());
     num_threads =
         std::min(num_threads, detail::parse_thread_limit(std::getenv("OMP_NUM_THREADS"), true));

--- a/forte2/helpers/parallel.h
+++ b/forte2/helpers/parallel.h
@@ -1,15 +1,21 @@
 #pragma once
 
-#include <cstddef>
-#include <thread>
-#include <version>
-#include <execution>
 #include <algorithm>
 #include <atomic>
-#include <ranges>
+#include <cstddef>
+#include <cstdlib>
+#include <execution>
 #include <future>
+#include <limits>
+#include <ranges>
+#include <thread>
 #include <utility>
 #include <vector>
+#include <version>
+
+#ifdef __linux__
+#include <sched.h>
+#endif
 
 #ifdef __APPLE__
 #include <dispatch/dispatch.h>
@@ -18,12 +24,105 @@
 #define SERIAL_THRESHOLD 3
 
 namespace forte2 {
+
+namespace detail {
+
+constexpr std::size_t no_thread_limit = std::numeric_limits<std::size_t>::max();
+
+constexpr bool is_space(const char c) noexcept {
+    return c == ' ' || c == '\t' || c == '\n' || c == '\r' || c == '\f' || c == '\v';
+}
+
+/// @brief Parse a positive thread count from an environment variable.
+/// @param value Environment variable value, or nullptr when it is unset.
+/// @param allow_list Whether to accept the comma-separated list syntax used by OMP_NUM_THREADS.
+/// @return The parsed limit, or no_thread_limit when the value is unset or invalid.
+inline std::size_t parse_thread_limit(const char* value, const bool allow_list = false) noexcept {
+    if (value == nullptr)
+        return no_thread_limit;
+
+    while (is_space(*value))
+        ++value;
+    if (*value < '0' || *value > '9')
+        return no_thread_limit;
+
+    std::size_t limit = 0;
+    bool overflow = false;
+    while (*value >= '0' && *value <= '9') {
+        const auto digit = static_cast<std::size_t>(*value - '0');
+        if (limit > (no_thread_limit - digit) / 10) {
+            overflow = true;
+        } else if (!overflow) {
+            limit = limit * 10 + digit;
+        }
+        ++value;
+    }
+
+    while (is_space(*value))
+        ++value;
+    if (*value != '\0' && !(allow_list && *value == ','))
+        return no_thread_limit;
+    if (limit == 0 && !overflow)
+        return no_thread_limit;
+    return overflow ? no_thread_limit : limit;
+}
+
+/// @brief Return the number of CPUs in the process affinity mask when available.
+inline std::size_t get_affinity_thread_limit() noexcept {
+#ifdef __linux__
+    cpu_set_t affinity;
+    CPU_ZERO(&affinity);
+    if (sched_getaffinity(0, sizeof(affinity), &affinity) == 0) {
+        std::size_t count = 0;
+        for (int cpu = 0; cpu < CPU_SETSIZE; ++cpu) {
+            if (CPU_ISSET(cpu, &affinity))
+                ++count;
+        }
+        if (count > 0)
+            return count;
+    }
+#endif
+    return no_thread_limit;
+}
+
+/// @brief Join every joinable thread in a worker container when leaving scope.
+///
+/// This guard must be declared immediately after the worker vector. If creating a later worker
+/// throws, the guard joins the workers that were already created before their destructors run.
+class ThreadJoiner {
+  public:
+    explicit ThreadJoiner(std::vector<std::thread>& threads) noexcept : threads_(threads) {}
+
+    ThreadJoiner(const ThreadJoiner&) = delete;
+    ThreadJoiner& operator=(const ThreadJoiner&) = delete;
+
+    ~ThreadJoiner() {
+        for (auto& thread : threads_) {
+            if (thread.joinable())
+                thread.join();
+        }
+    }
+
+  private:
+    std::vector<std::thread>& threads_;
+};
+
+} // namespace detail
+
 /// @brief Get the number of threads to use for parallel execution
-/// This function returns the number of hardware threads available, but ensures that at least 1
-/// thread is returned.
+/// This function bounds the hardware thread count by the process affinity mask, OpenMP limits, and
+/// the per-task CPU count reported by Slurm. It always returns at least one thread.
 /// @return The number of threads to use for parallel execution.
 static std::size_t get_num_threads() {
-    return static_cast<std::size_t>(std::max(1u, std::thread::hardware_concurrency()));
+    auto num_threads = static_cast<std::size_t>(std::max(1u, std::thread::hardware_concurrency()));
+    num_threads = std::min(num_threads, detail::get_affinity_thread_limit());
+    num_threads =
+        std::min(num_threads, detail::parse_thread_limit(std::getenv("OMP_NUM_THREADS"), true));
+    num_threads =
+        std::min(num_threads, detail::parse_thread_limit(std::getenv("OMP_THREAD_LIMIT")));
+    num_threads =
+        std::min(num_threads, detail::parse_thread_limit(std::getenv("SLURM_CPUS_PER_TASK")));
+    return std::max<std::size_t>(1, num_threads);
 }
 
 template <typename F> void serial_for(const std::size_t begin, const std::size_t end, F&& func) {
@@ -42,6 +141,8 @@ void parallel_for_chunked_thread(const std::size_t begin, const std::size_t end,
         return;
     }
     std::vector<std::thread> threads;
+    threads.reserve(num_threads);
+    detail::ThreadJoiner thread_joiner(threads);
     const std::size_t block_size = (count + num_threads - 1) / num_threads;
 
     for (std::size_t t = 0; t < num_threads; ++t) {
@@ -124,6 +225,7 @@ void parallel_for_interleaved_thread(const std::size_t begin, const std::size_t 
 
     std::vector<std::thread> workers;
     workers.reserve(num_threads);
+    detail::ThreadJoiner thread_joiner(workers);
     for (std::size_t t{0}; t < num_threads; ++t) {
         workers.emplace_back([count, num_threads, t, begin, &func]() {
             for (std::size_t i{t}; i < count; i += num_threads)
@@ -172,6 +274,8 @@ void parallel_for_dynamic_thread(const std::size_t begin, const std::size_t end,
     }
     std::atomic<std::size_t> next_index(begin);
     std::vector<std::thread> threads;
+    threads.reserve(num_threads);
+    detail::ThreadJoiner thread_joiner(threads);
     for (std::size_t t = 0; t < num_threads; ++t) {
         threads.emplace_back([begin, end, &func, &next_index]() {
             while (true) {

--- a/forte2/lib/cpp_helpers.pyi
+++ b/forte2/lib/cpp_helpers.pyi
@@ -32,3 +32,5 @@ def set_log_level(arg: int, /) -> None:
 
 def get_log_level() -> int:
     """Get the current logging verbosity level"""
+
+def get_num_threads() -> int: ...

--- a/tests/ci/test_ci_rdms.py
+++ b/tests/ci/test_ci_rdms.py
@@ -1,7 +1,9 @@
 import numpy as np
+import pytest
 
 from forte2 import System, RHF, CI, State
 from forte2.helpers.comparisons import approx
+from forte2.lib.ci_helpers import CISigmaBuilder, CIStrings
 
 
 def compare_rdms(ci):
@@ -371,3 +373,64 @@ def test_ci_rdms_sa():
     e_from_cumulants -= 0.25 * np.einsum("pqrs,ps,qr->", ci_ints.V, g1, g1)
 
     assert e_avg == approx(e_from_cumulants)
+
+
+def test_ci_rdms_respect_small_builder_memory_across_composite_hole_chunks():
+    """Low-memory composite-hole chunks must agree with an unchunked contraction."""
+    norb = 12
+    lists = CIStrings(2, 5, 0, [[0] * norb], [], [])
+    H = np.zeros((norb, norb))
+    V = np.zeros((norb, norb, norb, norb))
+    low_memory_builder = CISigmaBuilder(lists, 0.0, H, V, 0)
+    reference_builder = CISigmaBuilder(lists, 0.0, H, V, 0)
+
+    rng = np.random.default_rng(204)
+    C_left = rng.normal(size=lists.ndet)
+    C_right = rng.normal(size=lists.ndet)
+    C_left /= np.linalg.norm(C_left)
+    C_right /= np.linalg.norm(C_right)
+
+    with pytest.raises(ValueError, match="memory must be non-negative"):
+        low_memory_builder.set_memory(-1)
+
+    # A zero-byte limit cannot hold even one column, and must fail without corrupting the builder.
+    low_memory_builder.set_memory(0)
+    with pytest.raises(RuntimeError, match="too small for one K-block column"):
+        low_memory_builder.ab_2rdm(C_left, C_right)
+
+    # One MiB forces chunks that split the flattened (Ka, Kb) index, including within Kb.
+    low_memory_builder.set_memory(1)
+    reference_builder.set_memory(64)
+    for method_name in ("ab_2rdm", "aab_3rdm", "abb_3rdm"):
+        low_memory_rdm = getattr(low_memory_builder, method_name)(C_left, C_right)
+        reference_rdm = getattr(reference_builder, method_name)(C_left, C_right)
+        np.testing.assert_allclose(
+            low_memory_rdm, reference_rdm, rtol=1e-12, atol=1e-12
+        )
+
+
+def test_ci_builder_memory_reconfiguration_is_retry_safe():
+    """A failed cached-buffer request must not corrupt a later sigma build."""
+    norb = 6
+    lists = CIStrings(2, 2, 0, [[0] * norb], [], [])
+    H = np.diag(np.linspace(-1.0, 1.0, norb))
+    V = np.zeros((norb, norb, norb, norb))
+    builder = CISigmaBuilder(lists, 0.25, H, V, 0)
+    builder.set_algorithm("hz")
+
+    rng = np.random.default_rng(205)
+    basis = rng.normal(size=lists.ndet)
+    basis /= np.linalg.norm(basis)
+
+    builder.set_memory(1)
+    expected = np.zeros(lists.ndet)
+    builder.Hamiltonian(basis, expected)
+
+    builder.set_memory(0)
+    with pytest.raises(RuntimeError, match="too small for one K-block column"):
+        builder.Hamiltonian(basis, np.zeros(lists.ndet))
+
+    builder.set_memory(1)
+    actual = np.zeros(lists.ndet)
+    builder.Hamiltonian(basis, actual)
+    np.testing.assert_allclose(actual, expected, rtol=1e-12, atol=1e-12)

--- a/tests/helpers/parallel_test_driver.cc
+++ b/tests/helpers/parallel_test_driver.cc
@@ -1,8 +1,13 @@
 #include <atomic>
+#include <chrono>
 #include <cstddef>
+#include <cstdlib>
 #include <iostream>
+#include <limits>
 #include <stdexcept>
 #include <string_view>
+#include <thread>
+#include <vector>
 
 #ifdef __linux__
 #include <sched.h>
@@ -12,7 +17,7 @@
 
 namespace {
 
-int pin_to_one_cpu() {
+int test_pin_to_one_cpu() {
 #ifdef __linux__
     cpu_set_t available;
     CPU_ZERO(&available);
@@ -27,52 +32,176 @@ int pin_to_one_cpu() {
         }
     }
     if (first_cpu < 0)
-        return 77;
+        return 77; // unsupported environment - not a failure
 
     cpu_set_t affinity;
     CPU_ZERO(&affinity);
     CPU_SET(first_cpu, &affinity);
     return sched_setaffinity(0, sizeof(affinity), &affinity) == 0 ? 0 : 77;
 #else
-    return 77;
+    return 77; // unsupported environment - not a failure
 #endif
 }
 
-bool joins_workers_during_unwinding() {
-    std::atomic<bool> worker_completed{false};
+/// @brief Verify ThreadJoiner joins every already-launched worker while an exception unwinds.
+///
+/// This models a failure that occurs partway through launching workers: several threads are
+/// already running when the next launch "fails" (simulated by a throw). We wait until every worker
+/// has started, then throw; because each worker keeps working (a short sleep) after signaling that
+/// it started, all workers are still running when ~ThreadJoiner fires during unwinding, so the join
+/// must actually wait for them.
+///
+/// The post-condition relies on join's happens-before guarantee: only if every worker was joined
+/// are all their `completed` increments visible here, giving completed == num_workers. A
+/// ThreadJoiner that failed to join would either let the process std::terminate (a still-running
+/// thread's destructor) or race ahead of the sleeping workers and observe completed < num_workers.
+bool test_thread_joiner() {
+    constexpr unsigned num_workers = 8;
+    std::atomic<unsigned> started{0};
+    std::atomic<unsigned> completed{0};
+
     try {
         std::vector<std::thread> workers;
-        workers.reserve(2);
+        workers.reserve(num_workers);
         forte2::detail::ThreadJoiner thread_joiner(workers);
-        workers.emplace_back([&worker_completed]() { worker_completed.store(true); });
-        throw std::runtime_error("simulate failure to create the next worker");
+        for (unsigned w = 0; w < num_workers; ++w) {
+            workers.emplace_back([&]() {
+                started.fetch_add(1);
+                // Keep working after signaling start, so the worker is still running (joinable)
+                // when the throw unwinds through ~ThreadJoiner.
+                std::this_thread::sleep_for(std::chrono::milliseconds(50));
+                completed.fetch_add(1);
+            });
+        }
+        // Ensure every worker is actually running before we unwind.
+        while (started.load() < num_workers)
+            std::this_thread::yield();
+        throw std::runtime_error("simulate failure to launch the next worker");
     } catch (const std::runtime_error&) {
-        return worker_completed.load();
+        // Reachable only after ~ThreadJoiner joined all workers during stack unwinding.
+        return completed.load() == num_workers;
     }
+}
+
+/// @brief Verify every index in [0, count) was visited exactly once.
+///
+/// Returns 0 when coverage is exact, or 1 otherwise (printing the offending statistics to stderr
+/// for diagnostics). An empty range is vacuously exact.
+int report_coverage(const std::vector<std::atomic<unsigned>>& visits, const std::size_t count) {
+    unsigned long long total = 0;
+    unsigned min_visits = std::numeric_limits<unsigned>::max();
+    unsigned max_visits = 0;
+    for (const auto& visit : visits) {
+        const unsigned seen = visit.load();
+        total += seen;
+        min_visits = std::min(min_visits, seen);
+        max_visits = std::max(max_visits, seen);
+    }
+    const bool exact = count == 0 ? true : (total == count && min_visits == 1 && max_visits == 1);
+    if (!exact) {
+        std::cerr << "coverage not exact for count=" << count << ": total=" << total
+                  << " min=" << min_visits << " max=" << max_visits << '\n';
+        return 1;
+    }
+    return 0;
+}
+
+/// @brief Drive an index-callback variant of parallel_for_*, e.g. func(i), and check exact-once coverage.
+template <typename Invoker> int run_index_fn(const std::size_t count, Invoker invoke) {
+    std::vector<std::atomic<unsigned>> visits(count);
+    invoke([&visits](const std::size_t i) { visits[i].fetch_add(1, std::memory_order_relaxed); });
+    return report_coverage(visits, count);
+}
+
+/// @brief Drive a range-callback variant of parallel_for_*, e.g. func(begin, end), and check exact-once coverage.
+template <typename Invoker> int run_range_fn(const std::size_t count, Invoker invoke) {
+    std::vector<std::atomic<unsigned>> visits(count);
+    invoke([&visits](const std::size_t begin, const std::size_t end) {
+        for (std::size_t i = begin; i < end; ++i)
+            visits[i].fetch_add(1, std::memory_order_relaxed);
+    });
+    return report_coverage(visits, count);
+}
+
+int test_parallel_for_variant(const std::string_view name, const std::size_t count) {
+    // Range-callback variants: func(begin, end).
+    if (name == "parallel_for_chunked")
+        return run_range_fn(count,
+                            [count](auto&& f) { forte2::parallel_for_chunked(0, count, f); });
+    if (name == "parallel_for_chunked_thread")
+        return run_range_fn(
+            count, [count](auto&& f) { forte2::parallel_for_chunked_thread(0, count, f); });
+    if (name == "parallel_for_chunked_async")
+        return run_range_fn(
+            count, [count](auto&& f) { forte2::parallel_for_chunked_async(0, count, f); });
+
+    // Index-callback variants: func(i).
+    if (name == "parallel_for")
+        return run_index_fn(count, [count](auto&& f) { forte2::parallel_for(0, count, f); });
+    if (name == "parallel_for_interleaved_thread")
+        return run_index_fn(
+            count, [count](auto&& f) { forte2::parallel_for_interleaved_thread(0, count, f); });
+    if (name == "parallel_for_interleaved_async")
+        return run_index_fn(
+            count, [count](auto&& f) { forte2::parallel_for_interleaved_async(0, count, f); });
+    if (name == "parallel_for_dynamic_thread")
+        return run_index_fn(
+            count, [count](auto&& f) { forte2::parallel_for_dynamic_thread(0, count, f); });
+    if (name == "parallel_for_dynamic_async")
+        return run_index_fn(
+            count, [count](auto&& f) { forte2::parallel_for_dynamic_async(0, count, f); });
+    if (name == "parallel_for_each") {
+#if defined(__cpp_lib_execution)
+        return run_index_fn(count,
+                            [count](auto&& f) { forte2::parallel_for_each(0, count, f); });
+#else
+        // C++17 parallel algorithms are unavailable (e.g. Apple Clang): signal a skip.
+        return 77;
+#endif
+    }
+
+    std::cerr << "unknown parallel_for variant: " << name << '\n';
+    return 2;
+}
+
+/// @brief Pin the process to one CPU and verify get_num_threads() honors the affinity mask.
+///
+/// Once pinned to a single CPU, get_num_threads() must report 1. Returns 0 on success, 1 on
+/// failure (printing the observed count for diagnostics), or 77 (skip) when affinity controls are
+/// unavailable.
+int test_process_affinity() {
+    if (const int status = test_pin_to_one_cpu(); status != 0)
+        return status;
+
+    const std::size_t num_threads = forte2::get_num_threads();
+    if (num_threads != 1) {
+        std::cerr << "expected get_num_threads() == 1 when pinned to one CPU, got " << num_threads
+                  << '\n';
+        return 1;
+    }
+    return 0;
 }
 
 } // namespace
 
 int main(int argc, char** argv) {
-    if (argc == 2 && std::string_view(argv[1]) == "--join-on-exception") {
-        const bool joined = joins_workers_during_unwinding();
-        std::cout << joined << '\n';
-        return joined ? 0 : 1;
-    }
-    if (argc == 2 && std::string_view(argv[1]) == "--pin-one") {
-        if (const int status = pin_to_one_cpu(); status != 0)
-            return status;
-    }
+    const std::string_view mode = argc >= 2 ? std::string_view(argv[1]) : std::string_view();
 
-    const std::size_t num_threads = forte2::get_num_threads();
-    const std::size_t count = 3 * num_threads;
-    std::atomic<std::size_t> chunks{0};
-    std::atomic<std::size_t> visited{0};
-    forte2::parallel_for_chunked(count, [&](const std::size_t begin, const std::size_t end) {
-        chunks.fetch_add(1);
-        visited.fetch_add(end - begin);
-    });
+    if (argc == 2 && mode == "--test-thread-joiner") {
+        if (test_thread_joiner())
+            return 0;
+        std::cerr << "ThreadJoiner did not join all workers during unwinding\n";
+        return 1;
+    }
+    if (argc == 4 && mode == "--test-parallel-for-variant") {
+        const std::size_t count = std::strtoull(argv[3], nullptr, 10);
+        return test_parallel_for_variant(std::string_view(argv[2]), count);
+    }
+    if (argc == 2 && mode == "--test-process-affinity")
+        return test_process_affinity();
 
-    std::cout << num_threads << ' ' << chunks.load() << ' ' << visited.load() << '\n';
-    return visited.load() == count ? 0 : 1;
+    std::cerr << "usage: " << argv[0]
+              << " {--test-thread-joiner | --test-parallel-for-variant <name> <count>"
+                 " | --test-process-affinity}\n";
+    return 2;
 }

--- a/tests/helpers/parallel_test_driver.cc
+++ b/tests/helpers/parallel_test_driver.cc
@@ -1,0 +1,78 @@
+#include <atomic>
+#include <cstddef>
+#include <iostream>
+#include <stdexcept>
+#include <string_view>
+
+#ifdef __linux__
+#include <sched.h>
+#endif
+
+#include "forte2/helpers/parallel.h"
+
+namespace {
+
+int pin_to_one_cpu() {
+#ifdef __linux__
+    cpu_set_t available;
+    CPU_ZERO(&available);
+    if (sched_getaffinity(0, sizeof(available), &available) != 0)
+        return 77;
+
+    int first_cpu = -1;
+    for (int cpu = 0; cpu < CPU_SETSIZE; ++cpu) {
+        if (CPU_ISSET(cpu, &available)) {
+            first_cpu = cpu;
+            break;
+        }
+    }
+    if (first_cpu < 0)
+        return 77;
+
+    cpu_set_t affinity;
+    CPU_ZERO(&affinity);
+    CPU_SET(first_cpu, &affinity);
+    return sched_setaffinity(0, sizeof(affinity), &affinity) == 0 ? 0 : 77;
+#else
+    return 77;
+#endif
+}
+
+bool joins_workers_during_unwinding() {
+    std::atomic<bool> worker_completed{false};
+    try {
+        std::vector<std::thread> workers;
+        workers.reserve(2);
+        forte2::detail::ThreadJoiner thread_joiner(workers);
+        workers.emplace_back([&worker_completed]() { worker_completed.store(true); });
+        throw std::runtime_error("simulate failure to create the next worker");
+    } catch (const std::runtime_error&) {
+        return worker_completed.load();
+    }
+}
+
+} // namespace
+
+int main(int argc, char** argv) {
+    if (argc == 2 && std::string_view(argv[1]) == "--join-on-exception") {
+        const bool joined = joins_workers_during_unwinding();
+        std::cout << joined << '\n';
+        return joined ? 0 : 1;
+    }
+    if (argc == 2 && std::string_view(argv[1]) == "--pin-one") {
+        if (const int status = pin_to_one_cpu(); status != 0)
+            return status;
+    }
+
+    const std::size_t num_threads = forte2::get_num_threads();
+    const std::size_t count = 3 * num_threads;
+    std::atomic<std::size_t> chunks{0};
+    std::atomic<std::size_t> visited{0};
+    forte2::parallel_for_chunked(count, [&](const std::size_t begin, const std::size_t end) {
+        chunks.fetch_add(1);
+        visited.fetch_add(end - begin);
+    });
+
+    std::cout << num_threads << ' ' << chunks.load() << ' ' << visited.load() << '\n';
+    return visited.load() == count ? 0 : 1;
+}

--- a/tests/helpers/test_parallel.py
+++ b/tests/helpers/test_parallel.py
@@ -7,8 +7,32 @@ import sys
 
 import pytest
 
+from forte2.lib import cpp_helpers
+
 _ROOT = Path(__file__).resolve().parents[2]
-_THREAD_LIMIT_ENV = ("OMP_NUM_THREADS", "OMP_THREAD_LIMIT", "SLURM_CPUS_PER_TASK")
+
+_THREAD_ENV = (
+    "FORTE_NUM_THREADS_OVERRIDE",
+    "OMP_NUM_THREADS",
+    "OMP_THREAD_LIMIT",
+    "SLURM_CPUS_PER_TASK",
+)
+
+_PARALLEL_FOR_VARIANTS = (
+    "parallel_for",
+    "parallel_for_chunked",
+    "parallel_for_chunked_thread",
+    "parallel_for_chunked_async",
+    "parallel_for_interleaved_thread",
+    "parallel_for_interleaved_async",
+    "parallel_for_dynamic_thread",
+    "parallel_for_dynamic_async",
+    "parallel_for_each",
+)
+
+# Counts spanning the interesting regimes: empty, single, below SERIAL_THRESHOLD*threads (serial
+# fallback), an uneven size that does not divide evenly into blocks, and larger parallel sizes.
+_COVERAGE_COUNTS = (0, 1, 2, 7, 101, 1000)
 
 
 @pytest.fixture(scope="module")
@@ -29,50 +53,92 @@ def parallel_test_driver(tmp_path_factory):
     return executable
 
 
-def _run_driver(executable, limits=None, *args):
+def _run_driver(executable, *args):
+    """Run one driver mode. The driver self-asserts and communicates via exit code alone:
+    0 = passed, 77 = skip (unsupported environment), anything else = failed. On failure the
+    driver's stderr is surfaced in the assertion message."""
     env = os.environ.copy()
-    for variable in _THREAD_LIMIT_ENV:
+    for variable in _THREAD_ENV:
         env.pop(variable, None)
-    env.update(limits or {})
     result = subprocess.run(
         [str(executable), *args], env=env, check=False, capture_output=True, text=True
     )
     if result.returncode == 77:
-        pytest.skip("process affinity controls are unavailable")
-    result.check_returncode()
-    return tuple(int(value) for value in result.stdout.split())
+        pytest.skip("driver reported an unsupported environment (exit code 77)")
+    assert result.returncode == 0, result.stderr or result.stdout
 
 
-def test_parallel_thread_count_honors_environment_limits(parallel_test_driver):
-    baseline, baseline_chunks, baseline_visited = _run_driver(
-        parallel_test_driver, {"OMP_NUM_THREADS": "8"}
-    )
-    assert baseline >= 1
-    assert baseline_chunks == baseline
-    assert baseline_visited == 3 * baseline
+def test_get_num_threads(monkeypatch):
+    def _reset():
+        for var in _THREAD_ENV:
+            monkeypatch.delenv(var, raising=False)
+
+    _reset()
+    # baseline min(hardware, affinity)
+    phys_thrds = cpp_helpers.get_num_threads()
 
     cases = [
-        ({"OMP_NUM_THREADS": "1"}, 1),
-        ({"OMP_NUM_THREADS": "1,4"}, 1),
-        ({"OMP_NUM_THREADS": "8", "OMP_THREAD_LIMIT": "2"}, min(baseline, 2)),
-        ({"OMP_NUM_THREADS": "8", "SLURM_CPUS_PER_TASK": "2"}, min(baseline, 2)),
+        # override bypasses the min-chain, so it wins regardless of hardware
+        ([("FORTE_NUM_THREADS_OVERRIDE", " 12345678\t\n\v")], 12345678),
+        # a small valid override wins even below the hardware count
+        ([("FORTE_NUM_THREADS_OVERRIDE", "2")], 2),
+        # malformed / out-of-range overrides fall through to the min-chain
+        ([("FORTE_NUM_THREADS_OVERRIDE", "9" * 20)], phys_thrds),  # overflows size_t
+        ([("FORTE_NUM_THREADS_OVERRIDE", "1.23")], phys_thrds),
+        ([("FORTE_NUM_THREADS_OVERRIDE", "12-3")], phys_thrds),
+        ([("FORTE_NUM_THREADS_OVERRIDE", "-1")], phys_thrds),
+        ([("FORTE_NUM_THREADS_OVERRIDE", "0")], phys_thrds),
+        ([("FORTE_NUM_THREADS_OVERRIDE", "")], phys_thrds),
+        # the override does not accept the comma-list syntax
+        ([("FORTE_NUM_THREADS_OVERRIDE", "12,6")], phys_thrds),
+        ([("FORTE_NUM_THREADS_OVERRIDE", "12"), ("SLURM_CPUS_PER_TASK", "6")], 12),
+        # no override: the smallest valid limit wins, bounded by the hardware count
+        (
+            [
+                ("OMP_NUM_THREADS", "12"),
+                ("SLURM_CPUS_PER_TASK", "6"),
+                ("OMP_THREAD_LIMIT", "3"),
+            ],
+            min(phys_thrds, 3),
+        ),
+        # an invalid limit is ignored; the next-smallest valid one applies
+        (
+            [
+                ("OMP_NUM_THREADS", "12"),
+                ("SLURM_CPUS_PER_TASK", "4"),
+                ("OMP_THREAD_LIMIT", "-5"),
+            ],
+            min(phys_thrds, 4),
+        ),
+        # only the first element of an OMP_NUM_THREADS list is used
+        ([("OMP_NUM_THREADS", "2,1 , 2")], min(phys_thrds, 2)),
     ]
-    for limits, expected in cases:
-        num_threads, chunks, visited = _run_driver(parallel_test_driver, limits)
-        assert num_threads == expected
-        assert chunks == expected
-        assert visited == 3 * expected
 
-
-def test_worker_threads_are_joined_during_exception_unwinding(parallel_test_driver):
-    assert _run_driver(parallel_test_driver, None, "--join-on-exception") == (1,)
+    for envvars, expected in cases:
+        _reset()
+        for var, val in envvars:
+            monkeypatch.setenv(var, val)
+        assert cpp_helpers.get_num_threads() == expected
 
 
 @pytest.mark.skipif(
     not sys.platform.startswith("linux"), reason="sched affinity is Linux-only"
 )
-def test_parallel_thread_count_honors_process_affinity(parallel_test_driver):
-    num_threads, chunks, visited = _run_driver(parallel_test_driver, None, "--pin-one")
-    assert num_threads == 1
-    assert chunks == 1
-    assert visited == 3
+def test_get_num_threads_with_affinity_mask(parallel_test_driver):
+    # The driver pins itself to a single CPU, then asserts get_num_threads() reports 1.
+    _run_driver(parallel_test_driver, "--test-process-affinity")
+
+
+@pytest.mark.parametrize("variant", _PARALLEL_FOR_VARIANTS)
+@pytest.mark.parametrize("count", _COVERAGE_COUNTS)
+def test_parallel_for_variants(parallel_test_driver, variant, count):
+    # The driver runs the variant and asserts every index in [0, count) is visited exactly once,
+    # failing (non-zero exit) otherwise. A returncode of 77 (skip) is handled inside _run_driver,
+    # e.g. for parallel_for_each where the C++17 parallel algorithms are unavailable (Apple Clang).
+    _run_driver(
+        parallel_test_driver, "--test-parallel-for-variant", variant, str(count)
+    )
+
+
+def test_thread_joiner(parallel_test_driver):
+    _run_driver(parallel_test_driver, "--test-thread-joiner")

--- a/tests/helpers/test_parallel.py
+++ b/tests/helpers/test_parallel.py
@@ -1,0 +1,78 @@
+import os
+from pathlib import Path
+import shlex
+import shutil
+import subprocess
+import sys
+
+import pytest
+
+_ROOT = Path(__file__).resolve().parents[2]
+_THREAD_LIMIT_ENV = ("OMP_NUM_THREADS", "OMP_THREAD_LIMIT", "SLURM_CPUS_PER_TASK")
+
+
+@pytest.fixture(scope="module")
+def parallel_test_driver(tmp_path_factory):
+    compiler = shlex.split(os.environ.get("CXX", "c++"))
+    if not compiler or shutil.which(compiler[0]) is None:
+        pytest.skip(
+            "a C++ compiler is required to test the header-only parallel helpers"
+        )
+
+    executable = tmp_path_factory.mktemp("parallel") / "parallel_test_driver"
+    source = Path(__file__).with_name("parallel_test_driver.cc")
+    command = compiler + ["-std=c++20", "-pthread"]
+    if sys.platform == "darwin":
+        command.append("-fblocks")
+    command += ["-I", str(_ROOT), str(source), "-o", str(executable)]
+    subprocess.run(command, check=True, capture_output=True, text=True)
+    return executable
+
+
+def _run_driver(executable, limits=None, *args):
+    env = os.environ.copy()
+    for variable in _THREAD_LIMIT_ENV:
+        env.pop(variable, None)
+    env.update(limits or {})
+    result = subprocess.run(
+        [str(executable), *args], env=env, check=False, capture_output=True, text=True
+    )
+    if result.returncode == 77:
+        pytest.skip("process affinity controls are unavailable")
+    result.check_returncode()
+    return tuple(int(value) for value in result.stdout.split())
+
+
+def test_parallel_thread_count_honors_environment_limits(parallel_test_driver):
+    baseline, baseline_chunks, baseline_visited = _run_driver(
+        parallel_test_driver, {"OMP_NUM_THREADS": "8"}
+    )
+    assert baseline >= 1
+    assert baseline_chunks == baseline
+    assert baseline_visited == 3 * baseline
+
+    cases = [
+        ({"OMP_NUM_THREADS": "1"}, 1),
+        ({"OMP_NUM_THREADS": "1,4"}, 1),
+        ({"OMP_NUM_THREADS": "8", "OMP_THREAD_LIMIT": "2"}, min(baseline, 2)),
+        ({"OMP_NUM_THREADS": "8", "SLURM_CPUS_PER_TASK": "2"}, min(baseline, 2)),
+    ]
+    for limits, expected in cases:
+        num_threads, chunks, visited = _run_driver(parallel_test_driver, limits)
+        assert num_threads == expected
+        assert chunks == expected
+        assert visited == 3 * expected
+
+
+def test_worker_threads_are_joined_during_exception_unwinding(parallel_test_driver):
+    assert _run_driver(parallel_test_driver, None, "--join-on-exception") == (1,)
+
+
+@pytest.mark.skipif(
+    not sys.platform.startswith("linux"), reason="sched affinity is Linux-only"
+)
+def test_parallel_thread_count_honors_process_affinity(parallel_test_driver):
+    num_threads, chunks, visited = _run_driver(parallel_test_driver, None, "--pin-one")
+    assert num_threads == 1
+    assert chunks == 1
+    assert visited == 3


### PR DESCRIPTION
## Summary

- make real and relativistic K-block allocation strict, budget-bounded, and retry-safe
- tile AB, AAB, and ABB RDM contractions across the full composite hole index and release scratch after each call
- cap thread workers by affinity, OpenMP limits, and Slurm CPU allocation
- join partially launched worker sets safely during exception unwinding

This is a stacked fix for #204 and targets `nonrel-ci-perf` directly.

## Validation

- `pytest -q tests/ci` — 79 passed
- `pytest -q tests/helpers/test_parallel.py` — 2 passed, 1 platform skip
- `pytest -q -m "not slow"` — 607 passed, 3 skipped, 28 deselected
- editable C++ rebuild completed successfully on macOS