### PR TITLE
gha: clean up caches more consistently

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -66,7 +66,6 @@ jobs:
         key: cxxbuild-${{ matrix.os }}-${{ hashFiles('environment.yml', '**/CMakeLists.txt', 'pyproject.toml') }}-${{ github.run_id }}
         restore-keys: |
           cxxbuild-${{ matrix.os }}-${{ hashFiles('environment.yml', '**/CMakeLists.txt', 'pyproject.toml') }}-
-          cxxbuild-${{ matrix.os }}-
 
     - name: Restore ccache
       id: ccache-restore
@@ -89,21 +88,6 @@ jobs:
         ccache --show-stats
         pip list
 
-    - name: Trim stale build caches for this ref
-      if: ${{ steps.compile-forte2.outcome == 'success' && !cancelled() }}
-      env:
-        GH_TOKEN: ${{ github.token }}
-      run: |
-        prefix="cxxbuild-${{ matrix.os }}-"
-        # Newest first; keep index 0 (the fallback we just restored), delete the rest.
-        ids=$(gh cache list --ref "$GITHUB_REF" --key "$prefix" \
-                --sort created_at --order desc --limit 100 \
-                --json id --jq '.[1:][].id' \
-                --repo "$GITHUB_REPOSITORY" 2>/dev/null) || ids=""
-        for id in $ids; do
-          gh cache delete "$id" --repo "$GITHUB_REPOSITORY" || true
-        done
-
     - name: Save C++ build tree
       if: ${{ steps.compile-forte2.outcome == 'success' && !cancelled() }}
       uses: actions/cache/save@v4
@@ -117,6 +101,29 @@ jobs:
       with:
         path: ${{ env.CCACHE_DIR }}
         key: ccache-${{ matrix.os }}-${{ github.run_id }}
+
+    # Keep only the most recent generation of this job's caches for this ref
+    - name: Prune stale caches for this ref
+      if: ${{ steps.compile-forte2.outcome == 'success' && !cancelled() }}
+      env:
+        GH_TOKEN: ${{ github.token }}
+        OS: ${{ matrix.os }}
+      run: |
+        # The caches are named
+        # "ccache-<os>-<runid>" and "cxxbuild-<os>-<64hexhash>-<runid>"
+        for pat in \
+          "^ccache-${OS}-[0-9]+\$" \
+          "^cxxbuild-${OS}-[0-9a-f]+-[0-9]+\$"; do
+          # Newest first; keep index 0 (the generation we just saved), delete the rest.
+          ids=$(gh cache list --ref "$GITHUB_REF" \
+                  --sort created_at --order desc --limit 100 \
+                  --json id,key --repo "$GITHUB_REPOSITORY" \
+                  --jq "[.[] | select(.key | test(\"$pat\"))][1:][].id" 2>/dev/null) || ids=""
+          for id in $ids; do
+            echo "Deleting stale cache $id"
+            gh cache delete "$id" --repo "$GITHUB_REPOSITORY" || true
+          done
+        done
 
     - name: Run Forte2 pytest tests
       if: ${{ steps.compile-forte2.outcome == 'success' && !cancelled() }}

--- a/.github/workflows/cleanup-caches.yml
+++ b/.github/workflows/cleanup-caches.yml
@@ -1,7 +1,11 @@
 name: cleanup-pr-caches
 
-# When a PR closes (merged or not), its refs/pull/<N>/merge caches can never be
-# read again, so delete them all to reclaim the repo's 10 GB cache budget.
+# When a PR closes (merged or not), the caches it created can never be read
+# again, so delete them all to reclaim the repo's 10 GB cache budget. Two kinds
+# of refs are cleaned up:
+#   * refs/pull/<N>/merge                      - caches from pull_request runs
+#   * gh-readonly-queue/<base>/pr-<N>-<sha>    - caches from merge-queue runs
+#
 on:
   pull_request:
     types: [closed]
@@ -16,13 +20,18 @@ jobs:
       - name: Delete all caches for the closed PR
         env:
           GH_TOKEN: ${{ github.token }}
-          PR_REF: refs/pull/${{ github.event.pull_request.number }}/merge
+          PR_NUM: ${{ github.event.pull_request.number }}
         run: |
-          ids=$(gh cache list --ref "$PR_REF" --limit 100 \
-                  --json id --jq '.[].id' \
-                  --repo "$GITHUB_REPOSITORY") || ids=""
+          ids=$(gh cache list --limit 1000 --json id,ref \
+                  --repo "$GITHUB_REPOSITORY" \
+                  --jq '.[]
+                        | select(
+                            .ref == "refs/pull/" + env.PR_NUM + "/merge"
+                            or (.ref | test("gh-readonly-queue/[^/]+/pr-" + env.PR_NUM + "-[0-9a-f]+$"))
+                          )
+                        | .id') || ids=""
           if [ -z "$ids" ]; then
-            echo "No caches found for $PR_REF"
+            echo "No caches found for PR #${PR_NUM}"
             exit 0
           fi
           for id in $ids; do


### PR DESCRIPTION
This cleans up the merge queue caches after a PR is closed,
and also cleans up the ccache items which were previously not cleaned.