### PR TITLE
opt(jk): optimize on-the-fly FockBuilder

### DIFF
--- a/forte2/integrals/two_electron_compute.h
+++ b/forte2/integrals/two_electron_compute.h
@@ -317,9 +317,12 @@ void compute_two_electron_3c_by_shell(
     const std::size_t stride2 = buffer.shape(1);
     const std::size_t stride3 = buffer.shape(2);
 
+    const std::size_t nish = ish1 - ish0;
+    const std::size_t njsh = jsh1 - jsh0;
+
     /// This lambda function computes the integrals for a given range of shells
     /// in the first basis and fills the buffer.
-    auto kernel = [&](std::size_t s1_begin, std::size_t s1_end) {
+    auto kernel = [&](std::size_t idx_begin, std::size_t idx_end) {
         libint2::Engine engine(Op, max_nprim, max_l);
         engine.set(libint2::BraKet::xs_xx);
         if constexpr (!std::is_same_v<Params, NoParams>) {
@@ -327,37 +330,38 @@ void compute_two_electron_3c_by_shell(
         }
         const auto& results = engine.results();
 
-        // Loop over the given range of shells in basis1
-        for (std::size_t s1 = s1_begin; s1 < s1_end; ++s1) {
+        // Loop over the given range of composite ij indices
+        for (std::size_t idx = idx_begin; idx < idx_end; ++idx) {
+            const std::size_t s1 = ish0 + idx / njsh;
+            const std::size_t s2 = jsh0 + idx % njsh;
+
             const auto& shell1 = basis1[s1];
             auto [f1, n1] = first_size1[s1];
             f1 -= first1; // adjust f1 to be the index in the sliced basis
 
-            // Loop over the shells in basis2 and basis3
-            for (std::size_t s2 = jsh0; s2 < jsh1; ++s2) {
-                const auto& shell2 = basis2[s2];
-                auto [f2, n2] = first_size2[s2];
-                f2 -= first2; // adjust f2 to be the index in the sliced basis
-                for (std::size_t s3 = ksh0; s3 < ksh1; ++s3) {
-                    const auto& shell3 = basis3[s3];
+            const auto& shell2 = basis2[s2];
+            auto [f2, n2] = first_size2[s2];
+            f2 -= first2; // adjust f2 to be the index in the sliced basis
 
-                    // Compute the integrals for this shell triplet
-                    engine.compute(shell1, shell2, shell3);
-                    auto buf = results[0];
-                    if (!buf)
-                        continue;
+            for (std::size_t s3 = ksh0; s3 < ksh1; ++s3) {
+                const auto& shell3 = basis3[s3];
 
-                    auto [f3, n3] = first_size3[s3];
-                    f3 -= first3; // adjust f3 to be the index in the sliced basis
+                // Compute the integrals for this shell triplet
+                engine.compute(shell1, shell2, shell3);
+                auto buf = results[0];
+                if (!buf)
+                    continue;
 
-                    std::size_t offset = f1 * stride2 * stride3 + f2 * stride3 + f3;
+                auto [f3, n3] = first_size3[s3];
+                f3 -= first3; // adjust f3 to be the index in the sliced basis
 
-                    for (std::size_t i = 0, ijk = 0; i < n1; ++i) {
-                        for (std::size_t j = 0; j < n2; ++j) {
-                            for (std::size_t k = 0; k < n3; ++k, ++ijk) {
-                                data[offset + i * stride2 * stride3 + j * stride3 + k] =
-                                    static_cast<double>(buf[ijk]);
-                            }
+                const std::size_t offset = f1 * stride2 * stride3 + f2 * stride3 + f3;
+
+                for (std::size_t i = 0, ijk = 0; i < n1; ++i) {
+                    for (std::size_t j = 0; j < n2; ++j) {
+                        for (std::size_t k = 0; k < n3; ++k, ++ijk) {
+                            data[offset + i * stride2 * stride3 + j * stride3 + k] =
+                                static_cast<double>(buf[ijk]);
                         }
                     }
                 }
@@ -365,7 +369,7 @@ void compute_two_electron_3c_by_shell(
         }
     };
 
-    parallel_for_chunked(ish0, ish1, kernel);
+    parallel_for_chunked(0, nish * njsh, kernel);
 
     // Finalize libint2
     libint2::finalize();

--- a/forte2/jkbuilder/jkbuilder.py
+++ b/forte2/jkbuilder/jkbuilder.py
@@ -660,9 +660,13 @@ class FockBuilderOTF:
 
         if self.backend == "auto":
             max_l = max(self.auxbasis.max_l, self.basis.max_l)
-            _backend = integrals._choose_backend(max_l)
+            if integrals.LIBCINT_AVAILABLE:
+                _backend = integrals._choose_backend(max_l, backend="libcint")
+            else:
+                _backend = integrals._choose_backend(max_l)
         else:
             _backend = self.backend
+
         if _backend == "libint2":
             self.compute_int3c2e_slice = libint2_compute
         else:  # libcint
@@ -791,6 +795,21 @@ class FockBuilderOTF:
     def _fill_Pmn_buffer(self, pshell0, pshell1):
         return self.compute_int3c2e_slice(pshell0, pshell1)
 
+    def _transpose_mPi(self, Pmi, n, scratch):
+        # reinterpretation of buffer, no new allocation
+        mPi = scratch.reshape(-1)[: self.nbf * self.naux * n].reshape(
+            self.nbf, self.naux, n
+        )
+        np.einsum("Pmi->mPi", Pmi, optimize=True, out=mPi)
+        return mPi
+
+    def _conjugate_mPi(self, mPi, n, scratch):
+        mPi_conj = scratch.reshape(-1)[: self.nbf * self.naux * n].reshape(
+            self.nbf, self.naux, n
+        )
+        np.conjugate(mPi, out=mPi_conj)
+        return mPi_conj
+
     def _J_kernel(self, D):
         # 1. Batch over the (raw) P index of (P|mn) integrals
         pshell0, pshell1 = 0, 0
@@ -848,12 +867,10 @@ class FockBuilderOTF:
                 optimize=True,
                 out=self._Pmi_buf[:, :, : i1 - i0],
             )
-            K += np.einsum(
-                "Pmi,Pni->mn",
-                self._Pmi_buf[:, :, : i1 - i0],
-                self._Pmi_buf[:, :, : i1 - i0].conj(),
-                optimize=True,
+            mPi = self._transpose_mPi(
+                self._Pmi_buf[:, :, : i1 - i0], i1 - i0, self._Qmi_buf
             )
+            K += np.einsum("mPi,nPi->mn", mPi, mPi, optimize=True)
             i0 = i1
         return K
 
@@ -907,27 +924,21 @@ class FockBuilderOTF:
                 optimize=True,
                 out=self._Qmi_buf[:, :, : i1 - i0],
             )
+
+            mPi_a = self._transpose_mPi(
+                self._Pmi_buf[:, :, : i1 - i0], i1 - i0, self._Qmi_buf2
+            )
+            mPi_b = self._transpose_mPi(
+                self._Qmi_buf[:, :, : i1 - i0], i1 - i0, self._Pmi_buf
+            )
+            mPi_a_conj = self._conjugate_mPi(mPi_a, i1 - i0, self._Qmi_buf)
             # aa contribution
-            K[0] += np.einsum(
-                "Pmi,Pni->mn",
-                self._Pmi_buf[:, :, : i1 - i0],
-                self._Pmi_buf[:, :, : i1 - i0].conj(),
-                optimize=True,
-            )
+            K[0] += np.einsum("mPi,nPi->mn", mPi_a, mPi_a_conj, optimize=True)
+            mPi_b_conj = self._conjugate_mPi(mPi_b, i1 - i0, self._Qmi_buf)
             # ab contribution
-            K[1] += np.einsum(
-                "Pmi,Pni->mn",
-                self._Pmi_buf[:, :, : i1 - i0],
-                self._Qmi_buf[:, :, : i1 - i0].conj(),
-                optimize=True,
-            )
+            K[1] += np.einsum("mPi,nPi->mn", mPi_a, mPi_b_conj, optimize=True)
             # bb contribution
-            K[2] += np.einsum(
-                "Pmi,Pni->mn",
-                self._Qmi_buf[:, :, : i1 - i0],
-                self._Qmi_buf[:, :, : i1 - i0].conj(),
-                optimize=True,
-            )
+            K[2] += np.einsum("mPi,nPi->mn", mPi_b, mPi_b_conj, optimize=True)
             i0 = i1
         return K
 
@@ -983,12 +994,10 @@ class FockBuilderOTF:
                 optimize=True,
                 out=self._Pmi_buf[:, :, : i1 - i0],
             )
-            K += np.einsum(
-                "Pmi,Pni->mn",
-                self._Pmi_buf[:, :, : i1 - i0],
-                self._Pmi_buf[:, :, : i1 - i0].conj(),
-                optimize=True,
+            mPi = self._transpose_mPi(
+                self._Pmi_buf[:, :, : i1 - i0], i1 - i0, self._Qmi_buf
             )
+            K += np.einsum("mPi,nPi->mn", mPi, mPi, optimize=True)
             if J_pass == 0:
                 bP = self._apply_Mm1(bP)
             J_pass += 1
@@ -1098,27 +1107,20 @@ class FockBuilderOTF:
                 optimize=True,
                 out=self._Qmi_buf[:, :, : i1 - i0],
             )
-            # Kaa contribution
-            K[0] += np.einsum(
-                "Pmi,Pni->mn",
-                self._Pmi_buf[:, :, : i1 - i0],
-                self._Pmi_buf[:, :, : i1 - i0].conj(),
-                optimize=True,
+            mPi_a = self._transpose_mPi(
+                self._Pmi_buf[:, :, : i1 - i0], i1 - i0, self._Qmi_buf2
             )
-            # Kab contribution
-            K[1] += np.einsum(
-                "Pmi,Pni->mn",
-                self._Pmi_buf[:, :, : i1 - i0],
-                self._Qmi_buf[:, :, : i1 - i0].conj(),
-                optimize=True,
+            mPi_b = self._transpose_mPi(
+                self._Qmi_buf[:, :, : i1 - i0], i1 - i0, self._Pmi_buf
             )
-            # Kbb contribution
-            K[2] += np.einsum(
-                "Pmi,Pni->mn",
-                self._Qmi_buf[:, :, : i1 - i0],
-                self._Qmi_buf[:, :, : i1 - i0].conj(),
-                optimize=True,
-            )
+            mPi_a_conj = self._conjugate_mPi(mPi_a, i1 - i0, self._Qmi_buf)
+            # aa contribution
+            K[0] += np.einsum("mPi,nPi->mn", mPi_a, mPi_a_conj, optimize=True)
+            mPi_b_conj = self._conjugate_mPi(mPi_b, i1 - i0, self._Qmi_buf)
+            # ab contribution
+            K[1] += np.einsum("mPi,nPi->mn", mPi_a, mPi_b_conj, optimize=True)
+            # bb contribution
+            K[2] += np.einsum("mPi,nPi->mn", mPi_b, mPi_b_conj, optimize=True)
             if J_pass == 0:
                 bPa = self._apply_Mm1(bPa)
                 bPb = self._apply_Mm1(bPb)

--- a/forte2/optimize/geometry_optimizer.py
+++ b/forte2/optimize/geometry_optimizer.py
@@ -362,9 +362,7 @@ def _project_previous_occupied_orbitals(previous_method, method):
         return None
 
     occupied_counts = _occupied_counts(method)
-    if occupied_counts is None or len(occupied_counts) != len(
-        previous_method.mos.C
-    ):
+    if occupied_counts is None or len(occupied_counts) != len(previous_method.mos.C):
         return None
 
     projected = []

--- a/forte2/scf/ghf.py
+++ b/forte2/scf/ghf.py
@@ -96,21 +96,16 @@ class GHF(SCFBase):
             ), f"{self._scf_type} requires non-negative number of alpha and beta electrons."
 
     def _build_fock(self, H, fock_builder, S):
-        Jaa, Jbb = fock_builder.build_J([self.D[0], self.D[3]])
-        nbf = Jaa.shape[0]
         if self.iter == 0 and self.ms_guess is not None:
             # Apply na/nb_guess
             mo_a, mo_b = self._guess_ms(self.C[0])
             occ = list(mo_a[: self.na_guess]) + list(mo_b[: self.nb_guess])
             occ = sorted(occ)
-            Kaa, Kab, Kba, Kbb = fock_builder.build_K([self.C[0][:, occ]])
+            Cocc = self.C[0][:, occ]
         else:
-            Kaa, Kab, Kba, Kbb = fock_builder.build_K([self.C[0][:, : self.nel]])
-        F = H.copy()
-        F[:nbf, :nbf] += Jaa + Jbb - Kaa
-        F[:nbf, nbf:] += -Kab
-        F[nbf:, :nbf] += -Kba
-        F[nbf:, nbf:] += Jaa + Jbb - Kbb
+            Cocc = self.C[0][:, : self.nel]
+        J, K = fock_builder.build_JK([Cocc])
+        F = H + J[0] - K[0]
 
         F_canon = F
 

--- a/forte2/scf/rhf.py
+++ b/forte2/scf/rhf.py
@@ -33,9 +33,8 @@ class RHF(SCFBase):
         self.na = self.nb = self.nel // 2
 
     def _build_fock(self, H, fock_builder, S):
-        J = fock_builder.build_J(self.D)[0]
-        K = fock_builder.build_K([self.C[0][:, : self.na]])[0]
-        F = H + 2.0 * J - K
+        J, K = fock_builder.build_JK([self.C[0][:, : self.na]])
+        F = H + 2.0 * J[0] - K[0]
         return [F], [F]
 
     def _build_density_matrix(self):

--- a/forte2/scf/rohf.py
+++ b/forte2/scf/rohf.py
@@ -44,8 +44,9 @@ class ROHF(SCFBase):
         return self
 
     def _build_fock(self, H, fock_builder, S):
-        Ja, Jb = fock_builder.build_J(self.D)
-        K = fock_builder.build_K([self.C[0][:, : self.na], self.C[0][:, : self.nb]])
+        (Ja, Jb), K = fock_builder.build_JK(
+            [self.C[0][:, : self.na], self.C[0][:, : self.nb]]
+        )
         F = [H + Ja + Jb - k for k in K]
 
         F_canon = self._build_canonical_fock(F, S)

--- a/forte2/scf/uhf.py
+++ b/forte2/scf/uhf.py
@@ -59,8 +59,9 @@ class UHF(SCFBase):
         ), f"{self._scf_type} requires non-negative number of alpha and beta electrons."
 
     def _build_fock(self, H, fock_builder, S):
-        Ja, Jb = fock_builder.build_J(self.D)
-        K = fock_builder.build_K([self.C[0][:, : self.na], self.C[1][:, : self.nb]])
+        (Ja, Jb), K = fock_builder.build_JK(
+            [self.C[0][:, : self.na], self.C[1][:, : self.nb]]
+        )
         F = [H + Ja + Jb - k for k in K]
 
         F_canon = F

--- a/tests/sci/test_sci.py
+++ b/tests/sci/test_sci.py
@@ -209,7 +209,7 @@ def test_sci5():
     )(rhf)
 
     sci.run()
-    assert sci.E[0] == pytest.approx(-96.6017082329, abs=1e-7)
+    assert sci.E[0] == pytest.approx(-96.60170826050286, abs=5e-7)
 
 
 @pytest.mark.skip(reason="Could not reproduce with FCI with energy_shift")


### PR DESCRIPTION
### Summary
1. switch the default FockBuilderOTF backend to libcint as it's faster
2. use build_JK in all SCF solvers instead of separate J/K. This doesn't make a difference for in-core JK builds but speeds up OTF since it uses fewer passes in the fused JK kernels.
3. transpose the Pmi scratches to mPi like in in-core algorithm for better contraction locality
4. better parallelization of libint2's 3c integral engine

### Timings
Nonrel benchmark is naphthalene/aug-cc-pvtz/cc-pvtz-jkfit, rel benchmark is Br2/cc-pv5z/cc-pvqz-jkfit. Run on my M2 air
call | before | after | speedup
-- | -- | -- | --
build_J (isolated) | 4.45 s | 2.14 s | 2.1x
build_K (isolated) | 2.41–2.59 s | 1.75–1.83 s | ~1.4x
build_JK (isolated, combined) | 5.46–6.12 s | 3.00–3.68 s | ~1.7–1.8x
RHF end-to-end (1 iter) | 15.4 s | 7.2 s | 2.1x
raw 3c ints, blocked pass, default backend | 1.51 s | 0.81 s | 1.85x
raw 3c ints, blocked pass, explicit backend="libint2" | 1.35 s | 1.41 s | ~1.0x (no change)

call | baseline (pre-opt) | after opt | total speedup
-- | -- | -- | --
build_K (isolated, OTF) | 3.43 s | 1.32 s | 2.6x
build_JK (isolated, OTF) | 5.85 s | 1.59 s | 3.7x
GHF end-to-end (maxiter=1) | 44.9 s | 8.7 s | 5.2x

