### PR TITLE
fix(helpers): drop unused parallel_for_each

### DIFF
--- a/forte2/helpers/parallel.h
+++ b/forte2/helpers/parallel.h
@@ -4,14 +4,11 @@
 #include <atomic>
 #include <cstddef>
 #include <cstdlib>
-#include <execution>
 #include <future>
 #include <limits>
-#include <ranges>
 #include <thread>
 #include <utility>
 #include <vector>
-#include <version>
 #include <charconv>
 
 #ifdef __linux__
@@ -308,20 +305,6 @@ void parallel_for_chunked(const std::size_t begin, const std::size_t end, F&& fu
 template <typename F> void parallel_for_chunked(const std::size_t count, F&& func) {
     return parallel_for_chunked(0, count, std::forward<F>(func));
 }
-
-// These are only defined if the compiler supports C++17 parallel algorithms (Apple Clang does not
-// support this)
-#if defined(__cpp_lib_execution)
-template <typename F>
-void parallel_for_each(const std::size_t begin, const std::size_t end, F&& func) {
-    std::ranges::iota_view indices(begin, end);
-    std::for_each(std::execution::par_unseq, indices.begin(), indices.end(), func);
-}
-
-template <typename F> void parallel_for_each(const std::size_t count, F&& func) {
-    return parallel_for_each(0, count, std::forward<F>(func));
-}
-#endif
 
 // if Apple, then use dispatch_apply for parallelism
 // finally, fall back to std::thread

--- a/tests/helpers/parallel_test_driver.cc
+++ b/tests/helpers/parallel_test_driver.cc
@@ -150,15 +150,6 @@ int test_parallel_for_variant(const std::string_view name, const std::size_t cou
     if (name == "parallel_for_dynamic_async")
         return run_index_fn(
             count, [count](auto&& f) { forte2::parallel_for_dynamic_async(0, count, f); });
-    if (name == "parallel_for_each") {
-#if defined(__cpp_lib_execution)
-        return run_index_fn(count,
-                            [count](auto&& f) { forte2::parallel_for_each(0, count, f); });
-#else
-        // C++17 parallel algorithms are unavailable (e.g. Apple Clang): signal a skip.
-        return 77;
-#endif
-    }
 
     std::cerr << "unknown parallel_for variant: " << name << '\n';
     return 2;

--- a/tests/helpers/test_parallel.py
+++ b/tests/helpers/test_parallel.py
@@ -27,7 +27,6 @@ _PARALLEL_FOR_VARIANTS = (
     "parallel_for_interleaved_async",
     "parallel_for_dynamic_thread",
     "parallel_for_dynamic_async",
-    "parallel_for_each",
 )
 
 # Counts spanning the interesting regimes: empty, single, below SERIAL_THRESHOLD*threads (serial
@@ -133,8 +132,7 @@ def test_get_num_threads_with_affinity_mask(parallel_test_driver):
 @pytest.mark.parametrize("count", _COVERAGE_COUNTS)
 def test_parallel_for_variants(parallel_test_driver, variant, count):
     # The driver runs the variant and asserts every index in [0, count) is visited exactly once,
-    # failing (non-zero exit) otherwise. A returncode of 77 (skip) is handled inside _run_driver,
-    # e.g. for parallel_for_each where the C++17 parallel algorithms are unavailable (Apple Clang).
+    # failing (non-zero exit) otherwise. A returncode of 77 (skip) is handled inside _run_driver.
     _run_driver(
         parallel_test_driver, "--test-parallel-for-variant", variant, str(count)
     )


### PR DESCRIPTION
This helper is never used. Apparently it requires intel's oneapi tbb to work properly even for compilers that support this feature, and without it, some compilers silently fall back to serial execution. Removed.