### PR TITLE
IBO final orbitals in CASSCF

### DIFF
--- a/docs/source/guide/basics.rst
+++ b/docs/source/guide/basics.rst
@@ -68,6 +68,31 @@ You can then run the whole chain with a single call:
 
 >>> casscf.run()
 
+Final orbital representations
+-----------------------------
+
+Single-shot CI methods and ``MCOptimizer`` accept a ``final_orbitals`` option.
+In addition to ``"original"``, ``"semicanonical"``, and ``"natural"``, real
+nonrelativistic calculations can request ``final_orbitals="ibo"`` to localize
+only the active orbitals. ``final_orbitals="ibo_atomic"`` performs the same IBO
+localization and then aligns atom-local blocks with the corresponding
+canonical, axis-oriented IAOs. Each assigned orbital is labeled by its atomic
+MINAO target and the final columns are ordered by atom index followed by the
+native Forte2 MINAO basis-function index. For example, the native order of a
+complete nitrogen valence shell is (2s, 2py, 2pz, 2px). The assignments are
+available as ``IBOAligner.atomic_orbital_assignments`` when using the
+post-processing class directly; unassigned orbitals are marked by ``None`` and
+follow the assigned orbitals in their original relative order.
+
+A block can span different atomic shells: a full valence block, for example,
+is aligned jointly before this final ordering. This applies to all angular
+momenta; d functions use Forte2's real-spherical convention. The alignment
+uses the molecule's input coordinate frame.
+
+Both IBO modes semicanonicalize the inactive orbital subspaces and localize
+separate GAS partitions independently. They are available only when the system
+runs in C1 symmetry; use ``System(..., symmetry=False)``.
+
 Parallelism
 -----------
 

--- a/forte2/base_classes/ci_base.py
+++ b/forte2/base_classes/ci_base.py
@@ -269,41 +269,45 @@ class CIBase(ActiveSpaceSolver):
 
     def _rotate_final_orbitals(self, final_orbitals):
         """
-        Apply the requested ``final_orbitals`` transformation and re-solve.
-        No-op unless "semicanonical" or "natural" is requested.
+        Apply the requested ``final_orbitals`` transformation.
 
         Parameters
         ----------
         final_orbitals : str
-            Type of final_orbitals. Validated by caller.
+            Type of final orbitals.
         """
         from forte2.orbitals import (
             check_final_orbital_energy_invariance,
             make_final_orbitals,
         )
 
-        if final_orbitals not in ("semicanonical", "natural"):
-            return
-
         irrep_indices = np.asarray(self.mos.irrep_indices[0], dtype=int)[
             self.mo_space.orig_to_contig
         ]
         C_contig = self.mos.C[0][:, self.mo_space.orig_to_contig].copy()
+        g1_act = (
+            self.make_average_1rdm()
+            if final_orbitals != "original"
+            else None
+        )
         C_final = make_final_orbitals(
             final_orbitals,
             system=self.system,
             mo_space=self.mo_space,
             irrep_indices=irrep_indices,
             C_contig=C_contig,
-            g1_act=self.make_average_1rdm(),
+            g1_act=g1_act,
         )
+        if final_orbitals == "original":
+            return
+
         # undo the contiguous ordering
         self.mos.C[0] = C_final[:, self.mo_space.contig_to_orig].copy()
 
         old_E = self.E.copy()
         old_E_avg = self.E_avg
 
-        # re-solve in the final orbital basis
+        # re-solve the CI in the final orbital basis
         ints = self._make_active_space_ints()
         self.set_ints(ints.E, ints.H, ints.V)
         # reset_eigensolver() drops the DavidsonLiuSolver, so the rerun rebuilds it

--- a/forte2/ci/ci.py
+++ b/forte2/ci/ci.py
@@ -17,7 +17,7 @@ from forte2.base_classes import CIBase
 from forte2.base_classes.params import DavidsonLiuParams, CIParams
 from forte2.helpers import logger
 from forte2.jkbuilder import RestrictedMOIntegrals
