### PR TITLE
fix(sci): sum each determinant's coupling before squaring it

### DIFF
--- a/forte2/base_classes/params.py
+++ b/forte2/base_classes/params.py
@@ -267,3 +267,11 @@ class SelectedCIParams(ParamsBase):
     energy_shift: float = None
     pt2_regularizer: Literal["none", "shift", "dsrg"] = "none"
     pt2_regularizer_strength: float = 0.0
+
+    def __post_init__(self):
+        super().__post_init__()
+        if self.var_threshold < 0:
+            raise RuntimeError(f"var_threshold cannot be negative, got {self.var_threshold}")
+        if self.pt2_threshold < 0:
+            raise RuntimeError(f"var_threshold cannot be negative, got {self.pt2_threshold}")
+

--- a/forte2/sci/rel_sci_helper.h
+++ b/forte2/sci/rel_sci_helper.h
@@ -186,12 +186,35 @@ class RelSelectedCIHelper {
     void H1a(std::span<std::complex<double>> basis, std::span<std::complex<double>> sigma) const;
     void H2a(std::span<std::complex<double>> basis, std::span<std::complex<double>> sigma) const;
 
-    /// @brief Select new variational and PT2 determinants using a batch approach
-    void select_hbci_batch(RelDetRootMap& V_map, RelDetRootMap& PT_map,
-                           std::vector<std::complex<double>>& V_coeffs,
-                           std::vector<std::complex<double>>& PT_coeffs, double var_threshold,
-                           double pt2_threshold, size_t num_batches, size_t batch_id,
-                           const DetSet& existing_dets);
+    /// @brief Reusable working buffers for select_hbci_batch
+    struct RelSelectHbciScratch {
+        /// @brief Maps each external determinant to the starting index of its coefficient block
+        RelDetRootMap map;
+        /// @brief The coupling <det|H|Psi_r> of each external determinant to each root, summed
+        /// over every parent that reaches it, as coeffs[idx + r]
+        std::vector<std::complex<double>> coeffs;
+        /// @brief One flag per external determinant, indexed as promoted[idx / nroots], set when
+        /// at least one of its connections exceeds var_threshold and it therefore will join the
+        /// variational space in the next iteration
+        std::vector<uint8_t> promoted;
+        /// @brief Scratch occupation vectors for occupied/virtual spinors
+        std::vector<size_t> aocc, avir;
+    };
+
+    /// @brief Enumerate the determinants of one batch that are connected to the variational space
+    /// and accumulate their couplings
+    /// @param s Working buffers owned by the calling thread, cleared on entry
+    /// @param var_threshold Connections above this promote their determinant into the variational
+    /// space. Must not be negative.
+    /// @param pt2_threshold Connections whose criterion does not exceed this are discarded. Must
+    /// not be negative.
+    /// @param num_batches The total number of batches
+    /// @param batch_id The batch index to process
+    /// @param existing_dets The set of determinants already in the variational space to skip
+    /// @note Batch membership is decided by the external determinant alone, so every parent
+    /// that reaches a given determinant is guaranteed to be visited in the same batch
+    void select_hbci_batch(RelSelectHbciScratch& s, double var_threshold, double pt2_threshold,
+                           size_t num_batches, size_t batch_id, const DetSet& existing_dets);
 
     // == Class Private Variables ==
 

--- a/forte2/sci/rel_sci_helper_select_hbci.cc
+++ b/forte2/sci/rel_sci_helper_select_hbci.cc
@@ -33,8 +33,11 @@ void RelSelectedCIHelper::select_hbci_ref(double var_threshold, double pt2_thres
 
     local_timer selection_timer;
 
-    std::vector<RelDetMap> V_map(nroots_);
-    std::vector<RelDetMap> PT_map(nroots_);
+    // One coupling per external determinant per root, plus the set of determinants that will
+    // join the variational space. The coupling must be complete before it is squared, so it is
+    // never split by which side of var_threshold an individual connection falls on.
+    std::vector<RelDetMap> map(nroots_);
+    DetSet promoted;
 
     std::vector<size_t> aocc(na_, 0);
     std::vector<size_t> avir(norb_ - na_, 0);
@@ -65,20 +68,17 @@ void RelSelectedCIHelper::select_hbci_ref(double var_threshold, double pt2_thres
                 const std::complex<double> integral = singles_coupling_a(i, a, det);
                 const double criterion = std::abs(integral * max_abs_c);
 
-                if (criterion < pt2_threshold)
+                if (criterion <= pt2_threshold)
                     continue;
 
                 const auto [new_det, sign] = create_single_a_excitation(det, i, a);
                 const std::complex<double> coupling = sign * std::conj(integral);
 
                 if (criterion > var_threshold) {
-                    for (size_t r{0}; r < nroots_; ++r) {
-                        V_map[r][new_det] += coupling * c_det[r];
-                    }
-                } else {
-                    for (size_t r{0}; r < nroots_; ++r) {
-                        PT_map[r][new_det] += coupling * c_det[r];
-                    }
+                    promoted.insert(new_det);
+                }
+                for (size_t r{0}; r < nroots_; ++r) {
+                    map[r][new_det] += coupling * c_det[r];
                 }
             }
         }
@@ -99,20 +99,17 @@ void RelSelectedCIHelper::select_hbci_ref(double var_threshold, double pt2_thres
 
                         const std::complex<double> integral = Va(i, j, a, b);
                         const double criterion = std::abs(integral * max_abs_c);
-                        if (criterion < pt2_threshold)
+                        if (criterion <= pt2_threshold)
                             continue;
 
                         const auto [new_det, sign] = create_double_aa_excitation(det, i, j, a, b);
                         const std::complex<double> coupling = sign * std::conj(integral);
 
                         if (criterion > var_threshold) {
-                            for (size_t r{0}; r < nroots_; ++r) {
-                                V_map[r][new_det] += coupling * c_det[r];
-                            }
-                        } else {
-                            for (size_t r{0}; r < nroots_; ++r) {
-                                PT_map[r][new_det] += coupling * c_det[r];
-                            }
+                            promoted.insert(new_det);
+                        }
+                        for (size_t r{0}; r < nroots_; ++r) {
+                            map[r][new_det] += coupling * c_det[r];
                         }
                     }
                 }
@@ -120,23 +117,17 @@ void RelSelectedCIHelper::select_hbci_ref(double var_threshold, double pt2_thres
         }
     }
 
