### PR TITLE
fix(sci): mix the string hash before assigning batches

### DIFF
--- a/forte2/helpers/random.hpp
+++ b/forte2/helpers/random.hpp
@@ -1,0 +1,17 @@
+#pragma once
+
+#include <cstdint>
+
+namespace forte2 {
+
+/// @brief The splitmix64 finalizer/mixer: spreads the bits of a 64-bit integer
+/// @param x The input value to mix
+/// @return The mixed value
+inline uint64_t splitmix64(uint64_t x) {
+    x = (x ^ (x >> 30)) * 0xbf58476d1ce4e5b9ULL;
+    x = (x ^ (x >> 27)) * 0x94d049bb133111ebULL;
+    x = x ^ (x >> 31);
+    return x;
+}
+
+} // namespace forte2

--- a/forte2/sci/rel_sci_helper_select_hbci.cc
+++ b/forte2/sci/rel_sci_helper_select_hbci.cc
@@ -352,7 +352,6 @@ void RelSelectedCIHelper::select_hbci_batch(RelDetRootMap& V_map, RelDetRootMap&
     norb_mask.fill_up_to(norb_);
 
     Determinant new_det;
-    auto hash = String::Hash();
     // Loop over all unique alpha strings. With nb == 0 each alpha string maps to exactly one
     // determinant (the beta string is the single empty spectator), so the per-alpha-string
     // coefficient "block" of the general helper collapses to one coefficient vector and the
@@ -391,7 +390,7 @@ void RelSelectedCIHelper::select_hbci_batch(RelDetRootMap& V_map, RelDetRootMap&
                 // *_unchecked avoids checking if i and a are already occupied/unoccupied
                 auto [new_a_str, sign] = create_single_excitation_unchecked(a_str, i, a);
                 // determine if this determinant belongs to the current batch
-                if (hash(new_a_str) % num_batches != batch_id) {
+                if (batch_of(new_a_str, num_batches) != batch_id) {
                     continue;
                 }
                 new_det.set_alpha_string(new_a_str);
@@ -428,7 +427,7 @@ void RelSelectedCIHelper::select_hbci_batch(RelDetRootMap& V_map, RelDetRootMap&
 
                     auto [new_a_str, sign] = create_double_excitation_unchecked(a_str, i, j, a, b);
 
-                    if (hash(new_a_str) % num_batches != batch_id) {
+                    if (batch_of(new_a_str, num_batches) != batch_id) {
                         continue;
                     }
 

--- a/forte2/sci/sci_helper.h
+++ b/forte2/sci/sci_helper.h
@@ -8,6 +8,7 @@
 
 #include "helpers/ndarray.h"
 #include "helpers/parallel.h"
+#include "helpers/random.hpp"
 #include "helpers/spin.h"
 
 #include "determinant/determinant.h"
@@ -32,6 +33,19 @@ enum class EnergyCorrection { PT2, Variational };
 
 /// @brief Energy correction regularization method
 enum class PT2Regularizer { None, Shift, DSRG };
+
+/// @brief Assign a string to one of `num_batches` batches
+/// @param s The string to assign
+/// @param num_batches The number of batches (must be > 0)
+/// @return The batch index in [0, num_batches)
+inline size_t batch_of(const String& s, size_t num_batches) {
+    // the hash returns just returns the string for Norb == 64
+    // so hash % num_batches directly would distribute determinants
+    // by the occupation of the lowest few orbitals, leading to load imbalance.
+    // Add a pass through a mixer to send determinants equally to all batches.
+    uint64_t x = splitmix64(static_cast<uint64_t>(String::Hash()(s)));
+    return static_cast<size_t>(x % num_batches);
+}
 
 /// @brief A helper class for selected CI methods such as CIPSI and HBCI
 /// This class manages selection and sigma vector computation for selected CI methods.

--- a/forte2/sci/sci_helper_select_hbci.cc
+++ b/forte2/sci/sci_helper_select_hbci.cc
@@ -492,7 +492,6 @@ void SelectedCIHelper::select_hbci_batch(DetRootMap& V_map, DetRootMap& PT_map,
     norb_mask.fill_up_to(norb_);
 
     Determinant new_det;
-    auto hash = String::Hash();
     // Loop over all unique alpha strings
     for (size_t i{0}; i < a_string_size; ++i) {
         const String& a_str = ab_list_.sorted_first_string(i);
@@ -532,7 +531,7 @@ void SelectedCIHelper::select_hbci_batch(DetRootMap& V_map, DetRootMap& PT_map,
                 // since we already know they are
                 auto [new_a_str, sign] = create_single_excitation_unchecked(a_str, i, a);
                 // determine if this determinant belongs to the current batch
-                if (hash(new_a_str) % num_batches != batch_id) {
+                if (batch_of(new_a_str, num_batches) != batch_id) {
                     continue;
                 }
                 new_det.set_alpha_string(new_a_str);
@@ -576,7 +575,7 @@ void SelectedCIHelper::select_hbci_batch(DetRootMap& V_map, DetRootMap& PT_map,
 
                     auto [new_a_str, sign] = create_double_excitation_unchecked(a_str, i, j, a, b);
 
-                    if (hash(new_a_str) % num_batches != batch_id) {
+                    if (batch_of(new_a_str, num_batches) != batch_id) {
                         continue;
                     }
 
@@ -609,7 +608,7 @@ void SelectedCIHelper::select_hbci_batch(DetRootMap& V_map, DetRootMap& PT_map,
                 // find the new alpha string after excitation and the sign and store it
                 auto [new_a_str, a_sign] = create_single_excitation_unchecked(a_str, i, a);
 
-                if (hash(new_a_str) % num_batches != batch_id) {
+                if (batch_of(new_a_str, num_batches) != batch_id) {
                     continue;
                 }
 
@@ -654,7 +653,7 @@ void SelectedCIHelper::select_hbci_batch(DetRootMap& V_map, DetRootMap& PT_map,
         }
 
         // beta excitations
-        if (hash(a_str) % num_batches != batch_id)
+        if (batch_of(a_str, num_batches) != batch_id)
             continue;
 
         new_det.set_alpha_string(a_str);

--- a/forte2/sci/sci_helper_spin.cc
+++ b/forte2/sci/sci_helper_spin.cc
@@ -61,7 +61,7 @@ std::vector<double> SelectedCIHelper::spin2_batch(size_t num_batches, size_t bat
             const double a_sign = new_a_str.create(a);
 
             // only process this string if it belongs to the current batch
-            if (String::Hash()(new_a_str) % num_batches != batch_id) {
+            if (batch_of(new_a_str, num_batches) != batch_id) {
                 continue;
             }
             new_det.set_alpha_string(new_a_str);


### PR DESCRIPTION
### Problem
Today, `String::Hash` takes the `N == 64` branch of `BitArray::Hash`, which returns `words_[0]` unchanged. 
This can lead to load imbalance for the selected CI algorithm in the following way:

In selected CI with batching, the batch that a determinant belongs to is calculated by`String::Hash()(a_str) % num_batches`.
If `num_batches` is a power of two (which is common!), the batch index would be exactly the decimal representation of the occupation of the lowest `log2(num_batches)` orbitals.  For example, if `num_batches` is 16, then any string with the lowest 4 bits set will be sent to batch 15. In the extreme case that all determinants have the lowest 4 orbitals occupied, all determinants will be sent to batch 15.

### Solution
Add randomness to the `String::Hash()` return using [Splitmix64](https://rosettacode.org/wiki/Pseudo-random_numbers/Splitmix64). This ensures that determinants are sent (quasi-)uniformly across all 64 bits before taking the modulo.

### Benchmarking
Measured on a water/cc-pVDZ wavefunction with 6543 unique alpha strings, the ratio of the largest batch to the mean grew with the batch count instead of staying flat: 6.15 at 64 batches, 10.45 at 128, 17.10 at 256, and 27.86 at 512, where 209 of the 512 batches were empty. With the mixing step those become 1.19, 1.31, 1.57, and 1.96 with no empty batches.