-from forte2.orbitals import FinalOrbitals, validate_final_orbitals
+from forte2.orbitals import FinalOrbitals
 from .ci_utils import (
     pretty_print_gas_info,
     pretty_print_ci_summary,
@@ -1009,7 +1009,6 @@ class CI(CISolver):
 
     def __post_init__(self):
         super().__post_init__()
-        validate_final_orbitals(self.final_orbitals)
 
     def run(self):
         self._solve()

--- a/forte2/ci/rel_ci.py
+++ b/forte2/ci/rel_ci.py
@@ -13,7 +13,7 @@ from forte2.base_classes import RelCIBase
 from forte2.base_classes.params import DavidsonLiuParams, CIParams
 from forte2.helpers import logger
 from forte2.jkbuilder import SpinorbitalIntegrals
-from forte2.orbitals import FinalOrbitals, validate_final_orbitals
+from forte2.orbitals import FinalOrbitals
 from .ci_utils import (
     pretty_print_ci_summary,
     pretty_print_ci_nat_occ_numbers,
@@ -471,7 +471,6 @@ class RelCI(RelCISolver):
 
     def __post_init__(self):
         super().__post_init__()
-        validate_final_orbitals(self.final_orbitals)
 
     def run(self):
         self._solve()

--- a/forte2/helpers/__init__.py
+++ b/forte2/helpers/__init__.py
@@ -8,6 +8,7 @@ from .matrix_functions import (
     block_diag_2x2,
     random_unitary,
     i_sigma_dot,
+    procrustes_rotation,
 )
 from .diis import DIIS
 from . import logger  # setup logging configuration

--- a/forte2/helpers/matrix_functions.py
+++ b/forte2/helpers/matrix_functions.py
@@ -6,6 +6,32 @@ from . import logger
 MACHEPS = 1e-14
 
 
+def procrustes_rotation(overlap):
+    """Return the unitary polar factor of a square overlap matrix.
+
+    This is the orthogonal Procrustes solution that maximizes the overlap with
+    the input matrix. If ``overlap = L @ diag(s) @ R.conj().T``, the returned
+    rotation is ``L @ R.conj().T``.
+
+    Parameters
+    ----------
+    overlap : NDArray
+        Square real or complex overlap matrix.
+
+    Returns
+    -------
+    NDArray
+        The closest orthogonal or unitary matrix.
+    """
+
+    overlap = np.asarray(overlap)
+    if overlap.ndim != 2 or overlap.shape[0] != overlap.shape[1]:
+        raise ValueError("The Procrustes overlap matrix must be square.")
+
+    left, _, right_h = np.linalg.svd(overlap, full_matrices=False)
+    return left @ right_h
+
+
 def _eigh_metric_kernel(S, rtol=1e-7):
     info = {}
     sevals, sevecs = np.linalg.eigh(S)

--- a/forte2/mcopt/mc_optimizer.py
+++ b/forte2/mcopt/mc_optimizer.py
@@ -11,7 +11,7 @@ from forte2.base_classes import (
     RelCIBase,
     Method,
 )
-from forte2.orbitals import FinalOrbitals, validate_final_orbitals
+from forte2.orbitals import FinalOrbitals
 from forte2.helpers import logger, LBFGS
 from forte2.system.basis_utils import BasisInfo
 from forte2.system import ModelSystem
@@ -60,6 +60,12 @@ class MCOptimizerBase(Method):
         - "natural": Same as semicanonical, but the active orbitals are natural orbitals
           and diagonalize the spin- and state-averaged 1-RDM within the CAS
           subspace or within each of the GAS subspaces.
+        - "ibo": Localize only the active orbitals as intrinsic bond orbitals.
+          Inactive orbitals are semicanonical and GAS blocks are preserved.
+          This option is available only in C1 symmetry.
+        - "ibo_atomic": As ``"ibo"``, followed by alignment of atom-local
+          blocks with canonical axis-oriented IAOs and ordering by atom and
+          native MINAO basis-function index within each GAS partition.
         - "original": The orbitals are left in the original basis after the optimization.
           This option is only for debugging purposes and should generally be avoided
           as the active orbitals will not be uniquely defined and may not be suitable
@@ -106,8 +112,6 @@ class MCOptimizerBase(Method):
     def __post_init__(self):
         if not isinstance(self.ci_solver, (CIBase, RelCIBase)):
             raise ValueError("ci_solver must be an instance of CIBase or RelCIBase.")
-
-        validate_final_orbitals(self.final_orbitals)
 
         self.requires = {"system", "mos"}
         self.provides = {"system", "mos", "mo_space"}

--- a/forte2/orbitals/__init__.py
+++ b/forte2/orbitals/__init__.py
@@ -7,11 +7,11 @@ from .final_orbitals import (
     VALID_FINAL_ORBITALS,
     check_final_orbital_energy_invariance,
     make_final_orbitals,
-    validate_final_orbitals,
 )
 from .orbital_blocks import OrbitalBlockBuilder
 from .aset import ASET
 from .iao import IAO, IBO
+from .ibo_align import AtomicOrbitalAssignment, IBOAligner
 from .converters import SpinorUpcaster
 from .orbital_overlap import mo_overlap, project_orbitals, project_occupied_orbitals
 

--- a/forte2/orbitals/final_orbitals.py
+++ b/forte2/orbitals/final_orbitals.py
@@ -5,34 +5,15 @@ from numpy.typing import ArrayLike, NDArray
 
 from forte2.helpers import logger
 
+from .iao import IBO
+from .ibo_align import IBOAligner
 from .natural_orbitals import NaturalOrbitals
+from .orbital_blocks import OrbitalBlockBuilder
 from .semicanonicalizer import Semicanonicalizer
 
-FinalOrbitals = Literal["original", "semicanonical", "natural"]
+FinalOrbitals = Literal["original", "semicanonical", "natural", "ibo", "ibo_atomic"]
 
 VALID_FINAL_ORBITALS = get_args(FinalOrbitals)
-
-
-def validate_final_orbitals(value: str) -> None:
-    """
-    Validate a final_orbitals option value.
-
-    Parameters
-    ----------
-    value : str
-        The requested value.
-
-    Raises
-    ------
-    ValueError
-        If value is not in the FinalOrbitals literal.
-    """
-    if value not in VALID_FINAL_ORBITALS:
-        raise ValueError(
-            f"final_orbitals must be one of {VALID_FINAL_ORBITALS}, "
-            f"but got {value!r}."
-        )
-    return
 
 
 def make_final_orbitals(
@@ -42,22 +23,28 @@ def make_final_orbitals(
     mo_space,
     irrep_indices: ArrayLike,
     C_contig: NDArray,
-    g1_act: NDArray,
+    g1_act: NDArray | None,
 ) -> NDArray:
     """
     Build the requested final orbitals, in contiguous MO-space ordering.
 
-    The inactive subspaces are always semicanonicalized. The active space is
-    semicanonicalized for mode="semicanonical", or left alone by the
-    semicanonicalizer and then diagonalized against the active 1-RDM for
-    mode="natural" (separately within each GAS partition and irrep block, so
-    those structures are preserved).
+    For every mode except ``"original"``, the inactive subspaces are
+    semicanonicalized. For ``mode``:
+
+    - ``"semicanonical"``: The active space is semicanonicalized.
+    - ``"natural"``: The active space is rotated to make the active 1-RDM diagonal.
+    - ``"ibo"``: The active orbitals are localized as intrinsic bond orbitals (IBOs).
+    - ``"ibo_atomic"``: The active orbitals are localized and aligned to the
+      global axis-oriented IAOs and ordered by atom and native MINAO
+      basis-function index. Localization and ordering are applied separately
+      within each GAS partition, and both modes are available only in C1
+      symmetry.
 
     Parameters
     ----------
     mode : str
-        Either "semicanonical" or "natural". Callers are expected to skip
-        this function entirely for "original".
+        Either "original", "semicanonical", "natural", "ibo", or
+        "ibo_atomic".
     system : System
         The system, used to build the generalized Fock matrix.
     mo_space : MOSpace or EmbeddingMOSpace
@@ -66,23 +53,42 @@ def make_final_orbitals(
         Orbital irrep labels in the same contiguous ordering as C_contig.
     C_contig : NDArray
         Full MO coefficient matrix in contiguous MO-space ordering.
-    g1_act : NDArray
+    g1_act : NDArray or None
         Active-space one-particle density matrix (spin-summed if non-relativistic,
-        spin-orbital if relativistic).
+        spin-orbital if relativistic). May be ``None`` only for ``"original"``.
 
     Returns
     -------
     NDArray
         The transformed coefficient matrix, still in contiguous ordering.
     """
-    if mode not in ("semicanonical", "natural"):
+    if mode not in VALID_FINAL_ORBITALS:
         raise ValueError(
-            "make_final_orbitals expects mode to be 'semicanonical' or 'natural', "
-            f"but got {mode}."
+            f"final_orbitals must be one of {VALID_FINAL_ORBITALS}, "
+            f"but got {mode!r}."
         )
 
-    # Semicanonicalize the orbital subspaces (except the CAS/GAS in the case of
-    # natural orbitals, which are defined by the 1-RDM instead).
+    C_final = np.asarray(C_contig).copy()
+    if mode == "original":
+        return C_final
+
+    ibo_mode = mode in ("ibo", "ibo_atomic")
+    if ibo_mode:
+        point_group = str(getattr(system, "point_group", "C1")).upper()
+        if point_group != "C1":
+            raise ValueError(
+                f"final_orbitals={mode!r} is only available in C1 symmetry, but the "
+                f"system uses point group {point_group!r}. Construct the System with "
+                "symmetry=False to disable point-group symmetry."
+            )
+        if getattr(system, "two_component", False) or np.iscomplexobj(C_contig):
+            raise NotImplementedError(
+                f"final_orbitals={mode!r} is currently implemented only for real, "
+                "nonrelativistic orbitals."
+            )
+
+    # Semicanonicalize every inactive subspace. The active space is included
+    # only for semicanonical mode; natural and IBO modes define it separately.
     semi = Semicanonicalizer(
         mo_space=mo_space,
         system=system,
@@ -91,8 +97,25 @@ def make_final_orbitals(
         mix_active=False,
         do_active=(mode == "semicanonical"),
     )
-    semi.semi_canonicalize(g1=g1_act, C_contig=C_contig)
+    semi.semi_canonicalize(g1=g1_act, C_contig=C_final)
     C_final = semi.C_semican.copy()
+
+    if ibo_mode:
+        # Rotations across GAS partitions change the variational space of a GAS
+        # calculation, so localize each active partition independently. Since
+        # do_active=False above, these columns are still the input active MOs.
+        orbital_blocks = OrbitalBlockBuilder(mo_space)
+        for active_block in orbital_blocks.active_blocks(relative_index=False):
+            if active_block.size < 2 and mode == "ibo":
+                continue
+            ibo = IBO(system, C_final[:, active_block])
+            if mode == "ibo_atomic":
+                ibo_aligner = IBOAligner(ibo)
+                ibo_aligner.align_to_atomic_orbitals()
+                C_final[:, active_block] = ibo_aligner.C_ibo
+            else:
+                C_final[:, active_block] = ibo.C_ibo
+        return C_final
 
     if mode == "natural":
         natural_orbital = NaturalOrbitals(mo_space, irrep_indices=irrep_indices)

--- a/forte2/orbitals/iao.py
+++ b/forte2/orbitals/iao.py
@@ -142,6 +142,13 @@ class IBO(IAO):
     g_tol : float, optional, default=1e-8
         The RMS gradient convergence criterion for the IBO optimization.
 
+    Attributes
+    ----------
+    U_ibo : NDArray
+        The unitary rotation from the input orbitals to the IBOs.
+    C_ibo : NDArray
+        The IBO coefficients, formed as ``C_occ @ U_ibo``.
+
     Notes
     -----
     There are typos in the original paper, specifically for the Aij and Bij elements.
@@ -161,6 +168,7 @@ class IBO(IAO):
         # Occupied MO coefficients in the IAO basis
         # shape (nminao, nocc)
         C_occ_iao = self.C_iao.T @ self.S1 @ self.C_occ
+        U_ibo = np.eye(self.nocc, dtype=self.C_occ.dtype)
         center_first_and_last = self.system.minao_basis.center_first_and_last
         natoms = self.system.natoms
 
@@ -194,6 +202,13 @@ class IBO(IAO):
                     )
                     C_occ_iao[:, i] = i_new.copy()
                     C_occ_iao[:, j] = j_new.copy()
+
+                    # Accumulate the same Jacobi rotation in the input orbital
+                    # basis so the final IBOs remain exactly in that subspace.
+                    i_new = np.cos(phi_ij) * U_ibo[:, i] + np.sin(phi_ij) * U_ibo[:, j]
+                    j_new = -np.sin(phi_ij) * U_ibo[:, i] + np.cos(phi_ij) * U_ibo[:, j]
+                    U_ibo[:, i] = i_new.copy()
+                    U_ibo[:, j] = j_new.copy()
             if np.sqrt(grad) < self.g_tol:
                 logger.log_info1(f"\nIBO converged after {ibo_iter} iterations.")
                 break
@@ -203,5 +218,5 @@ class IBO(IAO):
                 f"IBO did not converge after {self.maxiter} iterations. Change `maxiter` or `g_tol`."
             )
 
-        # (nbf, nminao) @ (nminao, nocc) = (nbf, nocc)
-        return self.C_iao @ C_occ_iao
+        self.U_ibo = U_ibo
+        return self.C_occ @ self.U_ibo

--- a/forte2/orbitals/ibo_align.py
+++ b/forte2/orbitals/ibo_align.py
@@ -1,0 +1,255 @@
+from dataclasses import dataclass
+
+import numpy as np
+
+from forte2.helpers import logger, procrustes_rotation
+from forte2.system.basis_utils import BasisInfo, get_shell_label
+
+from .iao import IBO
+
+
+@dataclass(frozen=True)
+class AtomicOrbitalAssignment:
+    """Atomic MINAO target assigned to one atomically aligned IBO.
+
+    ``atom_index`` and ``minao_basis_index`` are zero-based. The latter is the
+    absolute basis-function index in Forte2's native MINAO ordering.
+    ``component_index`` is the function's index within its real-spherical
+    shell.
+    """
+
+    atom_index: int
+    minao_basis_index: int
+    n: int
+    l: int
+    component_index: int
+    label: str
+
+
+class IBOAligner:
+    """Align and order IBOs against canonical atomic orbitals.
+
+    :meth:`align_to_atomic_orbitals` aligns atom-local blocks with axis-oriented
+    IAOs and orders them by atom and native MINAO basis-function index.
+
+    Parameters
+    ----------
+    ibo : IBO
+        A completed IBO localization.
+    """
+
+    def __init__(self, ibo: IBO):
+        self.ibo = ibo
+        self.system = ibo.system
+        self.C_occ = ibo.C_occ
+        self.C_iao = ibo.C_iao
+        self.S1 = ibo.S1
+        self.nocc = ibo.nocc
+
+        self.U_ibo = ibo.U_ibo.copy()
+        self.C_ibo = ibo.C_ibo.copy()
+        self._cartesian_alignment_groups = []
+        self._atomic_alignment_objective_change = 0.0
+        self.atomic_orbital_assignments = (None,) * self.nocc
+        self.atomic_orbital_order = tuple(range(self.nocc))
+
+    def align_to_atomic_orbitals(self):
+        """Align localized orbitals with canonical atomic IAO components.
+
+        This post-processes the current IBOs in place, orders assigned orbitals
+        by atom and native MINAO basis-function index, and returns the aligned
+        coefficients. Every accepted output orbital remains predominantly on
+        the same atom, but the explicit atomic gauge may slightly change the IBO
+        localization objective. Unassigned orbitals follow the assigned ones in
+        their original relative order.
+
+        Returns
+        -------
+        NDArray
+            The aligned IBO coefficient matrix.
+        """
+
+        C_ibo_iao = self.C_iao.T @ self.S1 @ self.C_ibo
+        _, self.U_ibo = self._align_cartesian_atomic_orbitals(
+            C_ibo_iao, self.U_ibo.copy()
+        )
+        self.C_ibo = self.C_occ @ self.U_ibo
+        return self.C_ibo
+
+    def _align_cartesian_atomic_orbitals(self, C_ibo_iao, U_ibo):
+        """Fix atom-local blocks to the global axis-oriented IAOs.
+
+        Group all sufficiently atom-local IBOs by their dominant atom. Such a
+        block may span several radial and angular-momentum shells. Use an
+        orthogonal Procrustes rotation to maximize its overlap with the best
+        matching ordered minimal-basis atomic orbitals. This fixes phases and
+        orientations without imposing an artificial shell separation. A trial
+        rotation is accepted only if every output orbital remains predominantly
+        localized on the same atom.
+        """
+
+        atom_local_threshold = 0.9
+        target_weight_threshold = 0.9
+
+        center_ranges = self.system.minao_basis.center_first_and_last
+        atom_populations = np.vstack(
+            [
+                np.einsum("mi,mi->i", C_ibo_iao[first:last], C_ibo_iao[first:last])
+                for first, last in center_ranges
+            ]
+        )
+        minao_labels = BasisInfo(self.system, self.system.minao_basis).basis_labels
+        atom_rows = {}
+        for row, label in enumerate(minao_labels):
+            atom_rows.setdefault(label.iatom, []).append(row)
+
+        alignment_groups = []
+        objective_before = self._ibo_objective(C_ibo_iao)
+        for iatom, rows in atom_rows.items():
+            group = [
+                i
+                for i in range(self.nocc)
+                if np.argmax(atom_populations[:, i]) == iatom
+                and atom_populations[iatom, i] > atom_local_threshold
+            ]
+            if not group or len(group) > len(rows):
+                continue
+
+            row_weights = {row: np.sum(C_ibo_iao[row, group] ** 2) for row in rows}
+            target_rows = sorted(rows, key=row_weights.get, reverse=True)[: len(group)]
+            target_rows.sort(
+                key=lambda row: self._atomic_orbital_order(minao_labels[row])
+            )
+            target_weight = np.sum(C_ibo_iao[np.ix_(target_rows, group)] ** 2) / len(
+                group
+            )
+            if target_weight < target_weight_threshold:
+                continue
+
+            # M = L^T S T. Because C_ibo_iao contains IBO coefficients in
+            # the orthonormal IAO basis, the selected rows are T^T S L.
+            M = C_ibo_iao[np.ix_(target_rows, group)].T
+            rotation = procrustes_rotation(M)
+
+            C_trial = C_ibo_iao.copy()
+            C_trial[:, group] = C_trial[:, group] @ rotation
+            first, last = center_ranges[iatom]
+            trial_populations = np.einsum(
+                "mi,mi->i", C_trial[first:last, group], C_trial[first:last, group]
+            )
+            if np.any(trial_populations < atom_local_threshold):
+                continue
+
+            C_ibo_iao = C_trial
+            U_ibo[:, group] = U_ibo[:, group] @ rotation
+            alignment_groups.append((iatom, tuple(group), tuple(target_rows)))
+
+        C_ibo_iao, U_ibo, alignment_groups = self._order_atomic_orbitals(
+            C_ibo_iao, U_ibo, alignment_groups, minao_labels
+        )
+        self._cartesian_alignment_groups = alignment_groups
+        objective_after = self._ibo_objective(C_ibo_iao)
+        self._atomic_alignment_objective_change = objective_after - objective_before
+        if alignment_groups:
+            logger.log_info1(
+                f"Aligned {len(alignment_groups)} atom-local IBO block(s) "
+                "to the global axis-oriented IAOs.\n"
+                f"Atomic alignment change in IBO objective: "
+                f"{self._atomic_alignment_objective_change:+.3e}."
+            )
+        return C_ibo_iao, U_ibo
+
+    def _order_atomic_orbitals(self, C_ibo_iao, U_ibo, alignment_groups, minao_labels):
+        """Order assigned IBOs by atom and native MINAO function index."""
+
+        assignment_rows = [None] * self.nocc
+        for iatom, orbital_indices, target_rows in alignment_groups:
+            for orbital, row in zip(orbital_indices, target_rows):
+                assignment_rows[orbital] = (iatom, row)
+
+        assigned = [
+            i for i, assignment in enumerate(assignment_rows) if assignment is not None
+        ]
+        assigned.sort(
+            key=lambda i: (
+                assignment_rows[i][0],
+                minao_labels[assignment_rows[i][1]].abs_idx,
+            )
+        )
+        unassigned = [
+            i for i, assignment in enumerate(assignment_rows) if assignment is None
+        ]
+        order = assigned + unassigned
+        old_to_new = np.empty(self.nocc, dtype=int)
+        old_to_new[order] = np.arange(self.nocc)
+
+        assignments = []
+        for old_index in order:
+            assignment = assignment_rows[old_index]
+            if assignment is None:
+                assignments.append(None)
+                continue
+            _, row = assignment
+            target = minao_labels[row]
+            assignments.append(
+                AtomicOrbitalAssignment(
+                    atom_index=target.iatom,
+                    minao_basis_index=target.abs_idx,
+                    n=target.n,
+                    l=target.l,
+                    component_index=target.m,
+                    label=f"{target.n}{get_shell_label(target.l, target.m)}",
+                )
+            )
+
+        reordered_groups = []
+        for iatom, orbital_indices, target_rows in alignment_groups:
+            pairs = sorted(
+                (int(old_to_new[orbital]), row)
+                for orbital, row in zip(orbital_indices, target_rows)
+            )
+            reordered_groups.append(
+                (
+                    iatom,
+                    tuple(index for index, _ in pairs),
+                    tuple(row for _, row in pairs),
+                )
+            )
+        reordered_groups.sort(key=lambda item: item[1][0] if item[1] else self.nocc)
+
+        self.atomic_orbital_assignments = tuple(assignments)
+        self.atomic_orbital_order = tuple(order)
+        return C_ibo_iao[:, order], U_ibo[:, order], reordered_groups
+
+    @staticmethod
+    def _component_order(angular_momentum, component):
+        """Return a stable axis-oriented ordering for shell components."""
+
+        if angular_momentum == 1:
+            # Libint stores real p functions as (py, pz, px), but the fixed
+            # Cartesian axes convention is more naturally exposed as (px, py,
+            # pz). Higher angular momenta retain Forte2's real-spherical order.
+            label = get_shell_label(angular_momentum, component)
+            return {"px": 0, "py": 1, "pz": 2}[label]
+        return component
+
+    @classmethod
+    def _atomic_orbital_order(cls, label):
+        """Order atomic orbitals by n, l, and axis-oriented component."""
+
+        return (
+            label.n,
+            label.l,
+            cls._component_order(label.l, label.m),
+        )
+
+    def _ibo_objective(self, C_ibo_iao):
+        """Evaluate the atom-population objective used by the IBO optimizer."""
+
+        objective = 0.0
+        for first, last in self.system.minao_basis.center_first_and_last:
+            populations = np.einsum(
+                "mi,mi->i", C_ibo_iao[first:last], C_ibo_iao[first:last]
+            )
+            objective += np.sum(populations**4)
+        return objective

--- a/forte2/sci/rel_sci.py
+++ b/forte2/sci/rel_sci.py
@@ -13,7 +13,7 @@ from forte2.base_classes import RelCIBase
 from forte2.base_classes.params import SelectedCIParams, DavidsonLiuParams
 from forte2.helpers import logger
 from forte2.jkbuilder import SpinorbitalIntegrals
-from forte2.orbitals import FinalOrbitals, validate_final_orbitals
+from forte2.orbitals import FinalOrbitals
 from forte2.ci.ci_utils import (
     pretty_print_ci_summary,
     pretty_print_ci_dets,
@@ -392,7 +392,6 @@ class RelSelectedCI(RelSelectedCISolver):
 
     def __post_init__(self):
         super().__post_init__()
-        validate_final_orbitals(self.final_orbitals)
 
     def run(self):
         self._solve()

--- a/forte2/sci/sci.py
+++ b/forte2/sci/sci.py
@@ -16,7 +16,7 @@ from forte2.base_classes import CIBase
 from forte2.base_classes.params import SelectedCIParams, DavidsonLiuParams
 from forte2.helpers import logger
 from forte2.jkbuilder import RestrictedMOIntegrals
-from forte2.orbitals import FinalOrbitals, validate_final_orbitals
+from forte2.orbitals import FinalOrbitals
 from forte2.ci.ci_utils import (
     pretty_print_ci_summary,
     pretty_print_ci_dets,
@@ -1129,7 +1129,6 @@ class SelectedCI(SelectedCISolver):
 
     def __post_init__(self):
         super().__post_init__()
-        validate_final_orbitals(self.final_orbitals)
 
     def run(self):
         self._solve()

--- a/forte2/symmetry/pg_sym_detect.py
+++ b/forte2/symmetry/pg_sym_detect.py
@@ -3,7 +3,7 @@ import itertools
 import numpy as np
 import scipy as sp
 
-from forte2.helpers import logger
+from forte2.helpers import logger, procrustes_rotation
 from .sym_utils import rotation_mat, reflection_mat, equivalent_under_operation
 
 
@@ -94,8 +94,7 @@ class PGSymmetryDetector:
 
         if not np.isclose(np.abs(det), 1.0, atol=self.tol):
             # re-orthogonalize
-            u, _, vh = np.linalg.svd(self.prinrot)
-            self.prinrot = u @ vh
+            self.prinrot = procrustes_rotation(self.prinrot)
             det = np.linalg.det(self.prinrot)
 
         if det < 0:

--- a/tests/ci/test_ci_rhf.py
+++ b/tests/ci/test_ci_rhf.py
@@ -391,7 +391,10 @@ def test_ci_natural_noncontiguous_mo_space():
     assert np.max(np.abs(off_diag)) < 1e-8
 
 
-@pytest.mark.parametrize("final_orbitals", ["original", "semicanonical", "natural"])
+@pytest.mark.parametrize(
+    "final_orbitals",
+    ["original", "semicanonical", "natural", "ibo", "ibo_atomic"],
+)
 def test_ci_final_orbitals(final_orbitals):
     eref = -99.82331087176414
     xyz = """
@@ -422,3 +425,24 @@ def test_ci_final_orbitals(final_orbitals):
     )(rhf)
     ci_solver.run()
     assert ci_solver.E_avg == approx(eref)
+
+
+@pytest.mark.parametrize("final_orbitals", ["ibo", "ibo_atomic"])
+def test_ci_ibo_final_orbitals_rejects_non_c1_symmetry(final_orbitals):
+    system = System(
+        xyz="H 0.0 0.0 0.0\nH 0.0 0.0 1.0",
+        basis_set="sto-6g",
+        auxiliary_basis_set="cc-pVTZ-JKFIT",
+        symmetry=True,
+    )
+    assert system.point_group.upper() != "C1"
+
+    rhf = RHF(charge=0, e_tol=1e-12)(system)
+    ci_solver = CI(
+        State(nel=2, multiplicity=1, ms=0.0),
+        active_orbitals=[0, 1],
+        final_orbitals=final_orbitals,
+    )(rhf)
+
+    with pytest.raises(ValueError, match="only available in C1 symmetry"):
+        ci_solver.run()

--- a/tests/helpers/test_matrix_functions.py
+++ b/tests/helpers/test_matrix_functions.py
@@ -1,7 +1,13 @@
 import numpy as np
 import scipy as sp
 
-from forte2.helpers import invsqrt_matrix, eigh_gen, canonical_orth, random_unitary
+from forte2.helpers import (
+    invsqrt_matrix,
+    eigh_gen,
+    canonical_orth,
+    procrustes_rotation,
+    random_unitary,
+)
 from forte2.helpers.comparisons import approx
 
 
@@ -14,6 +20,18 @@ def test_invsqrt_matrix():
 
     Sm1_ref = np.linalg.inv(S)
     assert np.allclose(Sm12 @ Sm12, Sm1_ref)
+
+
+def test_procrustes_rotation():
+    rng = np.random.default_rng(12)
+    rotation = random_unitary(6, cmplx=False, rng=rng, rotation=False)
+    factor = rng.normal(size=(6, 6))
+    positive_matrix = factor.T @ factor + np.eye(6)
+
+    recovered = procrustes_rotation(positive_matrix @ rotation)
+
+    np.testing.assert_allclose(recovered, rotation, atol=1.0e-12)
+    np.testing.assert_allclose(recovered.T @ recovered, np.eye(6), atol=1.0e-12)
 
 
 def test_invsqrt_matrix_singular():

--- a/tests/mcopt/test_casscf_simple.py
+++ b/tests/mcopt/test_casscf_simple.py
@@ -1,3 +1,6 @@
+import numpy as np
+import pytest
+
 from forte2 import System, RHF, MCOptimizer, State, CISolver
 from forte2.helpers.comparisons import approx, is_diagonal_matrix
 
@@ -71,6 +74,49 @@ def test_casscf_h2_all_orbitals_active_positive_maxiter():
     assert mc.iter == 0
     assert mc.converged
     assert mc.E == approx(-1.096071975854)
+
+
+@pytest.mark.parametrize("final_orbitals", ["ibo", "ibo_atomic"])
+def test_casscf_h2_ibo_final_orbitals(final_orbitals):
+    xyz = f"""
+    H 0.0 0.0 0.0
+    H 0.0 0.0 {0.529177210903 * 2}
+    """
+    system = System(
+        xyz=xyz,
+        basis_set="sto-6g",
+        auxiliary_basis_set="cc-pVTZ-JKFIT",
+    )
+    rhf = RHF(charge=0, e_tol=1e-12)(system)
+    rhf.run()
+    C_canonical = rhf.mos.C[0].copy()
+
+    ci_solver = CISolver(State(nel=2, multiplicity=1, ms=0.0), active_orbitals=2)
+    mc = MCOptimizer(ci_solver, final_orbitals=final_orbitals)(rhf)
+    mc.run()
+
+    assert mc.E == approx(-1.096071975854)
+    overlap = C_canonical.T @ system.ints_overlap() @ mc.mos.C[0]
+    np.testing.assert_allclose(overlap.T @ overlap, np.eye(2), atol=1e-12)
+    assert not np.allclose(np.abs(overlap), np.eye(2), atol=1e-3)
+
+
+@pytest.mark.parametrize("final_orbitals", ["ibo", "ibo_atomic"])
+def test_casscf_ibo_final_orbitals_rejects_non_c1_symmetry(final_orbitals):
+    system = System(
+        xyz="H 0.0 0.0 0.0\nH 0.0 0.0 1.0",
+        basis_set="sto-6g",
+        auxiliary_basis_set="cc-pVTZ-JKFIT",
+        symmetry=True,
+    )
+    assert system.point_group.upper() != "C1"
+
+    rhf = RHF(charge=0, e_tol=1e-12)(system)
+    ci_solver = CISolver(State(nel=2, multiplicity=1, ms=0.0), active_orbitals=[0, 1])
+    mc = MCOptimizer(ci_solver, final_orbitals=final_orbitals)(rhf)
+
+    with pytest.raises(ValueError, match="only available in C1 symmetry"):
+        mc.run()
 
 
 def test_casscf_n2():

--- a/tests/orbitals/test_ibo.py
+++ b/tests/orbitals/test_ibo.py
@@ -1,8 +1,34 @@
-import numpy as np
+from types import SimpleNamespace
 
-from forte2 import System, RHF
+import numpy as np
+import pytest
+
+from forte2 import System, RHF, MOSpace
+from forte2.orbitals import make_final_orbitals
+import forte2.orbitals.final_orbitals as final_orbitals_module
+import forte2.orbitals.ibo_align as ibo_align_module
 from forte2.orbitals.iao import IBO
+from forte2.orbitals.ibo_align import IBOAligner
 from forte2.helpers.comparisons import approx
+from forte2.system.basis_utils import BasisInfo
+
+
+def test_make_final_orbitals_centralizes_validation_and_original_mode():
+    C = np.eye(3)
+    kwargs = {
+        "system": None,
+        "mo_space": None,
+        "irrep_indices": np.zeros(3, dtype=int),
+        "C_contig": C,
+        "g1_act": None,
+    }
+
+    C_original = make_final_orbitals("original", **kwargs)
+    np.testing.assert_array_equal(C_original, C)
+    assert C_original is not C
+
+    with pytest.raises(ValueError, match="final_orbitals must be one of"):
+        make_final_orbitals("invalid", **kwargs)
 
 
 def test_ibo_water():
@@ -22,3 +48,284 @@ def test_ibo_water():
     E = np.einsum("pq,pq->", D_ibo, rhf.F[0] + system.ints_hcore())
 
     assert E + system.nuclear_repulsion == approx(rhf.E)
+    np.testing.assert_allclose(
+        ibo.U_ibo.T @ ibo.U_ibo,
+        np.eye(rhf.ndocc),
+        atol=1.0e-12,
+    )
+    np.testing.assert_allclose(ibo.C_ibo, C_occ @ ibo.U_ibo, atol=1.0e-12)
+
+
+def test_ibo_cartesian_alignment_is_not_p_specific(monkeypatch):
+    labels = [SimpleNamespace(abs_idx=0, iatom=0, n=1, l=0, m=0)]
+    labels += [SimpleNamespace(abs_idx=i + 1, iatom=0, n=2, l=1, m=i) for i in range(3)]
+    labels += [SimpleNamespace(abs_idx=i + 4, iatom=0, n=3, l=2, m=i) for i in range(5)]
+    monkeypatch.setattr(
+        ibo_align_module,
+        "BasisInfo",
+        lambda system, basis: SimpleNamespace(basis_labels=labels),
+    )
+
+    ibo_aligner = object.__new__(IBOAligner)
+    ibo_aligner.system = SimpleNamespace(
+        minao_basis=SimpleNamespace(center_first_and_last=[(0, 9)])
+    )
+    ibo_aligner.nocc = 6
+
+    # Include an s orbital with negative phase and a randomly rotated complete
+    # d shell. The unused p rows ensure unrelated IAOs can be skipped.
+    rng = np.random.default_rng(7)
+    d_rotation, _ = np.linalg.qr(rng.normal(size=(5, 5)))
+    C_ibo_iao = np.zeros((9, 6))
+    C_ibo_iao[0, 0] = -1.0
+    C_ibo_iao[4:9, 1:6] = d_rotation
+
+    C_aligned, U_aligned = ibo_aligner._align_cartesian_atomic_orbitals(
+        C_ibo_iao, np.eye(6)
+    )
+
+    target_rows = [0, 4, 5, 6, 7, 8]
+    np.testing.assert_allclose(
+        C_aligned[np.ix_(target_rows, range(6))], np.eye(6), atol=1.0e-12
+    )
+    np.testing.assert_allclose(U_aligned.T @ U_aligned, np.eye(6), atol=1.0e-12)
+    assert [
+        len(group) for _, group, _ in ibo_aligner._cartesian_alignment_groups
+    ] == [6]
+    assert [
+        assignment.minao_basis_index
+        for assignment in ibo_aligner.atomic_orbital_assignments
+    ] == [
+        0,
+        4,
+        5,
+        6,
+        7,
+        8,
+    ]
+
+
+def test_ibo_aligns_atom_local_p_orbitals_to_cartesian_iaos():
+    system = System(
+        xyz="N 0.0 0.0 -0.75\nN 0.0 0.0 0.75",
+        basis_set="cc-pVDZ",
+        cholesky_tei=True,
+        unit="angstrom",
+        symmetry=False,
+    )
+    rhf = RHF(charge=0, e_tol=1.0e-12)(system)
+    rhf.run()
+
+    # The six valence orbitals contain a rotationally free px/py pair on each
+    # atom. Their raw IBO orientations depend on the starting pi orbitals.
+    ibo = IBO(system, rhf.C[0][:, 4:10])
+    ibo_aligner = IBOAligner(ibo)
+    assert ibo_aligner._cartesian_alignment_groups == []
+    ibo_aligner.align_to_atomic_orbitals()
+    C_ibo_iao = ibo.C_iao.T @ system.ints_overlap() @ ibo_aligner.C_ibo
+    minao_labels = BasisInfo(system, system.minao_basis).basis_labels
+
+    transverse_groups = [
+        group
+        for group in ibo_aligner._cartesian_alignment_groups
+        if len(group[1]) == 2
+    ]
+    assert len(transverse_groups) == 2
+    assert {group[0] for group in transverse_groups} == {0, 1}
+    for _, orbital_indices, target_rows in transverse_groups:
+        assert [minao_labels[row].label() for row in target_rows] == ["2py", "2px"]
+        np.testing.assert_allclose(
+            C_ibo_iao[np.ix_(target_rows, orbital_indices)],
+            np.eye(2),
+            atol=1.0e-10,
+        )
+
+    assignments = ibo_aligner.atomic_orbital_assignments
+    assert [assignment.atom_index for assignment in assignments[:4]] == [0, 0, 1, 1]
+    assert [assignment.label for assignment in assignments[:4]] == [
+        "2py",
+        "2px",
+        "2py",
+        "2px",
+    ]
+    assert assignments[4:] == (None, None)
+
+    np.testing.assert_allclose(
+        ibo_aligner.U_ibo.T @ ibo_aligner.U_ibo,
+        np.eye(ibo_aligner.nocc),
+        atol=1.0e-12,
+    )
+
+
+def test_ibo_atomic_order_follows_atom_and_native_minao_index(monkeypatch):
+    labels = []
+    for iatom in range(2):
+        offset = 5 * iatom
+        labels.append(SimpleNamespace(abs_idx=offset, iatom=iatom, n=1, l=0, m=0))
+        labels.append(SimpleNamespace(abs_idx=offset + 1, iatom=iatom, n=2, l=0, m=0))
+        labels.extend(
+            SimpleNamespace(
+                abs_idx=offset + 2 + component,
+                iatom=iatom,
+                n=2,
+                l=1,
+                m=component,
+            )
+            for component in range(3)
+        )
+    monkeypatch.setattr(
+        ibo_align_module,
+        "BasisInfo",
+        lambda system, basis: SimpleNamespace(basis_labels=labels),
+    )
+
+    ibo_aligner = object.__new__(IBOAligner)
+    ibo_aligner.system = SimpleNamespace(
+        minao_basis=SimpleNamespace(center_first_and_last=[(0, 5), (5, 10)])
+    )
+    ibo_aligner.nocc = 8
+
+    # Start from a deliberately interleaved atomic order. The Procrustes step
+    # fixes the Cartesian gauge before the final native-order permutation.
+    starting_rows = [6, 1, 9, 4, 7, 2, 8, 3]
+    C_ibo_iao = np.eye(10)[:, starting_rows]
+    C_aligned, U_aligned = ibo_aligner._align_cartesian_atomic_orbitals(
+        C_ibo_iao, np.eye(8)
+    )
+
+    expected_rows = [1, 2, 3, 4, 6, 7, 8, 9]
+    np.testing.assert_allclose(C_aligned[expected_rows], np.eye(8), atol=1.0e-12)
+    np.testing.assert_allclose(U_aligned.T @ U_aligned, np.eye(8), atol=1.0e-12)
+    assert [
+        assignment.atom_index for assignment in ibo_aligner.atomic_orbital_assignments
+    ] == [
+        0,
+        0,
+        0,
+        0,
+        1,
+        1,
+        1,
+        1,
+    ]
+    assert [
+        assignment.label for assignment in ibo_aligner.atomic_orbital_assignments
+    ] == [
+        "2s",
+        "2py",
+        "2pz",
+        "2px",
+        "2s",
+        "2py",
+        "2pz",
+        "2px",
+    ]
+
+
+@pytest.mark.parametrize("mode", ["ibo", "ibo_atomic"])
+def test_ibo_final_orbitals_semicanonicalizes_inactive_space(mode):
+    system = System(
+        xyz="Li 0.0 0.0 0.0\nH 0.0 0.0 3.0",
+        basis_set="sto-3g",
+        auxiliary_basis_set="def2-universal-JKFIT",
+        unit="bohr",
+    )
+    rhf = RHF(charge=0, e_tol=1e-12)(system)
+    rhf.run()
+
+    # The frozen virtual makes the original-to-contiguous permutation nontrivial.
+    mo_space = MOSpace(
+        nmo=system.nmo,
+        core_orbitals=[0],
+        active_orbitals=[1, 2],
+        frozen_virtual_orbitals=[3],
+    )
+    C_original = rhf.mos.C[0].copy()
+    C_contig = C_original[:, mo_space.orig_to_contig]
+    irrep_indices = np.asarray(rhf.mos.irrep_indices[0])[mo_space.orig_to_contig]
+
+    C_final_contig = make_final_orbitals(
+        mode,
+        system=system,
+        mo_space=mo_space,
+        irrep_indices=irrep_indices,
+        C_contig=C_contig,
+        g1_act=np.zeros((mo_space.nactv, mo_space.nactv)),
+    )
+    C_final = C_final_contig[:, mo_space.contig_to_orig]
+
+    C_semican_contig = make_final_orbitals(
+        "semicanonical",
+        system=system,
+        mo_space=mo_space,
+        irrep_indices=irrep_indices,
+        C_contig=C_contig,
+        g1_act=np.zeros((mo_space.nactv, mo_space.nactv)),
+    )
+    C_semican = C_semican_contig[:, mo_space.contig_to_orig]
+
+    inactive = [0, 3, 4, 5]
+    np.testing.assert_allclose(C_final[:, inactive], C_semican[:, inactive], atol=1e-12)
+
+    S = system.ints_overlap()
+    active_overlap = (
+        C_original[:, mo_space.active_indices].T
+        @ S
+        @ C_final[:, mo_space.active_indices]
+    )
+    np.testing.assert_allclose(active_overlap.T @ active_overlap, np.eye(2), atol=1e-12)
+    assert not np.allclose(np.abs(active_overlap), np.eye(2), atol=1e-3)
+
+
+@pytest.mark.parametrize(("mode", "aligned"), [("ibo", False), ("ibo_atomic", True)])
+def test_ibo_final_orbitals_preserves_gas_blocks(monkeypatch, mode, aligned):
+    class _InactiveSemicanonicalizer:
+        def __init__(self, *, do_active, **kwargs):
+            assert not do_active
+
+        def semi_canonicalize(self, g1, C_contig):
+            self.C_semican = C_contig.copy()
+            self.C_semican[:, [0, 9]] *= -1
+
+    class _ReversingIBO:
+        def __init__(self, system, C, **kwargs):
+            self.C_ibo = C[:, ::-1]
+
+    class _PassThroughAligner:
+        def __init__(self, ibo):
+            self.C_ibo = ibo.C_ibo.copy()
+
+        def align_to_atomic_orbitals(self):
+            self.C_ibo *= -1
+            return self.C_ibo
+
+    monkeypatch.setattr(final_orbitals_module, "IBO", _ReversingIBO)
+    monkeypatch.setattr(final_orbitals_module, "IBOAligner", _PassThroughAligner)
+    monkeypatch.setattr(
+        final_orbitals_module, "Semicanonicalizer", _InactiveSemicanonicalizer
+    )
+
+    mo_space = MOSpace(
+        nmo=10,
+        core_orbitals=[0],
+        active_orbitals=[[1, 2, 3, 4], [5, 6, 7, 8]],
+        frozen_virtual_orbitals=[9],
+    )
+    C = np.eye(10)
+    irrep_indices = np.zeros(10, dtype=int)
+    C_final = make_final_orbitals(
+        mode,
+        system=object(),
+        mo_space=mo_space,
+        irrep_indices=irrep_indices,
+        C_contig=C,
+        g1_act=np.zeros((mo_space.nactv, mo_space.nactv)),
+    )
+
+    expected = C.copy()
+    expected[:, [0, 9]] *= -1
+    for block in ([1, 2, 3, 4], [5, 6, 7, 8]):
+        expected[:, block] = expected[:, block[::-1]]
+        if aligned:
+            expected[:, block] *= -1
+    np.testing.assert_array_equal(C_final, expected)

--- a/tests/sci/test_sci.py
+++ b/tests/sci/test_sci.py
@@ -981,7 +981,10 @@ def test_sci_set_ints_then_run_updates_slater_rules():
     assert after - before == approx(1.0)
 
 
-@pytest.mark.parametrize("final_orbitals", ["original", "semicanonical", "natural"])
+@pytest.mark.parametrize(
+    "final_orbitals",
+    ["original", "semicanonical", "natural", "ibo", "ibo_atomic"],
+)
 def test_sci_final_orbitals(final_orbitals):
     rhf = _h4_rhf()
 


### PR DESCRIPTION
This pull request introduces support for new final orbital representations in CI and MCOptimizer workflows, notably adding "ibo" and "ibo_atomic" options for intrinsic bond orbital (IBO) localization and atomic alignment. It also refactors and simplifies how final orbital options are validated and handled, and adds a utility for optimal orbital alignment. The most important changes are grouped below.

### New Final Orbital Representations

* Added support for `final_orbitals="ibo"` and `final_orbitals="ibo_atomic"` options, enabling localization of active orbitals as intrinsic bond orbitals and optional alignment to atomic orbitals, respectively. These are available only for real, nonrelativistic C1 symmetry calculations. [[1]](diffhunk://#diff-ecd2bc04191fa1a0257d7cc57d81014bc824e2f25e18dd488926a801d3cf79b5R71-R95) [[2]](diffhunk://#diff-79d52e1c0b38436ef76d47fa8f63ba944eb0615820184a7a23af8f9b53051c45R8-R47) [[3]](diffhunk://#diff-79d52e1c0b38436ef76d47fa8f63ba944eb0615820184a7a23af8f9b53051c45L69-R91) [[4]](diffhunk://#diff-79d52e1c0b38436ef76d47fa8f63ba944eb0615820184a7a23af8f9b53051c45L94-R119) [[5]](diffhunk://#diff-7e2f8c71fd756d9d9f9f732203c442b502aff41c078d606ecc803090ac085955R63-R68)

* Updated documentation to describe the new options, their usage, and the resulting orbital ordering and labeling.

### Refactoring and Validation

* Removed the `validate_final_orbitals` function and its calls, moving validation into the `make_final_orbitals` function and updating all relevant classes to reflect this change. [[1]](diffhunk://#diff-9ff2a90b3ba37280f7e9633e9c2f464aa1f152661b9405cda59bda17bed714a5L20-R20) [[2]](diffhunk://#diff-9ff2a90b3ba37280f7e9633e9c2f464aa1f152661b9405cda59bda17bed714a5L1012) [[3]](diffhunk://#diff-056e0adf51c005d8d1cc1518d15bada80e97d5988a7279f88dd6093bb92374deL16-R16) [[4]](diffhunk://#diff-056e0adf51c005d8d1cc1518d15bada80e97d5988a7279f88dd6093bb92374deL474) [[5]](diffhunk://#diff-7e2f8c71fd756d9d9f9f732203c442b502aff41c078d606ecc803090ac085955L14-R14) [[6]](diffhunk://#diff-7e2f8c71fd756d9d9f9f732203c442b502aff41c078d606ecc803090ac085955L110-L111) [[7]](diffhunk://#diff-79d52e1c0b38436ef76d47fa8f63ba944eb0615820184a7a23af8f9b53051c45R8-R47) [[8]](diffhunk://#diff-74aa174889b3a27b999803b4af27926a42226d6cb3d8723d62f9a2183dde9ba3L10-R14)

* The `make_final_orbitals` function now checks for valid options and enforces symmetry and orbital type restrictions for IBO modes.

### IBO Implementation Improvements

* The IBO algorithm now accumulates and returns the explicit unitary rotation (`U_ibo`) relating input orbitals to IBOs, ensuring the final IBOs remain exactly in the input subspace. [[1]](diffhunk://#diff-3e39d9d75736ad939c269f9d07ca18113967c2e819ecf08c68ede5647378752dR145-R151) [[2]](diffhunk://#diff-3e39d9d75736ad939c269f9d07ca18113967c2e819ecf08c68ede5647378752dR171) [[3]](diffhunk://#diff-3e39d9d75736ad939c269f9d07ca18113967c2e819ecf08c68ede5647378752dR205-R211) [[4]](diffhunk://#diff-3e39d9d75736ad939c269f9d07ca18113967c2e819ecf08c68ede5647378752dL206-R222)

### Utilities

* Added a new `procrustes_rotation` function for optimal unitary alignment of orbital sets, used in atomic orbital alignment. [[1]](diffhunk://#diff-87653593013e3fc82b645b045a8418410f17a6ad37235b8597dd0d201db698b1R11) [[2]](diffhunk://#diff-185252a2a77bb4075940b067d80676cd52dbc30ee0e32ecbf157863d84daca43R9-R40)

### API and Type Updates

* Extended the `FinalOrbitals` type and related documentation to include the new options. [[1]](diffhunk://#diff-79d52e1c0b38436ef76d47fa8f63ba944eb0615820184a7a23af8f9b53051c45R8-R47) [[2]](diffhunk://#diff-7e2f8c71fd756d9d9f9f732203c442b502aff41c078d606ecc803090ac085955R63-R68)

These changes collectively enhance the flexibility and accuracy of post-processing orbital transformations in CI and MC optimization workflows.