-    // Remove the coupling to determinants that are already in the variational space
-    for (size_t r{0}; r < nroots_; ++r) {
-        for (const auto& det : dets_) {
-            V_map[r].erase(det);
-            PT_map[r].erase(det);
+    // Drop the determinants that are already in the variational space; the correction runs over
+    // the determinants outside it
+    for (const auto& det : dets_) {
+        promoted.erase(det);
+        for (size_t r{0}; r < nroots_; ++r) {
+            map[r].erase(det);
         }
     }
 
-    // Remove the coupling for the PT2 determinants that are already in the new variational space
-    for (size_t r{0}; r < nroots_; ++r) {
-        for (const auto& [det, val] : V_map[r]) {
-            PT_map[r].erase(det);
-        }
-    }
-
-    // add variational determinants first (root 0 defines the variational space)
-    for (const auto& [det, val] : V_map[0]) {
+    // add variational determinants first
+    for (const auto& det : promoted) {
         dets_.push_back(det);
     }
 
@@ -144,21 +135,17 @@ void RelSelectedCIHelper::select_hbci_ref(double var_threshold, double pt2_thres
     for (size_t r{0}; r < nroots_; ++r) {
         double var = 0.0;
         double pt = 0.0;
-        for (const auto& [det, val] : V_map[r]) {
+        for (const auto& [det, val] : map[r]) {
             const double delta = root_energies_[r] - slater_rules_.energy(det);
-            var += compute_delta_ept2(delta, std::abs(val));
-        }
-        for (const auto& [det, val] : PT_map[r]) {
-            const double delta = root_energies_[r] - slater_rules_.energy(det);
-            pt += compute_delta_ept2(delta, std::abs(val));
+            (promoted.count(det) ? var : pt) += compute_delta_ept2(delta, std::abs(val));
         }
         ept2_var_[r] = var;
         ept2_pt_[r] = pt;
     }
 
     // number of new determinants added this cycle (root 0 defines the variational space)
-    num_new_dets_var_ = V_map[0].size();
-    num_new_dets_pt2_ = PT_map[0].size();
+    num_new_dets_var_ = promoted.size();
+    num_new_dets_pt2_ = map[0].size() - promoted.size();
 
     c_.resize(dets_.size() * nroots_, 0.0);
 
@@ -181,8 +168,7 @@ void RelSelectedCIHelper::select_hbci(double var_threshold, double pt2_threshold
     std::atomic<size_t> next_batch(0);
 
     std::vector<std::vector<Determinant>> thread_new_dets(num_threads);
-    std::vector<std::vector<double>> local_ept2_var(num_threads,
-                                                    std::vector<double>(nroots_, 0.0));
+    std::vector<std::vector<double>> local_ept2_var(num_threads, std::vector<double>(nroots_, 0.0));
     std::vector<std::vector<double>> local_ept2_pt(num_threads, std::vector<double>(nroots_, 0.0));
     std::vector<std::vector<std::tuple<size_t, size_t, double>>> thread_log_data(num_threads);
 
@@ -190,10 +176,9 @@ void RelSelectedCIHelper::select_hbci(double var_threshold, double pt2_threshold
 
     // worker function for each thread that processes batches of determinants
     auto worker = [&](size_t thread_id) {
-        // persistent storage for this thread to avoid repeated allocations. The maps are cleared
-        // at the beginning of select_hbci_batch, but the underlying memory is reused.
-        RelDetRootMap V_map, PT_map;
-        std::vector<std::complex<double>> V_coeffs, PT_coeffs;
+        // Persistent storage for this thread, so that re-walking the variational space once per
+        // batch does not reallocate. select_hbci_batch clears it on entry but the memory stays.
+        RelSelectHbciScratch s;
         std::vector<Determinant> new_dets_local;
 
         while (true) {
@@ -204,44 +189,36 @@ void RelSelectedCIHelper::select_hbci(double var_threshold, double pt2_threshold
 
             local_timer batch_timer;
 
-            select_hbci_batch(V_map, PT_map, V_coeffs, PT_coeffs, var_threshold, pt2_threshold,
-                              num_batches, batch_id, existing_dets);
+            select_hbci_batch(s, var_threshold, pt2_threshold, num_batches, batch_id,
+                              existing_dets);
 
-            // Filter out determinants in PT_map that are already in the new variational space
-            // (V_map). Both have already been filtered against the existing variational space in
-            // select_hbci_batch.
-            for (const auto& [det, _] : V_map) {
-                PT_map.erase(det);
-            }
-
-            // Compute energy contributions for new variational and PT2 determinants.
-            for (const auto& [det, idx] : V_map) {
+            // Each determinant carries its complete coupling to the variational wave function and
+            // is attributed to exactly one of the two contributions, so no filtering between them
+            // is needed. Determinants already in the variational space were skipped during
+            // generation.
+            new_dets_local.clear();
+            size_t num_pt_dets = 0;
+            for (const auto& [det, idx] : s.map) {
                 const double energy = slater_rules_.energy(det);
+                auto& target = s.promoted[idx / nroots_] ? local_ept2_var[thread_id]
+                                                         : local_ept2_pt[thread_id];
                 for (size_t r{0}; r < nroots_; ++r) {
-                    local_ept2_var[thread_id][r] +=
-                        compute_delta_ept2(root_energies_[r] - energy, std::abs(V_coeffs[idx + r]));
+                    target[r] +=
+                        compute_delta_ept2(root_energies_[r] - energy, std::abs(s.coeffs[idx + r]));
                 }
-            }
-
-            for (const auto& [det, idx] : PT_map) {
-                const double energy = slater_rules_.energy(det);
-                for (size_t r{0}; r < nroots_; ++r) {
-                    local_ept2_pt[thread_id][r] += compute_delta_ept2(root_energies_[r] - energy,
-                                                                      std::abs(PT_coeffs[idx + r]));
+                if (s.promoted[idx / nroots_]) {
+                    new_dets_local.push_back(det);
+                } else {
+                    num_pt_dets++;
                 }
             }
 
             // Append to thread-local container (no locks)
-            new_dets_local.clear();
-            new_dets_local.reserve(V_map.size());
-            for (const auto& [det, _] : V_map)
-                new_dets_local.push_back(det);
-
             thread_new_dets[thread_id].insert(thread_new_dets[thread_id].end(),
                                               new_dets_local.begin(), new_dets_local.end());
 
             thread_log_data[thread_id].push_back(
-                {batch_id, PT_map.size(), batch_timer.elapsed_seconds()});
+                {batch_id, num_pt_dets, batch_timer.elapsed_seconds()});
         }
     };
 
@@ -308,44 +285,58 @@ void RelSelectedCIHelper::select_hbci(double var_threshold, double pt2_threshold
     selection_time_ = selection_timer.elapsed_seconds();
 }
 
-void RelSelectedCIHelper::select_hbci_batch(RelDetRootMap& V_map, RelDetRootMap& PT_map,
-                                            std::vector<std::complex<double>>& V_coeffs,
-                                            std::vector<std::complex<double>>& PT_coeffs,
-                                            double var_threshold, double pt2_threshold,
-                                            size_t num_batches, size_t batch_id,
-                                            const DetSet& existing_dets) {
-    V_map.clear();
-    PT_map.clear();
-    V_coeffs.clear();
-    PT_coeffs.clear();
+void RelSelectedCIHelper::select_hbci_batch(RelSelectHbciScratch& s, double var_threshold,
+                                            double pt2_threshold, size_t num_batches,
+                                            size_t batch_id, const DetSet& existing_dets) {
+    auto& map = s.map;
+    auto& coeffs = s.coeffs;
+    auto& promoted = s.promoted;
+    map.clear();
+    coeffs.clear();
+    promoted.clear();
 
-    // Accumulate `prefactor * c_I` for the determinant `det`, appending a new coefficient block for
-    // each root if the determinant is seen for the first time. `prefactor` already carries the
-    // conjugated, signed coupling <J|H|I> (see the note at the top of this file).
-    auto accumulate = [&](RelDetRootMap& map, std::vector<std::complex<double>>& coeffs,
-                          const Determinant& det, std::complex<double> prefactor,
-                          const std::span<std::complex<double>>& c) {
-        size_t loc = coeffs.size();
-        auto [it, emplaced] = map.try_emplace(det, loc);
-        if (emplaced) {
-            // new determinant, need to append to coeffs vector
-            for (auto& c_r : c) {
-                coeffs.push_back(prefactor * c_r);
-            }
-        } else {
-            // idx is the starting index in the coeffs vector for this determinant
-            size_t idx = it->second;
-            for (size_t r{0}; auto& c_r : c) {
-                coeffs[idx + r] += prefactor * c_r;
-                r++;
-            }
-        }
-    };
-
-    std::vector<size_t> aocc(na_);
-    std::vector<size_t> avir(norb_ - na_);
+    // size the caller's buffers on first use; later batches reuse them untouched
+    s.aocc.resize(na_);
+    s.avir.resize(norb_ - na_);
+    auto& aocc = s.aocc;
+    auto& avir = s.avir;
 
     const auto a_string_size = ab_list_.first_string_size();
+
+    // The single place that decides whether a connection survives and what happens to it. Both
+    // channels go through it, so neither can drift from the other, and it applies the same test
+    // as select_hbci_ref. Channels also test the criterion themselves before building the
+    // external determinant, but only to skip work and only against an upper bound on it; this
+    // test is the one that decides.
+    //
+    // `coupling` already carries the conjugated, signed matrix element <J|H|I> (see the note at
+    // the top of this file).
+    auto accumulate = [&](const Determinant& det, std::span<const std::complex<double>> c_parent,
+                          std::complex<double> coupling, double criterion) {
+        if (criterion <= pt2_threshold)
+            return;
+        // if the determinant is already in the variational space, skip it
+        if (existing_dets.count(det))
+            return;
+        // A determinant can be reached by several parents. Every contribution to <det|H|Psi> has
+        // to be summed before that sum is squared, so all of them accumulate into one entry of
+        // coeffs regardless of which side of var_threshold the individual connection falls on.
+        // Whether the determinant is promoted is a property of the determinant, recorded
+        // separately: one connection above var_threshold is enough.
+        const size_t loc = coeffs.size();
+        auto [it, emplaced] = map.try_emplace(det, loc);
+        if (emplaced) {
+            for (size_t r{0}; r < nroots_; ++r)
+                coeffs.push_back(coupling * c_parent[r]);
+            promoted.push_back(criterion > var_threshold ? 1 : 0);
+        } else {
+            const size_t idx = it->second;
+            for (size_t r{0}; r < nroots_; ++r)
+                coeffs[idx + r] += coupling * c_parent[r];
+            if (criterion > var_threshold)
+                promoted[idx / nroots_] = 1;
+        }
+    };
 
     // norb_mask is used to compute the allowed virtual creation indices
     String norb_mask = String::zero();
@@ -366,10 +357,15 @@ void RelSelectedCIHelper::select_hbci_batch(RelDetRootMap& V_map, RelDetRootMap&
         new_det.set_beta_string(ab_list_.sorted_second_string(b_str_idx));
 
         // CI coefficients of this determinant for all roots, viewed directly in c_ (no gather)
-        std::span<std::complex<double>> c_det(c_.data() + det_index * nroots_, nroots_);
+        std::span<const std::complex<double>> c_det(c_.data() + det_index * nroots_, nroots_);
         double abs_c_max_det = 0.0;
         for (size_t r{0}; r < nroots_; ++r)
             abs_c_max_det = std::max(abs_c_max_det, std::abs(c_det[r]));
+
+        // Every criterion below is proportional to this coefficient, so a determinant whose
+        // coefficients are all zero cannot produce a connection that survives accumulate.
+        if (abs_c_max_det == 0.0)
+            continue;
 
         // find the occupied and virtual orbitals for the current alpha string
         auto a_str_annihilation_masked = a_str & ~frozen_annihilation_mask_;
@@ -395,18 +391,8 @@ void RelSelectedCIHelper::select_hbci_batch(RelDetRootMap& V_map, RelDetRootMap&
                 }
                 new_det.set_alpha_string(new_a_str);
                 const std::complex<double> integral = singles_coupling_a(i, a, new_det);
-                const double criterion = std::abs(integral * abs_c_max_det);
-                if (criterion > pt2_threshold) {
-                    // if the determinant is already in the variational space, skip it
-                    if (!existing_dets.count(new_det)) {
-                        const std::complex<double> coupling = sign * std::conj(integral);
-                        if (criterion > var_threshold) {
-                            accumulate(V_map, V_coeffs, new_det, coupling, c_det);
-                        } else {
-                            accumulate(PT_map, PT_coeffs, new_det, coupling, c_det);
-                        }
-                    }
-                }
+                accumulate(new_det, c_det, sign * std::conj(integral),
+                           std::abs(integral * abs_c_max_det));
             }
         }
 
@@ -419,7 +405,7 @@ void RelSelectedCIHelper::select_hbci_batch(RelDetRootMap& V_map, RelDetRootMap&
                 for (const auto& [key, integral, a, b] : v_list) {
                     // break early if the integrals are too small (the sorted real key monotonically
                     // decreases, so no later term can pass the threshold)
-                    if (std::fabs(key * abs_c_max_det) < pt2_threshold)
+                    if (std::fabs(key * abs_c_max_det) <= pt2_threshold)
                         break;
 
                     if ((a >= b) or a_str.get_bit(a) or a_str.get_bit(b))
@@ -432,18 +418,10 @@ void RelSelectedCIHelper::select_hbci_batch(RelDetRootMap& V_map, RelDetRootMap&
                     }
 
                     const double criterion = std::abs(integral * abs_c_max_det);
-                    if (criterion > pt2_threshold) {
-                        new_det.set_alpha_string(new_a_str);
-                        // if the determinant is already in the variational space, skip it
-                        if (!existing_dets.count(new_det)) {
-                            const std::complex<double> coupling = sign * std::conj(integral);
-                            if (criterion > var_threshold) {
-                                accumulate(V_map, V_coeffs, new_det, coupling, c_det);
-                            } else {
-                                accumulate(PT_map, PT_coeffs, new_det, coupling, c_det);
-                            }
-                        }
-                    }
+                    if (criterion <= pt2_threshold)
+                        continue;
+                    new_det.set_alpha_string(new_a_str);
+                    accumulate(new_det, c_det, sign * std::conj(integral), criterion);
                 }
             }
         }

--- a/forte2/sci/sci_helper.h
+++ b/forte2/sci/sci_helper.h
@@ -1,5 +1,6 @@
 #pragma once
 
+#include <concepts>
 #include <functional>
 #include <vector>
 #include <cmath>
@@ -284,21 +285,40 @@ class SelectedCIHelper {
                             const SelectedCIStrings& list, size_t i, size_t j,
                             double int_sign) const;
 
-    /// @brief Select new variational and PT2 determinants using a batch approach
-    /// @param V_map The map to accumulate variational determinants and their contributions
-    /// @param PT_map The map to accumulate PT2 determinants and their contributions
-    /// @param V_coeffs The vector to accumulate the coefficients of the variational
-    /// determinants
-    /// @param PT_coeffs The vector to accumulate the coefficients of the PT2 determinants
-    /// @param var_threshold The threshold for variational selection
-    /// @param pt2_threshold The threshold for PT2 selection
+    /// @brief Reusable working buffers for select_hbci_batch
+    struct SelectHbciScratch {
+        /// @brief Maps each external determinant to the starting index of its coefficient block
+        DetRootMap map;
+        /// @brief The coupling <det|H|Psi_r> of each external determinant to each root, summed
+        /// over every parent that reaches it, as coeffs[idx + r]
+        std::vector<double> coeffs;
+        /// @brief One flag per external determinant, indexed as promoted[idx / nroots], set when
+        /// at least one of its connections exceeds var_threshold and it therefore will join the
+        /// variational space in the next iteration
+        std::vector<uint8_t> promoted;
+        /// @brief Largest |c| over all roots for each determinant of the current alpha string
+        std::vector<double> abs_c_max;
+        /// @brief Coefficients of the current alpha string's determinants, as
+        /// c_block[k * nroots + r]
+        std::vector<double> c_block;
+        /// @brief Scratch occupation vectors for alpha/beta occupied/virtual
+        std::vector<size_t> aocc, bocc, avir, bvir;
+    };
+
+    /// @brief Enumerate the determinants of one batch that are connected to the variational space
+    /// and accumulate their couplings
+    /// @param s Working buffers owned by the calling thread, cleared on entry
+    /// @param var_threshold Connections above this promote their determinant into the variational
+    /// space. Must not be negative.
+    /// @param pt2_threshold Connections whose criterion does not exceed this are discarded. Must
+    /// not be negative.
     /// @param num_batches The total number of batches
     /// @param batch_id The batch index to process
     /// @param existing_dets The set of determinants already in the variational space to skip
-    void select_hbci_batch(DetRootMap& V_map, DetRootMap& PT_map, std::vector<double>& V_coeffs,
-                           std::vector<double>& PT_coeffs, double var_threshold,
-                           double pt2_threshold, size_t num_batches, size_t batch_id,
-                           const DetSet& existing_dets);
+    /// @note Batch membership is decided by the external determinant alone, so every parent
+    /// that reaches a given determinant is guaranteed to be visited in the same batch
+    void select_hbci_batch(SelectHbciScratch& s, double var_threshold, double pt2_threshold,
+                           size_t num_batches, size_t batch_id, const DetSet& existing_dets);
 
     /// @brief Compute the expectation value of S^2 for a given batch of determinants
     /// @param num_batches The total number of batches
@@ -445,6 +465,8 @@ class SelectedCIHelper {
 
     /// @brief The alpha and beta strings for the determinants in the variational space
     SelectedCIStrings ab_list_;
+    /// @brief The largest number of determinants sharing one alpha string in ab_list_
+    size_t max_block_size_ = 0;
     /// @brief The beta and alpha strings for the determinants in the variational space
     SelectedCIStrings ba_list_;
 

--- a/forte2/sci/sci_helper_select_hbci.cc
+++ b/forte2/sci/sci_helper_select_hbci.cc
@@ -1,4 +1,5 @@
 #include <atomic>
+#include <cmath>
 #include <thread>
 #include <future>
 #include <mutex>
@@ -55,10 +56,11 @@ void SelectedCIHelper::select_hbci_ref(double var_threshold, double pt2_threshol
 
     local_timer selection_timer;
 
-    size_t checks_count = 0;
-
-    std::vector<DetMap> V_map(nroots_);
-    std::vector<DetMap> PT_map(nroots_);
+    // One coupling per external determinant per root, plus the set of determinants that will
+    // join the variational space. The coupling must be complete before it is squared, so it is
+    // never split by which side of var_threshold an individual connection falls on.
+    std::vector<DetMap> map(nroots_);
+    DetSet promoted;
 
     std::vector<size_t> aocc(na_, 0);
     std::vector<size_t> bocc(nb_, 0);
@@ -96,21 +98,17 @@ void SelectedCIHelper::select_hbci_ref(double var_threshold, double pt2_threshol
                 const double integral = slater_rules_.singles_coupling_a(i, a, det);
                 const double criterion = std::fabs(integral * max_abs_c);
 
-                if (criterion < pt2_threshold)
+                if (criterion <= pt2_threshold)
                     continue;
 
                 const auto [new_det, sign] = create_single_a_excitation(det, i, a);
 
                 if (criterion > var_threshold) {
-                    for (size_t r{0}; r < nroots_; ++r) {
-                        V_map[r][new_det] += sign * integral * c_det[r];
-                    }
-                } else {
-                    for (size_t r{0}; r < nroots_; ++r) {
-                        PT_map[r][new_det] += sign * integral * c_det[r];
-                    }
+                    promoted.insert(new_det);
                 }
-                checks_count++;
+                for (size_t r{0}; r < nroots_; ++r) {
+                    map[r][new_det] += sign * integral * c_det[r];
+                }
             }
         }
 
@@ -124,21 +122,17 @@ void SelectedCIHelper::select_hbci_ref(double var_threshold, double pt2_threshol
                 //     slater_rules_.singles_coupling(i, a, bocc, aocc); // h_[i * norb_ + a];
                 const double integral = slater_rules_.singles_coupling_b(i, a, det);
                 const double criterion = std::fabs(integral * max_abs_c);
-                if (criterion < pt2_threshold)
+                if (criterion <= pt2_threshold)
                     continue;
 
                 const auto [new_det, sign] = create_single_b_excitation(det, i, a);
 
                 if (criterion > var_threshold) {
-                    for (size_t r{0}; r < nroots_; ++r) {
-                        V_map[r][new_det] += sign * integral * c_det[r];
-                    }
-                } else {
-                    for (size_t r{0}; r < nroots_; ++r) {
-                        PT_map[r][new_det] += sign * integral * c_det[r];
-                    }
+                    promoted.insert(new_det);
                 }
-                checks_count++;
+                for (size_t r{0}; r < nroots_; ++r) {
+                    map[r][new_det] += sign * integral * c_det[r];
+                }
             }
         }
 
@@ -157,21 +151,17 @@ void SelectedCIHelper::select_hbci_ref(double var_threshold, double pt2_threshol
 
                         const double integral = Va(i, j, a, b);
                         const double criterion = std::fabs(integral * max_abs_c);
-                        if (criterion < pt2_threshold)
+                        if (criterion <= pt2_threshold)
                             continue;
 
                         const auto [new_det, sign] = create_double_aa_excitation(det, i, j, a, b);
 
                         if (criterion > var_threshold) {
-                            for (size_t r{0}; r < nroots_; ++r) {
-                                V_map[r][new_det] += sign * integral * c_det[r];
-                            }
-                        } else {
-                            for (size_t r{0}; r < nroots_; ++r) {
-                                PT_map[r][new_det] += sign * integral * c_det[r];
-                            }
+                            promoted.insert(new_det);
                         }
-                        checks_count++;
+                        for (size_t r{0}; r < nroots_; ++r) {
+                            map[r][new_det] += sign * integral * c_det[r];
+                        }
                     }
                 }
             }
@@ -191,21 +181,17 @@ void SelectedCIHelper::select_hbci_ref(double var_threshold, double pt2_threshol
                             continue;
                         const double integral = Va(i, j, a, b);
                         const double criterion = std::fabs(integral * max_abs_c);
-                        if (criterion < pt2_threshold)
+                        if (criterion <= pt2_threshold)
                             continue;
 
                         const auto [new_det, sign] = create_double_bb_excitation(det, i, j, a, b);
 
                         if (criterion > var_threshold) {
-                            for (size_t r{0}; r < nroots_; ++r) {
-                                V_map[r][new_det] += sign * integral * c_det[r];
-                            }
-                        } else {
-                            for (size_t r{0}; r < nroots_; ++r) {
-                                PT_map[r][new_det] += sign * integral * c_det[r];
-                            }
+                            promoted.insert(new_det);
                         }
-                        checks_count++;
+                        for (size_t r{0}; r < nroots_; ++r) {
+                            map[r][new_det] += sign * integral * c_det[r];
+                        }
                     }
                 }
             }
@@ -225,58 +211,43 @@ void SelectedCIHelper::select_hbci_ref(double var_threshold, double pt2_threshol
                             continue;
                         const double integral = V(i, j, a, b);
                         const double criterion = std::fabs(integral * max_abs_c);
-                        if (criterion < pt2_threshold)
+                        if (criterion <= pt2_threshold)
                             continue;
 
                         const auto [new_det, sign] = create_double_ab_excitation(det, i, j, a, b);
 
                         if (criterion > var_threshold) {
-                            for (size_t r{0}; r < nroots_; ++r) {
-                                V_map[r][new_det] += sign * integral * c_det[r];
-                            }
-                        } else {
-                            for (size_t r{0}; r < nroots_; ++r) {
-                                PT_map[r][new_det] += sign * integral * c_det[r];
-                            }
+                            promoted.insert(new_det);
                         }
-                        checks_count++;
+                        for (size_t r{0}; r < nroots_; ++r) {
+                            map[r][new_det] += sign * integral * c_det[r];
+                        }
                     }
                 }
             }
         }
     }
 
-    // Remove the coupling to determinants that are already in the variational space
-    for (size_t r{0}; r < nroots_; ++r) {
-        for (const auto& det : dets_) {
-            V_map[r].erase(det);
-            PT_map[r].erase(det);
-        }
-    }
-
-    // Remove the coupling for the PT2 determinants that are already in the variational space
-    for (size_t r{0}; r < nroots_; ++r) {
-        for (const auto& [det, val] : V_map[r]) {
-            PT_map[r].erase(det);
+    // Drop the determinants that are already in the variational space; the correction runs over
+    // the determinants outside it
+    for (const auto& det : dets_) {
+        promoted.erase(det);
+        for (size_t r{0}; r < nroots_; ++r) {
+            map[r].erase(det);
         }
     }
 
     // add variational determinants first
-    for (const auto& [det, val] : V_map[0]) {
+    for (const auto& det : promoted) {
         dets_.push_back(det);
     }
 
-    // print all the variational determinants
     for (size_t r{0}; r < nroots_; ++r) {
         double var = 0.0;
         double pt = 0.0;
-        for (const auto& [det, val] : V_map[r]) {
+        for (const auto& [det, val] : map[r]) {
             const double delta = root_energies_[r] - slater_rules_.energy(det);
-            var += compute_delta_ept2(delta, val);
-        }
-        for (const auto& [det, val] : PT_map[r]) {
-            const double delta = root_energies_[r] - slater_rules_.energy(det);
-            pt += compute_delta_ept2(delta, val);
+            (promoted.count(det) ? var : pt) += compute_delta_ept2(delta, val);
         }
         ept2_var_[r] = var;
         ept2_pt_[r] = pt;
@@ -306,8 +277,7 @@ void SelectedCIHelper::select_hbci(double var_threshold, double pt2_threshold) {
     std::atomic<size_t> next_batch(0);
 
     std::vector<std::vector<Determinant>> thread_new_dets(num_threads);
-    std::vector<std::vector<double>> local_ept2_var(num_threads,
-                                                    std::vector<double>(nroots_, 0.0));
+    std::vector<std::vector<double>> local_ept2_var(num_threads, std::vector<double>(nroots_, 0.0));
     std::vector<std::vector<double>> local_ept2_pt(num_threads, std::vector<double>(nroots_, 0.0));
     std::vector<std::vector<std::tuple<size_t, size_t, double>>> thread_log_data(num_threads);
 
@@ -315,11 +285,9 @@ void SelectedCIHelper::select_hbci(double var_threshold, double pt2_threshold) {
 
     // worker function for each thread that processes batches of determinants
     auto worker = [&](size_t thread_id) {
-        // persistent storage for this thread to avoid repeated allocations
-        // The maps are cleared at the beginning of select_hbci_batch
-        // but underlying memory is reused and enlarged if needed
-        DetRootMap V_map, PT_map;
-        std::vector<double> V_coeffs, PT_coeffs;
+        // Persistent storage for this thread, so that re-walking the variational space once per
+        // batch does not reallocate. select_hbci_batch clears it on entry but the memory stays.
+        SelectHbciScratch s;
         std::vector<Determinant> new_dets_local;
 
         while (true) {
@@ -330,44 +298,35 @@ void SelectedCIHelper::select_hbci(double var_threshold, double pt2_threshold) {
 
             local_timer batch_timer;
 
-            select_hbci_batch(V_map, PT_map, V_coeffs, PT_coeffs, var_threshold, pt2_threshold,
-                              num_batches, batch_id, existing_dets);
+            select_hbci_batch(s, var_threshold, pt2_threshold, num_batches, batch_id,
+                              existing_dets);
 
-            // Filter out determinants in PT_map that are already in the new variational space
-            // (V_map) Both have already been filtered against the existing variational space in
-            // select_hbci_batch
-            for (const auto& [det, _] : V_map) {
-                PT_map.erase(det);
-            }
-
-            // Compute energy contributions for new variational and PT2 determinants.
-            for (const auto& [det, idx] : V_map) {
+            // Each determinant carries its complete coupling to the variational wave function and
+            // is attributed to exactly one of the two contributions, so no filtering between them
+            // is needed. Determinants already in the variational space were skipped during
+            // generation.
+            new_dets_local.clear();
+            size_t num_pt_dets = 0;
+            for (const auto& [det, idx] : s.map) {
                 const double energy = slater_rules_.energy(det);
+                auto& target = s.promoted[idx / nroots_] ? local_ept2_var[thread_id]
+                                                         : local_ept2_pt[thread_id];
                 for (size_t r{0}; r < nroots_; ++r) {
-                    local_ept2_var[thread_id][r] +=
-                        compute_delta_ept2(root_energies_[r] - energy, V_coeffs[idx + r]);
+                    target[r] += compute_delta_ept2(root_energies_[r] - energy, s.coeffs[idx + r]);
                 }
-            }
-
-            for (const auto& [det, idx] : PT_map) {
-                const double energy = slater_rules_.energy(det);
-                for (size_t r{0}; r < nroots_; ++r) {
-                    local_ept2_pt[thread_id][r] +=
-                        compute_delta_ept2(root_energies_[r] - energy, PT_coeffs[idx + r]);
+                if (s.promoted[idx / nroots_]) {
+                    new_dets_local.push_back(det);
+                } else {
+                    num_pt_dets++;
                 }
             }
 
             // Append to thread-local container (no locks)
-            new_dets_local.clear();
-            new_dets_local.reserve(V_map.size());
-            for (const auto& [det, _] : V_map)
-                new_dets_local.push_back(det);
-
             thread_new_dets[thread_id].insert(thread_new_dets[thread_id].end(),
                                               new_dets_local.begin(), new_dets_local.end());
 
             thread_log_data[thread_id].push_back(
-                {batch_id, PT_map.size(), batch_timer.elapsed_seconds()});
+                {batch_id, num_pt_dets, batch_timer.elapsed_seconds()});
         }
     };
 
@@ -434,58 +393,65 @@ void SelectedCIHelper::select_hbci(double var_threshold, double pt2_threshold) {
     selection_time_ = selection_timer.elapsed_seconds();
 }
 
-void SelectedCIHelper::select_hbci_batch(DetRootMap& V_map, DetRootMap& PT_map,
-                                         std::vector<double>& V_coeffs,
-                                         std::vector<double>& PT_coeffs, double var_threshold,
+void SelectedCIHelper::select_hbci_batch(SelectHbciScratch& s, double var_threshold,
                                          double pt2_threshold, size_t num_batches, size_t batch_id,
                                          const DetSet& existing_dets) {
-    V_map.clear();
-    PT_map.clear();
-    V_coeffs.clear();
-    PT_coeffs.clear();
+    auto& map = s.map;
+    auto& coeffs = s.coeffs;
+    auto& promoted = s.promoted;
+    map.clear();
+    coeffs.clear();
+    promoted.clear();
 
-    auto accumulate = [&](DetRootMap& map, std::vector<double>& coeffs, const Determinant& det,
-                          double prefactor, const std::span<double>& c) {
-        // try_emplace returns an iterator to the existing element
-        // if the determinant is already in the map
-        size_t loc = coeffs.size();
-        auto [it, emplaced] = map.try_emplace(det, loc);
-        if (emplaced) {
-            // new determinant, need to append to coeffs vector
-            for (auto& c_r : c) {
-                coeffs.push_back(prefactor * c_r);
-            }
-        } else {
-            // idx is the starting index in the coeffs vector for this determinant
-            size_t idx = it->second;
-            // existing determinant, just update the coefficients
-            for (size_t r{0}; auto& c_r : c) {
-                coeffs[idx + r] += prefactor * c_r;
-                r++;
-            }
-        }
-    };
-
-    std::vector<size_t> aocc(na_);
-    std::vector<size_t> bocc(nb_);
-    std::vector<size_t> avir(norb_ - na_);
-    std::vector<size_t> bvir(norb_ - nb_);
-
-    size_t checks_count = 0;
-    double e_pt2 = 0.0;
+    // size the caller's buffers on first use; later batches reuse them untouched
+    s.aocc.resize(na_);
+    s.bocc.resize(nb_);
+    s.avir.resize(norb_ - na_);
+    s.bvir.resize(norb_ - nb_);
+    s.abs_c_max.resize(max_block_size_);
+    s.c_block.resize(max_block_size_ * nroots_);
+    auto& aocc = s.aocc;
+    auto& bocc = s.bocc;
+    auto& avir = s.avir;
+    auto& bvir = s.bvir;
+    // the buffers belong to this thread, so they cannot alias c_ or the string lists; without
+    // that promise every criterion below reloads abs_c_max[k] from memory
+    double* __restrict abs_c_max = s.abs_c_max.data();
+    double* __restrict c_block = s.c_block.data();
 
     size_t noa, nob, nva, nvb;
     const auto a_string_size = ab_list_.first_string_size();
 
-    // precompute the maximum block size for the temporary storage
-    std::size_t max_block_size = 0;
-    for (size_t i{0}; i < a_string_size; ++i) {
-        max_block_size = std::max(max_block_size, ab_list_.second_string_to_det_index()[i].size());
-    }
-
-    // allocate the temporary storage for the largest block of alpha strings
-    std::vector<double> abs_c_max(max_block_size, 0.0);
-    std::vector<double> c_block(max_block_size * nroots_, 0.0);
+    // The single place that decides whether a connection survives and what happens to it. Every
+    // channel goes through it, so none of them can drift from the others. Channels also test the
+    // criterion themselves before building the external determinant, but only to skip work and
+    // only against an upper bound on it; this test is the one that decides.
+    auto accumulate = [&](const Determinant& det, const double* c_parent, double coupling,
+                          double criterion) {
+        if (criterion <= pt2_threshold)
+            return;
+        // if the determinant is already in the variational space, skip it
+        if (existing_dets.count(det))
+            return;
+        // A determinant can be reached by several parents. Every contribution to <det|H|Psi> has
+        // to be summed before that sum is squared, so all of them accumulate into one entry of
+        // coeffs regardless of which side of var_threshold the individual connection falls on.
+        // Whether the determinant is promoted is a property of the determinant, recorded
+        // separately: one connection above var_threshold is enough.
+        const size_t loc = coeffs.size();
+        auto [it, emplaced] = map.try_emplace(det, loc);
+        if (emplaced) {
+            for (size_t r{0}; r < nroots_; ++r)
+                coeffs.push_back(coupling * c_parent[r]);
+            promoted.push_back(criterion > var_threshold ? 1 : 0);
+        } else {
+            const size_t idx = it->second;
+            for (size_t r{0}; r < nroots_; ++r)
+                coeffs[idx + r] += coupling * c_parent[r];
+            if (criterion > var_threshold)
+                promoted[idx / nroots_] = 1;
+        }
+    };
 
     // norb_mask is used to compute the allowed virtual creation indices
     String norb_mask = String::zero();
@@ -495,22 +461,27 @@ void SelectedCIHelper::select_hbci_batch(DetRootMap& V_map, DetRootMap& PT_map,
     // Loop over all unique alpha strings
     for (size_t i{0}; i < a_string_size; ++i) {
         const String& a_str = ab_list_.sorted_first_string(i);
-        const auto& second_string_to_det_index = ab_list_.second_string_to_det_index()[i];
+        const auto& second_string_to_det_index = ab_list_.second_string_to_det_index()[i].values();
+        const size_t block_size = second_string_to_det_index.size();
 
-        // grab the CI coefficients for all determinants with the current alpha string for all
-        // roots
+        // Gather this alpha string's coefficients into the scratch buffers
         double abs_c_max_block = 0.0; // track the maximum absolute CI coefficient
-        for (size_t k{0}; const auto& [_, idx] : second_string_to_det_index) {
+        for (size_t k{0}; k < block_size; ++k) {
+            const size_t det_index = second_string_to_det_index[k].second;
             double abs_c_max_det = 0.0;
             for (size_t r{0}; r < nroots_; ++r) {
-                const double c_r = c_[idx * nroots_ + r];
+                const double c_r = c_[det_index * nroots_ + r];
                 c_block[k * nroots_ + r] = c_r;
-                abs_c_max_block = std::max(abs_c_max_block, std::abs(c_r));
                 abs_c_max_det = std::max(abs_c_max_det, std::abs(c_r));
             }
             abs_c_max[k] = abs_c_max_det;
-            ++k;
+            abs_c_max_block = std::max(abs_c_max_block, abs_c_max_det);
         }
+
+        // Every criterion below is proportional to one of these coefficients, so a block whose
+        // coefficients are all zero cannot produce a connection that survives accumulate.
+        if (abs_c_max_block == 0.0)
+            continue;
 
         // find the occupied and virtual orbitals for the current alpha string
         auto a_str_annihilation_masked = a_str & ~frozen_annihilation_mask_;
@@ -527,7 +498,7 @@ void SelectedCIHelper::select_hbci_batch(DetRootMap& V_map, DetRootMap& PT_map,
         // single alpha excitations
         for (const auto& i : aocc_span) {
             for (const auto& a : avir_span) {
-                // *_fast avoids checking if i and a are already occupied/unoccupied
+                // *_unchecked avoids checking if i and a are already occupied/unoccupied
                 // since we already know they are
                 auto [new_a_str, sign] = create_single_excitation_unchecked(a_str, i, a);
                 // determine if this determinant belongs to the current batch
@@ -536,25 +507,17 @@ void SelectedCIHelper::select_hbci_batch(DetRootMap& V_map, DetRootMap& PT_map,
                 }
                 new_det.set_alpha_string(new_a_str);
                 // add the occupied orbital contribution
-                for (size_t k{0}; const auto& [b_str_idx, det_index] : second_string_to_det_index) {
-                    const String& b_str = ab_list_.sorted_second_string(b_str_idx);
-                    new_det.set_beta_string(b_str);
+                for (size_t k{0}; k < block_size; ++k) {
+                    // singles_coupling_a is expensive, so drop parents that cannot survive first
+                    if (abs_c_max[k] == 0.0)
+                        continue;
+                    const auto& [b_str_idx, det_index] = second_string_to_det_index[k];
+                    new_det.set_beta_string(ab_list_.sorted_second_string(b_str_idx));
                     // singles_coupling_a can be expensive to compute
                     // a possible replacement here is h(i, a)
                     const double integral = slater_rules_.singles_coupling_a(i, a, new_det);
-                    const double criterion = std::fabs(integral * abs_c_max[k]);
-                    if (criterion > pt2_threshold) {
-                        // if the determinant is already in the variational space, skip it
-                        if (!existing_dets.count(new_det)) {
-                            auto coeffs = std::span<double>(c_block.data() + k * nroots_, nroots_);
-                            if (criterion > var_threshold) {
-                                accumulate(V_map, V_coeffs, new_det, sign * integral, coeffs);
-                            } else {
-                                accumulate(PT_map, PT_coeffs, new_det, sign * integral, coeffs);
-                            }
-                        }
-                    }
-                    k++;
+                    accumulate(new_det, c_block + k * nroots_, sign * integral,
+                               std::fabs(integral * abs_c_max[k]));
                 }
             }
         }
@@ -567,7 +530,7 @@ void SelectedCIHelper::select_hbci_batch(DetRootMap& V_map, DetRootMap& PT_map,
                 const auto& v_list = va_sorted_[i * norb_ + j];
                 for (const auto& [coupling, integral, a, b] : v_list) {
                     // break early if the integrals are too small for all determinants
-                    if (std::fabs(coupling * abs_c_max_block) < pt2_threshold)
+                    if (std::fabs(coupling * abs_c_max_block) <= pt2_threshold)
                         break;
 
                     if ((a >= b) or a_str.get_bit(a) or a_str.get_bit(b))
@@ -579,24 +542,14 @@ void SelectedCIHelper::select_hbci_batch(DetRootMap& V_map, DetRootMap& PT_map,
                         continue;
                     }
 
-                    for (size_t k{0};
-                         const auto& [b_str_idx, det_index] : second_string_to_det_index) {
+                    for (size_t k{0}; k < block_size; ++k) {
                         const double criterion = std::fabs(coupling * abs_c_max[k]);
-                        if (criterion > pt2_threshold) {
-                            new_det.set_alpha_string(new_a_str);
-                            new_det.set_beta_string(ab_list_.sorted_second_string(b_str_idx));
-                            // if the determinant is already in the variational space, skip it
-                            if (!existing_dets.count(new_det)) {
-                                auto coeffs =
-                                    std::span<double>(c_block.data() + k * nroots_, nroots_);
-                                if (criterion > var_threshold) {
-                                    accumulate(V_map, V_coeffs, new_det, sign * integral, coeffs);
-                                } else {
-                                    accumulate(PT_map, PT_coeffs, new_det, sign * integral, coeffs);
-                                }
-                            }
-                        }
-                        k++;
+                        if (criterion <= pt2_threshold)
+                            continue;
+                        const auto& [b_str_idx, det_index] = second_string_to_det_index[k];
+                        new_det.set_alpha_string(new_a_str);
+                        new_det.set_beta_string(ab_list_.sorted_second_string(b_str_idx));
+                        accumulate(new_det, c_block + k * nroots_, sign * integral, criterion);
                     }
                 }
             }
@@ -617,47 +570,41 @@ void SelectedCIHelper::select_hbci_batch(DetRootMap& V_map, DetRootMap& PT_map,
 
                 for (const auto& [coupling, integral, j, b] : v_list) {
                     // break early if the integrals are too small
-                    if (std::fabs(coupling * abs_c_max_block) < pt2_threshold)
+                    if (std::fabs(coupling * abs_c_max_block) <= pt2_threshold)
                         break;
-                    for (size_t k{0};
-                         const auto& [b_str_idx, det_index] : second_string_to_det_index) {
+                    for (size_t k{0}; k < block_size; ++k) {
+                        const auto& [b_str_idx, det_index] = second_string_to_det_index[k];
                         const String& b_str = ab_list_.sorted_second_string(b_str_idx);
 
                         // check if the beta excitation is valid
                         if ((not b_str.get_bit(j)) or b_str.get_bit(b)) {
-                            k++;
                             continue;
                         }
 
                         const double criterion = std::fabs(coupling * abs_c_max[k]);
-                        if (criterion > pt2_threshold) {
-                            auto [new_b_str, b_sign] =
-                                create_single_excitation_unchecked(b_str, j, b);
-                            new_det.set_beta_string(new_b_str);
-                            if (!existing_dets.count(new_det)) {
-                                auto coeffs =
-                                    std::span<double>(c_block.data() + k * nroots_, nroots_);
-                                if (criterion > var_threshold) {
-                                    accumulate(V_map, V_coeffs, new_det, a_sign * b_sign * integral,
-                                               coeffs);
-                                } else {
-                                    accumulate(PT_map, PT_coeffs, new_det,
-                                               a_sign * b_sign * integral, coeffs);
-                                }
-                            }
-                        }
-                        k++;
+                        if (criterion <= pt2_threshold)
+                            continue;
+
+                        auto [new_b_str, b_sign] = create_single_excitation_unchecked(b_str, j, b);
+                        new_det.set_beta_string(new_b_str);
+                        accumulate(new_det, c_block + k * nroots_, a_sign * b_sign * integral,
+                                   criterion);
                     }
                 }
             }
         }
 
         // beta excitations
+        
+        // All beta excitations with a shared a_str share a batch
         if (batch_of(a_str, num_batches) != batch_id)
             continue;
 
         new_det.set_alpha_string(a_str);
-        for (size_t k{0}; const auto& [b_str_idx, det_index] : second_string_to_det_index) {
+        for (size_t k{0}; k < block_size; ++k) {
+            if (abs_c_max[k] == 0.0)
+                continue;
+            const auto& [b_str_idx, det_index] = second_string_to_det_index[k];
             const String& b_str = ab_list_.sorted_second_string(b_str_idx);
             auto b_str_annihilation_masked = b_str & ~frozen_annihilation_mask_;
             b_str_annihilation_masked.find_set_bits(bocc, nob);
@@ -673,18 +620,11 @@ void SelectedCIHelper::select_hbci_batch(DetRootMap& V_map, DetRootMap& PT_map,
                         b_str); // push the current beta string to compute coupling
                     const double integral = slater_rules_.singles_coupling_b(i, a, new_det);
                     const double criterion = std::fabs(integral * abs_c_max[k]);
-                    if (criterion > pt2_threshold) {
-                        auto [new_b_str, sign] = create_single_excitation_unchecked(b_str, i, a);
-                        new_det.set_beta_string(new_b_str); // push the new beta string
-                        if (!existing_dets.count(new_det)) {
-                            auto coeffs = std::span<double>(c_block.data() + k * nroots_, nroots_);
-                            if (criterion > var_threshold) {
-                                accumulate(V_map, V_coeffs, new_det, sign * integral, coeffs);
-                            } else {
-                                accumulate(PT_map, PT_coeffs, new_det, sign * integral, coeffs);
-                            }
-                        }
-                    }
+                    if (criterion <= pt2_threshold)
+                        continue;
+                    auto [new_b_str, sign] = create_single_excitation_unchecked(b_str, i, a);
+                    new_det.set_beta_string(new_b_str); // push the new beta string
+                    accumulate(new_det, c_block + k * nroots_, sign * integral, criterion);
                 }
             }
 
@@ -696,7 +636,7 @@ void SelectedCIHelper::select_hbci_batch(DetRootMap& V_map, DetRootMap& PT_map,
                     const auto& v_list = va_sorted_[i * norb_ + j];
                     for (const auto& [coupling, integral, a, b] : v_list) {
                         const double criterion = std::fabs(coupling * abs_c_max[k]);
-                        if (criterion < pt2_threshold)
+                        if (criterion <= pt2_threshold)
                             break;
 
                         if ((a >= b) or b_str.get_bit(a) or b_str.get_bit(b))
@@ -706,18 +646,10 @@ void SelectedCIHelper::select_hbci_batch(DetRootMap& V_map, DetRootMap& PT_map,
                             create_double_excitation_unchecked(b_str, i, j, a, b);
                         new_det.set_alpha_string(a_str);
                         new_det.set_beta_string(new_b_str);
-                        if (!existing_dets.count(new_det)) {
-                            auto coeffs = std::span<double>(c_block.data() + k * nroots_, nroots_);
-                            if (criterion > var_threshold) {
-                                accumulate(V_map, V_coeffs, new_det, sign * integral, coeffs);
-                            } else {
-                                accumulate(PT_map, PT_coeffs, new_det, sign * integral, coeffs);
-                            }
-                        }
+                        accumulate(new_det, c_block + k * nroots_, sign * integral, criterion);
                     }
                 }
             }
-            k++;
         }
     }
 }

--- a/forte2/sci/sci_helper_sigma_build.cc
+++ b/forte2/sci/sci_helper_sigma_build.cc
@@ -30,6 +30,12 @@ void SelectedCIHelper::prepare_strings() {
         sorted_dets[i] = dets_[i].spin_flip();
     }
     ba_list_ = SelectedCIStrings(norb_, sorted_dets);
+
+    // the largest alpha-string block, used to size the select_hbci_batch scratch buffers
+    max_block_size_ = 0;
+    for (const auto& block : ab_list_.second_string_to_det_index()) {
+        max_block_size_ = std::max(max_block_size_, block.size());
+    }
 }
 
 void SelectedCIHelper::Hamiltonian(np_vector basis, np_vector sigma) const {

--- a/tests/sci/test_rel_sci.py
+++ b/tests/sci/test_rel_sci.py
@@ -7,6 +7,7 @@ from forte2.sci import RelSelectedCI, RelSelectedCISolver
 from forte2.helpers.comparisons import approx
 from forte2.base_classes.params import SelectedCIParams
 from forte2.lib.det import Determinant
+from forte2.lib.ci_helpers import RelSelectedCIHelper
 
 
 def _h2_ghf_upcast():
@@ -341,3 +342,54 @@ def test_rel_sci_final_orbitals(final_orbitals):
     sci.run()
 
     assert sci.E[0] == approx(-100.10065023157668)
+
+
+def test_rel_sci_pt2_split_is_independent_of_var_threshold():
+    """
+    ept2_var + ept2_pt is the Epstein-Nesbet PT2 over the determinants outside the
+    variational space, so it cannot depend on var_threshold. That threshold only decides how the total is split between the two reported energies.
+    """
+    pt2_threshold = 1e-10
+    xyz = """
+        O 0.0000000 0.0000000 -0.0655905
+        H 0.0000000 -0.7578344 0.5203775
+        H 0.0000000  0.7578344 0.5203775
+        """
+    system = System(xyz=xyz, basis_set="6-31g", auxiliary_basis_set="cc-pVTZ-JKFIT")
+    rhf = GHF(charge=0, e_tol=1e-12)(system)
+
+    sci = RelSelectedCI(
+        nel=10,
+        active_orbitals=list(range(26)),
+        sci_params=SelectedCIParams(
+            selection_algorithm="hbci",
+            var_threshold=1e-3,
+            pt2_threshold=pt2_threshold,
+            maxcycle=2,
+        ),
+    )(rhf)
+    sci.run()
+
+    # Freeze the variational space and its coefficients
+    # then run selection at different eps_var but fixed eps_pt2
+    worker = sci.sub_solvers[0]
+    dets = worker.dets
+    c = worker.evecs
+    energies = np.ascontiguousarray(np.asarray(worker.evals).real)
+
+    def probe(var_threshold):
+        helper = RelSelectedCIHelper(
+            worker.norb, dets, c, worker.ints.E, worker.ints.H, worker.ints.V, 0
+        )
+        helper.set_energies(energies)
+        helper.select_hbci(var_threshold=var_threshold, pt2_threshold=pt2_threshold)
+        return np.array(helper.ept2_var()), np.array(helper.ept2_pt())
+
+    # very large eps_var leaves all to PT2 space
+    # all subsequent e_var + e_pt2 must add to ref_pt
+    ref_var, ref_pt = probe(1e6)
+    assert np.all(ref_var == 0.0)
+
+    for var_threshold in (1e-3, 1e-4, 1e-5, 1e-7, 0.0):
+        var, pt = probe(var_threshold)
+        assert var + pt == approx(ref_pt)

--- a/tests/sci/test_sci.py
+++ b/tests/sci/test_sci.py
@@ -998,3 +998,54 @@ def test_sci_final_orbitals(final_orbitals):
     sci.run()
 
     assert sci.E[0] == approx(-2.180967812920)
+
+
+def test_sci_pt2_split_is_independent_of_var_threshold():
+    """
+    ept2_var + ept2_pt is the Epstein-Nesbet PT2 over the determinants outside the
+    variational space, so it cannot depend on var_threshold. That threshold only decides how the total is split between the two reported energies.
+    """
+    pt2_threshold = 1e-10
+    xyz = """
+        O 0.0000000 0.0000000 -0.0655905
+        H 0.0000000 -0.7578344 0.5203775
+        H 0.0000000  0.7578344 0.5203775
+        """
+    system = System(xyz=xyz, basis_set="6-31g", auxiliary_basis_set="cc-pVTZ-JKFIT")
+    rhf = RHF(charge=0, e_tol=1e-12)(system)
+
+    sci = SelectedCI(
+        states=State(nel=10, multiplicity=1, ms=0.0),
+        active_orbitals=list(range(13)),
+        sci_params=SelectedCIParams(
+            selection_algorithm="hbci",
+            var_threshold=1e-3,
+            pt2_threshold=pt2_threshold,
+            maxcycle=2,
+        ),
+    )(rhf)
+    sci.run()
+
+    # Freeze the variational space and its coefficients
+    # then run selection at different eps_var but fixed eps_pt2
+    worker = sci.sub_solvers[0]
+    dets = worker.dets
+    c = worker.evecs
+    energies = np.ascontiguousarray(np.asarray(worker.evals).real)
+
+    def probe(var_threshold):
+        helper = SelectedCIHelper(
+            worker.norb, dets, c, worker.ints.E, worker.ints.H, worker.ints.V, 0
+        )
+        helper.set_energies(energies)
+        helper.select_hbci(var_threshold=var_threshold, pt2_threshold=pt2_threshold)
+        return np.array(helper.ept2_var()), np.array(helper.ept2_pt())
+
+    # very large eps_var leaves all to PT2 space
+    # all subsequent e_var + e_pt2 must add to ref_pt
+    ref_var, ref_pt = probe(1e6)
+    assert np.all(ref_var == 0.0)
+
+    for var_threshold in (1e-3, 1e-4, 1e-5, 1e-7, 0.0):
+        var, pt = probe(var_threshold)
+        assert var + pt == approx(ref_pt)


### PR DESCRIPTION
For each determinant I in the variational space, HBCI generates
all single and double excitations K that's outside the variational
space subject to screening, and the ENPT2 correction due to these
determinants is given by
$$E^{(2)} = \sum_K \frac{(\sum_I H_{KI} c_I)^2} {E_0 - H_{KK}}$$
For a given K, multiple parents in the variational space can reach
it, with different contributions H_KI*c_I. Previously, these contributions
are accumulated into two sums depending on whether it is larger than eps_var,
which were then separatedly squared, resulting in the loss of the cross terms.
This only affected unconverged HBCI results.
